### PR TITLE
docs: update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LocalBackend` now checks permissions after `allowed_directories` validation
 - Legacy `require_write_approval` and `require_execute_approval` flags are preserved for backward compatibility but `permissions` parameter takes precedence when provided
 
+### Fixed
+
+- `DockerSandbox.execute()` no longer incorrectly escapes commands when timeout is specified.
+  Previously, using Python's `repr()` for shell quoting caused issues with commands containing
+  mixed quotes or special characters. ([#3](https://github.com/vstorm-co/pydantic-ai-backend/pull/3))
+
 ### Documentation
 
 - New "Permissions" concept guide with examples


### PR DESCRIPTION
## [0.1.2] - 2026-01-21

### Added

- **Fine-grained Permission System** - Pattern-based access control for file operations and shell execution
  - `PermissionRuleset` - Complete permission configuration with per-operation rules
  - `PermissionRule` - Glob pattern matching with `allow`, `deny`, or `ask` actions
  - `PermissionChecker` - Validates operations against rulesets with async callback support
  - `OperationPermissions` - Per-operation default actions and override rules

- **Pre-configured Permission Presets**
  - `DEFAULT_RULESET` - Safe defaults (allow reads except secrets, ask for writes/executes)
  - `PERMISSIVE_RULESET` - Allow most operations, deny only dangerous commands
  - `READONLY_RULESET` - Allow read operations only, deny all writes and executes
  - `STRICT_RULESET` - Everything requires explicit approval

- **Permission Integration**
  - `permissions` parameter in `LocalBackend` for fine-grained access control
  - `permissions` parameter in `create_console_toolset()` for tool approval requirements
  - `ask_callback` parameter for interactive permission prompts
  - `ask_fallback` parameter to control behavior when callback unavailable ("deny" or "error")

- **Helper Functions and Patterns**
  - `create_ruleset()` factory function for custom permission configurations
  - `SECRETS_PATTERNS` - Common patterns for sensitive files (.env, .pem, credentials, etc.)
  - `SYSTEM_PATTERNS` - Common patterns for system directories (/etc, /var, etc.)
  - `is_allowed()`, `is_denied()`, `requires_approval()` convenience methods

- **New Exceptions**
  - `PermissionError` - Raised when approval required but no callback available
  - `PermissionDeniedError` - Raised when operation is explicitly denied

### Changed

- `LocalBackend` now checks permissions after `allowed_directories` validation
- Legacy `require_write_approval` and `require_execute_approval` flags are preserved for backward compatibility but `permissions` parameter takes precedence when provided

### Fixed

- `DockerSandbox.execute()` no longer incorrectly escapes commands when timeout is specified.
  Previously, using Python's `repr()` for shell quoting caused issues with commands containing
  mixed quotes or special characters. ([#3](https://github.com/vstorm-co/pydantic-ai-backend/pull/3))

### Documentation

- New "Permissions" concept guide with examples
- Updated backends documentation with permission examples
- Updated console toolset documentation with permission configuration
- API reference for all permission types and functions
