### PR TITLE
fix: Allows configuring the maximum number of retries for all console tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+notes/
 .idea
 uv.lock
 # Byte-compiled / optimized / DLL files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2025-02-07
+
+### Added
+
+- **`max_retries` parameter for `create_console_toolset()`**: Allows configuring the maximum number of retries for all console tools (`write_file`, `edit_file`, `read_file`, `ls`, `glob`, `grep`, `execute`). When the model sends invalid arguments (e.g. missing a required field like `content` for `write_file`), the validation error is fed back and the model can self-correct up to `max_retries` times. Defaults to 1 (unchanged) for backward compatibility. ([pydantic-deepagents#25](https://github.com/vstorm-co/pydantic-deepagents/issues/25))
+
 ## [0.1.5] - 2025-01-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.1.5"
+version = "0.1.6"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -86,6 +86,7 @@ def create_console_toolset(  # noqa: C901
     require_execute_approval: bool = True,
     default_ignore_hidden: bool = True,
     permissions: PermissionRuleset | None = None,
+    max_retries: int = 1,
 ) -> FunctionToolset[ConsoleDeps]:
     """Create a console toolset for file operations and shell execution.
 
@@ -105,6 +106,10 @@ def create_console_toolset(  # noqa: C901
         permissions: Optional permission ruleset to determine tool approval requirements.
             If provided, overrides require_write_approval and require_execute_approval
             based on whether the operation's default action is "ask".
+        max_retries: Maximum number of retries for each tool during a run.
+            When the model sends invalid arguments (e.g. missing required fields),
+            the validation error is fed back and the model can retry up to this
+            many times. Defaults to 1.
 
     Returns:
         FunctionToolset with console tools.
@@ -135,7 +140,7 @@ def create_console_toolset(  # noqa: C901
         permissions, "execute", require_execute_approval
     )
 
-    toolset: FunctionToolset[ConsoleDeps] = FunctionToolset(id=id)
+    toolset: FunctionToolset[ConsoleDeps] = FunctionToolset(id=id, max_retries=max_retries)
 
     @toolset.tool
     async def ls(  # pragma: no cover


### PR DESCRIPTION
## [0.1.6] - 2025-02-07

### Added

- **`max_retries` parameter for `create_console_toolset()`**: Allows configuring the maximum number of retries for all console tools (`write_file`, `edit_file`, `read_file`, `ls`, `glob`, `grep`, `execute`). When the model sends invalid arguments (e.g. missing a required field like `content` for `write_file`), the validation error is fed back and the model can self-correct up to `max_retries` times. Defaults to 1 (unchanged) for backward compatibility. ([pydantic-deepagents#25](https://github.com/vstorm-co/pydantic-deepagents/issues/25))
