### PR TITLE
Fix Docker Console command line unnecessary unescaping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,10 @@ quote-style = "double"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "docker: marks tests as requiring Docker (deselect with '-m \"not docker\"')",
+]
+addopts = "-m 'not docker'"
 
 # Coverage configuration
 [tool.coverage.run]
@@ -149,4 +153,3 @@ disallow_untyped_defs = false
 # Codespell configuration
 [tool.codespell]
 skip = ".git,.venv*,uv.lock,htmlcov,.coverage"
-

--- a/src/pydantic_ai_backends/backends/docker/sandbox.py
+++ b/src/pydantic_ai_backends/backends/docker/sandbox.py
@@ -519,8 +519,7 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
             # Note: Docker SDK exec_run doesn't support timeout parameter directly.
             # For timeouts, we wrap the command with 'timeout' utility.
             if timeout:
-                command = f"timeout {timeout} sh -c {command!r}"
-                exec_cmd = ["sh", "-c", command]
+                exec_cmd = ["timeout", str(timeout), "sh", "-c", command]
             else:
                 exec_cmd = ["sh", "-c", command]
 


### PR DESCRIPTION
### Bug Description
By default a timeout was added to docker execute tool calls. 
The timeout wasn't handled right and caused unnecessary unescaping of the commands. 

### Fix 
- Changed timeout handling
- Added tests for this behaviour, which do not run by default because they require a running Docker image. runnable via `uv run pytest -m docker`

