### PR TITLE
feat: support image files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2025-02-16
+
+### Added
+
+- **Image support in `read_file`**: When `image_support=True` is passed to `create_console_toolset()`, reading image files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`) returns a `BinaryContent` object that multimodal models can see, instead of garbled text.
+  - `image_support` parameter on `create_console_toolset()` (default: `False`)
+  - `max_image_bytes` parameter to limit image file size (default: 50MB)
+  - `IMAGE_EXTENSIONS`, `IMAGE_MEDIA_TYPES`, `DEFAULT_MAX_IMAGE_BYTES` constants exported from the package
+- **Documentation**: Expanded guides for backends, console toolset, permissions, and multi-user setups.
+
 ## [0.1.6] - 2025-02-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ toolset = create_console_toolset(
 
 **Available tools:** `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `execute`
 
+### Image Support
+
+For multimodal models, enable image file handling:
+
+```python
+toolset = create_console_toolset(image_support=True)
+
+# Now read_file on .png/.jpg/.gif/.webp returns BinaryContent
+# that multimodal models (GPT-4o, Claude, etc.) can see directly
+```
+
 ## Permission System
 
 Fine-grained access control:
@@ -229,6 +240,7 @@ sandbox = await manager.get_or_create("user-123")
 | **Permission System** | Pattern-based access control with presets |
 | **Docker Isolation** | Safe execution of untrusted code |
 | **Session Management** | Multi-user support with workspace persistence |
+| **Image Support** | Multimodal models can see images via BinaryContent |
 | **Pre-built Runtimes** | Python and Node.js environments ready to go |
 
 ## Related Projects

--- a/docs/concepts/backends.md
+++ b/docs/concepts/backends.md
@@ -184,6 +184,133 @@ result = agent.run_sync(
 )
 ```
 
+### Path Prefix Matching
+
+CompositeBackend matches paths using **longest prefix first**. Routes are sorted by length at initialization, so more specific prefixes take priority over shorter ones:
+
+```python
+backend = CompositeBackend(
+    default=StateBackend(),
+    routes={
+        "/project/": LocalBackend("/my/project"),
+        "/project/vendor/": LocalBackend("/vendor/libs", enable_execute=False),
+    },
+)
+
+# Matches "/project/vendor/" (longer prefix wins)
+backend.read("/project/vendor/lib.py")
+
+# Matches "/project/"
+backend.read("/project/app.py")
+
+# No prefix matches - falls back to default StateBackend
+backend.write("/temp/scratch.txt", "temporary data")
+```
+
+Paths are matched with `str.startswith()`, so prefixes should end with `/` to avoid partial matches (e.g., `/project/` won't accidentally match `/projects/`).
+
+### Aggregated Operations
+
+When you call `ls`, `glob`, or `grep` at the root level (`/` or `""`), CompositeBackend aggregates results from **all** backends:
+
+```python
+from pydantic_ai_backends import CompositeBackend, StateBackend, LocalBackend
+
+backend = CompositeBackend(
+    default=StateBackend(),
+    routes={
+        "/src/": LocalBackend("/home/user/project/src"),
+        "/data/": LocalBackend("/shared/data", enable_execute=False),
+    },
+)
+
+# ls at root shows virtual directories for each route prefix
+# plus any files in the default backend
+entries = backend.ls_info("/")
+# Returns: [/data, /src, ...any default backend entries...]
+
+# glob from root searches ALL backends
+matches = backend.glob_info("**/*.py", "/")
+# Returns Python files from default backend, /src/, and /data/
+
+# grep from root searches ALL backends
+results = backend.grep_raw("TODO", "/")
+# Returns matches from all backends combined
+```
+
+When targeting a specific path, only the matching backend is queried:
+
+```python
+# Only searches the /src/ backend
+results = backend.grep_raw("import", "/src/")
+
+# Only searches the /data/ backend
+entries = backend.glob_info("*.csv", "/data/")
+```
+
+!!! note "Error handling in aggregated operations"
+    During aggregated `grep` operations, errors from individual backends are silently
+    ignored. This prevents a failing backend from blocking results from other backends.
+
+### Common Patterns
+
+#### Persistent project + ephemeral scratch space
+
+```python
+backend = CompositeBackend(
+    default=StateBackend(),  # Ephemeral scratch space
+    routes={
+        "/project/": LocalBackend("/home/user/my-app"),
+    },
+)
+
+# Agent writes code to persistent local filesystem
+# Agent uses /temp/ or /scratch/ for intermediate results (ephemeral)
+```
+
+#### Multiple local directories
+
+```python
+backend = CompositeBackend(
+    default=StateBackend(),
+    routes={
+        "/frontend/": LocalBackend("/home/user/app/frontend"),
+        "/backend/": LocalBackend("/home/user/app/backend"),
+        "/shared/": LocalBackend("/home/user/app/shared", enable_execute=False),
+    },
+)
+```
+
+#### Read-only data + writable output
+
+```python
+backend = CompositeBackend(
+    default=StateBackend(),  # Writable scratch space
+    routes={
+        "/data/": LocalBackend("/shared/datasets", enable_execute=False),
+        "/output/": LocalBackend("/home/user/results"),
+    },
+)
+```
+
+#### Local project + Docker execution
+
+```python
+from pydantic_ai_backends import (
+    CompositeBackend, LocalBackend, DockerSandbox
+)
+
+backend = CompositeBackend(
+    default=LocalBackend("/home/user/project"),
+    routes={
+        "/sandbox/": DockerSandbox(runtime="python-datascience"),
+    },
+)
+
+# Read/write files on local filesystem by default
+# Execute untrusted code safely in /sandbox/
+```
+
 ### Use Cases
 
 - Persistent project files + ephemeral scratch space

--- a/docs/concepts/console-toolset.md
+++ b/docs/concepts/console-toolset.md
@@ -95,6 +95,77 @@ When `permissions` is provided, it overrides the legacy `require_write_approval`
 
 See [Permissions](permissions.md) for full documentation.
 
+## Image Support
+
+When working with multimodal models (e.g., GPT-4o, Claude), you can enable image support so that `read_file` returns image data that the model can see, instead of garbled binary text.
+
+```python
+# Enable image support
+toolset = create_console_toolset(image_support=True)
+```
+
+When `image_support=True`, reading a file with a recognized image extension returns a `BinaryContent` object that pydantic-ai sends to the model as an inline image. For all other file types, `read_file` behaves normally and returns text.
+
+### Recognized Image Types
+
+| Extension | Media Type |
+|-----------|------------|
+| `.png` | `image/png` |
+| `.jpg` | `image/jpeg` |
+| `.jpeg` | `image/jpeg` |
+| `.gif` | `image/gif` |
+| `.webp` | `image/webp` |
+
+### Size Limits
+
+Large images are rejected to avoid excessive token usage. The default limit is 50 MB:
+
+```python
+# Default: 50 MB max
+toolset = create_console_toolset(image_support=True)
+
+# Custom limit: 5 MB max
+toolset = create_console_toolset(
+    image_support=True,
+    max_image_bytes=5 * 1024 * 1024,
+)
+```
+
+Images exceeding the limit return an error message like: `Error: Image 'photo.png' too large (12.3MB, max 5.0MB)`.
+
+### Example: Visual Analysis Agent
+
+```python
+from dataclasses import dataclass
+from pydantic_ai import Agent
+from pydantic_ai_backends import LocalBackend, create_console_toolset
+
+@dataclass
+class Deps:
+    backend: LocalBackend
+
+# Enable image support for multimodal model
+toolset = create_console_toolset(image_support=True)
+
+agent = Agent(
+    "openai:gpt-4o",  # Multimodal model
+    system_prompt="You can read and analyze images using read_file.",
+    deps_type=Deps,
+)
+agent = agent.with_toolset(toolset)
+
+result = agent.run_sync(
+    "Read screenshot.png and describe what you see",
+    deps=Deps(backend=LocalBackend(root_dir="/workspace")),
+)
+```
+
+!!! tip "When to enable image support"
+    Only enable `image_support` when using a multimodal model that can process images.
+    With text-only models, image data will be wasted tokens. When disabled (the default),
+    reading an image file returns the raw text representation, which is not useful
+    but avoids unexpected behavior.
+
 ## ConsoleDeps Protocol
 
 Your dependencies class must have a `backend` property:

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -202,41 +202,158 @@ PermissionRule(pattern="git *", action="allow")
 
 ## Ask Callback
 
-For interactive approval, provide an `ask_callback`:
+When a permission rule resolves to `"ask"`, the system invokes an `AskCallback` to determine whether the operation should proceed. The callback is an async function with the following signature:
 
 ```python
-async def my_approval_callback(
+from pydantic_ai_backends.permissions import AskCallback
+
+# Type: Callable[[PermissionOperation, str, str], Awaitable[bool]]
+#                  operation         target reason
+```
+
+### CLI Approval
+
+For interactive CLI applications, prompt the user directly:
+
+```python
+async def cli_approval(
     operation: str,  # "read", "write", "edit", "execute", etc.
     target: str,     # Path or command
     reason: str,     # Why approval is needed
 ) -> bool:
-    # Your approval logic here
-    response = input(f"Allow {operation} on {target}? [y/N] ")
+    response = input(f"Allow {operation} on '{target}'? [y/N] ")
     return response.lower() == "y"
 
 backend = LocalBackend(
     root_dir="/workspace",
     permissions=DEFAULT_RULESET,
-    ask_callback=my_approval_callback,
+    ask_callback=cli_approval,
 )
 ```
 
-### Ask Fallback
+### Web App Approval
 
-When no callback is provided, `ask_fallback` controls behavior:
+For web applications, you might store pending approvals and wait for a user response:
 
 ```python
-# Deny operations that need approval (default behavior)
+import asyncio
+
+# In-memory store for pending approvals
+pending_approvals: dict[str, asyncio.Future[bool]] = {}
+
+async def web_approval(operation: str, target: str, reason: str) -> bool:
+    """Send approval request to frontend via WebSocket, wait for response."""
+    approval_id = f"{operation}:{target}"
+    future: asyncio.Future[bool] = asyncio.get_event_loop().create_future()
+    pending_approvals[approval_id] = future
+
+    # Your WebSocket/SSE notification logic here
+    await notify_frontend(operation, target, reason)
+
+    try:
+        # Wait up to 60 seconds for user to respond
+        return await asyncio.wait_for(future, timeout=60.0)
+    except asyncio.TimeoutError:
+        return False  # Deny on timeout
+    finally:
+        pending_approvals.pop(approval_id, None)
+```
+
+### Auto-Approve with Logging
+
+For trusted environments where you want to allow everything but keep an audit trail:
+
+```python
+import logging
+
+logger = logging.getLogger("permissions")
+
+async def auto_approve_with_logging(
+    operation: str, target: str, reason: str
+) -> bool:
+    logger.info(f"Auto-approved: {operation} on '{target}' ({reason})")
+    return True
+
 backend = LocalBackend(
+    root_dir="/workspace",
+    permissions=STRICT_RULESET,  # Everything asks
+    ask_callback=auto_approve_with_logging,
+)
+```
+
+### Conditional Approval
+
+Implement logic that auto-approves some operations and denies others:
+
+```python
+# Auto-approve writes to temp directories, deny everything else
+async def conditional_approval(
+    operation: str, target: str, reason: str
+) -> bool:
+    if operation == "write" and target.startswith("/temp/"):
+        return True
+    if operation == "execute" and target.startswith("python "):
+        return True
+    return False
+```
+
+## Ask Fallback
+
+When a permission rule resolves to `"ask"` but no `ask_callback` is provided (or the callback returns `False`), the `AskFallback` setting controls what happens.
+
+There are two fallback modes:
+
+| Fallback | Behavior |
+|----------|----------|
+| `"deny"` | Raises `PermissionDeniedError` (operation silently blocked) |
+| `"error"` | Raises `PermissionError` (signals that approval was needed but unavailable) |
+
+```python
+from pydantic_ai_backends.permissions import AskFallback
+
+# Deny operations that need approval (safe for automated pipelines)
+backend = LocalBackend(
+    root_dir="/workspace",
     permissions=DEFAULT_RULESET,
     ask_fallback="deny",
 )
 
-# Raise PermissionError for operations that need approval
+# Raise PermissionError - useful for detecting missing callback setup
 backend = LocalBackend(
+    root_dir="/workspace",
     permissions=DEFAULT_RULESET,
     ask_fallback="error",
 )
+```
+
+### Using PermissionChecker Directly
+
+For programmatic use outside of backends, use `PermissionChecker` with explicit callback and fallback:
+
+```python
+from pydantic_ai_backends.permissions import PermissionChecker, DEFAULT_RULESET
+
+async def my_callback(op: str, target: str, reason: str) -> bool:
+    return input(f"Allow {op} on {target}? ").lower() == "y"
+
+checker = PermissionChecker(
+    ruleset=DEFAULT_RULESET,
+    ask_callback=my_callback,
+    ask_fallback="error",  # Raise if callback unavailable
+)
+
+# Async check - invokes callback for "ask" actions
+try:
+    allowed = await checker.check("write", "/config/settings.yaml", "Save settings")
+except PermissionError:
+    print("No callback available to ask for permission")
+except PermissionDeniedError:
+    print("Permission explicitly denied")
+
+# Sync check - returns action without invoking callback
+action = checker.check_sync("write", "/config/settings.yaml")
+if action == "ask":
+    print("This operation would need approval")
 ```
 
 ## Integration with LocalBackend

--- a/docs/examples/multi-user.md
+++ b/docs/examples/multi-user.md
@@ -142,12 +142,99 @@ async def main():
         await client.delete(f"/sessions/{session_id}")
 ```
 
+## Auto-Cleanup of Idle Sessions
+
+SessionManager can automatically clean up sessions that have been idle, preventing container sprawl in production.
+
+### Background Cleanup Loop
+
+Start a background task that periodically checks for and removes idle sessions:
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from pydantic_ai_backends import SessionManager
+
+session_manager: SessionManager | None = None
+
+@asynccontextmanager
+async def lifespan(app):
+    global session_manager
+    session_manager = SessionManager(
+        default_runtime="python-datascience",
+        workspace_root="/app/workspaces",
+        default_idle_timeout=1800,  # 30 minutes
+    )
+
+    # Start background cleanup every 5 minutes
+    session_manager.start_cleanup_loop(interval=300)
+
+    yield
+
+    # Graceful shutdown: stop cleanup loop and all containers
+    stopped = await session_manager.shutdown()
+    print(f"Stopped {stopped} sessions on shutdown")
+
+app = FastAPI(lifespan=lifespan)
+```
+
+### Manual Cleanup
+
+You can also trigger cleanup manually, for example in a scheduled endpoint or health check:
+
+```python
+@app.post("/admin/cleanup")
+async def cleanup_idle_sessions(max_idle: int = 1800):
+    """Remove sessions idle for more than max_idle seconds."""
+    cleaned = await session_manager.cleanup_idle(max_idle=max_idle)
+    return {
+        "cleaned": cleaned,
+        "active": session_manager.session_count,
+    }
+```
+
+### Per-User Session Lifecycle
+
+SessionManager handles the full lifecycle of each user's sandbox:
+
+```python
+# 1. First request from user - creates a new container
+sandbox = await session_manager.get_or_create("user-alice")
+
+# 2. Subsequent requests - reuses the existing container
+#    (also resets the idle timer)
+sandbox = await session_manager.get_or_create("user-alice")
+
+# 3. If container dies between requests, a new one is created automatically
+sandbox = await session_manager.get_or_create("user-alice")
+
+# 4. Explicit release when user logs out
+await session_manager.release("user-alice")
+
+# 5. Or let idle cleanup handle it automatically
+```
+
+### Monitoring Active Sessions
+
+```python
+@app.get("/admin/sessions")
+async def list_sessions():
+    return {
+        "count": session_manager.session_count,
+        "session_ids": list(session_manager.sessions.keys()),
+    }
+
+@app.get("/admin/sessions/{session_id}")
+async def check_session(session_id: str):
+    return {"exists": session_id in session_manager}
+```
+
 ## Security Features
 
 - **User Isolation**: Each user's container is separate
 - **No Cross-Access**: Users cannot see other users' files
 - **Persistent Storage**: Files stored on host, mounted into containers
-- **Automatic Cleanup**: Containers removed when sessions end
+- **Automatic Cleanup**: Containers removed when sessions end or go idle
 
 ## Full Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.1.6"
+version = "0.1.7"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -88,6 +88,9 @@ if TYPE_CHECKING:
         create_ruleset,
     )
     from pydantic_ai_backends.toolsets.console import (
+        DEFAULT_MAX_IMAGE_BYTES,
+        IMAGE_EXTENSIONS,
+        IMAGE_MEDIA_TYPES,
         ConsoleDeps,
         ConsoleToolset,
         create_console_toolset,
@@ -101,6 +104,9 @@ _LAZY_IMPORTS = {
     "get_console_system_prompt": "pydantic_ai_backends.toolsets.console",
     "ConsoleToolset": "pydantic_ai_backends.toolsets.console",
     "ConsoleDeps": "pydantic_ai_backends.toolsets.console",
+    "IMAGE_EXTENSIONS": "pydantic_ai_backends.toolsets.console",
+    "IMAGE_MEDIA_TYPES": "pydantic_ai_backends.toolsets.console",
+    "DEFAULT_MAX_IMAGE_BYTES": "pydantic_ai_backends.toolsets.console",
     # Docker sandbox (requires docker extra)
     "DockerSandbox": "pydantic_ai_backends.backends.docker.sandbox",
     "BaseSandbox": "pydantic_ai_backends.backends.docker.sandbox",
@@ -159,6 +165,10 @@ __all__ = [
     "get_console_system_prompt",
     "ConsoleToolset",
     "ConsoleDeps",
+    # Image support constants
+    "IMAGE_EXTENSIONS",
+    "IMAGE_MEDIA_TYPES",
+    "DEFAULT_MAX_IMAGE_BYTES",
     # Docker sandbox (optional - requires docker extra)
     "BaseSandbox",
     "DockerSandbox",

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -3,12 +3,27 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, runtime_checkable
 
-from pydantic_ai import RunContext
+from pydantic_ai import BinaryContent, RunContext
 
 from pydantic_ai_backends.protocol import BackendProtocol
 from pydantic_ai_backends.types import GrepMatch
+
+IMAGE_EXTENSIONS: frozenset[str] = frozenset({"png", "jpg", "jpeg", "gif", "webp"})
+"""File extensions recognized as images when image_support is enabled."""
+
+IMAGE_MEDIA_TYPES: dict[str, str] = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+"""Mapping of file extensions to MIME media types for images."""
+
+DEFAULT_MAX_IMAGE_BYTES: int = 50 * 1024 * 1024
+"""Default maximum image file size (50MB)."""
 
 if TYPE_CHECKING:
     from pydantic_ai.toolsets import FunctionToolset
@@ -87,6 +102,8 @@ def create_console_toolset(  # noqa: C901
     default_ignore_hidden: bool = True,
     permissions: PermissionRuleset | None = None,
     max_retries: int = 1,
+    image_support: bool = False,
+    max_image_bytes: int = DEFAULT_MAX_IMAGE_BYTES,
 ) -> FunctionToolset[ConsoleDeps]:
     """Create a console toolset for file operations and shell execution.
 
@@ -110,6 +127,13 @@ def create_console_toolset(  # noqa: C901
             When the model sends invalid arguments (e.g. missing required fields),
             the validation error is fed back and the model can retry up to this
             many times. Defaults to 1.
+        image_support: Whether to enable image file handling in read_file.
+            When True, reading image files (.png, .jpg, .jpeg, .gif, .webp) returns
+            a BinaryContent object that multimodal models can see, instead of garbled
+            text. Defaults to False.
+        max_image_bytes: Maximum image file size in bytes (default: 10MB).
+            Images larger than this will return an error message instead.
+            Only used when image_support is True.
 
     Returns:
         FunctionToolset with console tools.
@@ -125,6 +149,9 @@ def create_console_toolset(  # noqa: C901
 
         toolset = create_console_toolset()
         deps = MyDeps(backend=LocalBackend("/workspace"))
+
+        # With image support for multimodal models
+        toolset = create_console_toolset(image_support=True)
 
         # Or with permissions
         from pydantic_ai_backends.permissions import DEFAULT_RULESET
@@ -174,7 +201,7 @@ def create_console_toolset(  # noqa: C901
         path: str,
         offset: int = 0,
         limit: int = 2000,
-    ) -> str:
+    ) -> Any:
         """Read file content with line numbers.
 
         Args:
@@ -182,6 +209,20 @@ def create_console_toolset(  # noqa: C901
             offset: Line number to start reading from (0-indexed).
             limit: Maximum number of lines to read.
         """
+        if image_support:
+            ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+            if ext in IMAGE_EXTENSIONS:
+                raw = ctx.deps.backend._read_bytes(path)
+                if not raw:
+                    return f"Error: Image file '{path}' not found or empty"
+                if len(raw) > max_image_bytes:
+                    size_mb = len(raw) / (1024 * 1024)
+                    limit_mb = max_image_bytes / (1024 * 1024)
+                    return (
+                        f"Error: Image '{path}' too large ({size_mb:.1f}MB, max {limit_mb:.1f}MB)"
+                    )
+                media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
+                return BinaryContent(data=raw, media_type=media_type)
         return ctx.deps.backend.read(path, offset, limit)
 
     @toolset.tool(requires_approval=write_approval)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -4,13 +4,20 @@ import inspect
 from dataclasses import dataclass
 from pathlib import Path
 
+from pydantic_ai import BinaryContent
+
 from pydantic_ai_backends import (
     LocalBackend,
     StateBackend,
     create_console_toolset,
     get_console_system_prompt,
 )
-from pydantic_ai_backends.toolsets.console import ConsoleDeps
+from pydantic_ai_backends.toolsets.console import (
+    DEFAULT_MAX_IMAGE_BYTES,
+    IMAGE_EXTENSIONS,
+    IMAGE_MEDIA_TYPES,
+    ConsoleDeps,
+)
 
 
 @dataclass
@@ -124,6 +131,191 @@ class TestGetConsoleSystemPrompt:
 
         # Should mention shell execution
         assert "execute" in prompt.lower() or "shell" in prompt.lower()
+
+
+class TestCreateConsoleToolsetImageParams:
+    """Test create_console_toolset with image parameters."""
+
+    def test_create_toolset_with_image_support(self):
+        """Test creating toolset with image_support=True."""
+        toolset = create_console_toolset(image_support=True)
+        assert "read_file" in toolset.tools
+
+    def test_create_toolset_with_custom_max_image_bytes(self):
+        """Test creating toolset with custom max_image_bytes."""
+        toolset = create_console_toolset(image_support=True, max_image_bytes=1024)
+        assert "read_file" in toolset.tools
+
+    def test_create_toolset_default_no_image_support(self):
+        """Test that image_support defaults to False."""
+        toolset = create_console_toolset()
+        assert "read_file" in toolset.tools
+
+
+class TestImageConstants:
+    """Test image-related constants."""
+
+    def test_image_extensions(self):
+        """Test IMAGE_EXTENSIONS contains expected formats."""
+        assert "png" in IMAGE_EXTENSIONS
+        assert "jpg" in IMAGE_EXTENSIONS
+        assert "jpeg" in IMAGE_EXTENSIONS
+        assert "gif" in IMAGE_EXTENSIONS
+        assert "webp" in IMAGE_EXTENSIONS
+        # SVG is intentionally excluded (it's text/XML)
+        assert "svg" not in IMAGE_EXTENSIONS
+
+    def test_image_media_types(self):
+        """Test IMAGE_MEDIA_TYPES maps extensions to MIME types."""
+        assert IMAGE_MEDIA_TYPES["png"] == "image/png"
+        assert IMAGE_MEDIA_TYPES["jpg"] == "image/jpeg"
+        assert IMAGE_MEDIA_TYPES["jpeg"] == "image/jpeg"
+        assert IMAGE_MEDIA_TYPES["gif"] == "image/gif"
+        assert IMAGE_MEDIA_TYPES["webp"] == "image/webp"
+
+    def test_all_extensions_have_media_types(self):
+        """Test every IMAGE_EXTENSION has a corresponding IMAGE_MEDIA_TYPE."""
+        for ext in IMAGE_EXTENSIONS:
+            assert ext in IMAGE_MEDIA_TYPES
+
+    def test_default_max_image_bytes(self):
+        """Test DEFAULT_MAX_IMAGE_BYTES is 50MB."""
+        assert DEFAULT_MAX_IMAGE_BYTES == 50 * 1024 * 1024
+
+
+class TestReadFileImageSupport:
+    """Test read_file with image_support enabled."""
+
+    def test_read_image_png_local_backend(self, tmp_path: Path):
+        """Test reading a PNG image returns BinaryContent."""
+        # Create a fake PNG file (PNG header + some data)
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(png_data)
+
+        backend = LocalBackend(root_dir=tmp_path)
+        result = backend._read_bytes("test.png")
+        assert result == png_data
+
+        # Verify the toolset is created with image_support
+        toolset = create_console_toolset(image_support=True)
+        assert "read_file" in toolset.tools
+
+    def test_read_image_jpg_local_backend(self, tmp_path: Path):
+        """Test reading a JPG image returns bytes via _read_bytes."""
+        jpg_data = b"\xff\xd8\xff\xe0" + b"\x00" * 50
+        img_path = tmp_path / "photo.jpg"
+        img_path.write_bytes(jpg_data)
+
+        backend = LocalBackend(root_dir=tmp_path)
+        result = backend._read_bytes("photo.jpg")
+        assert result == jpg_data
+
+    def test_read_image_jpeg_extension(self, tmp_path: Path):
+        """Test .jpeg extension is recognized."""
+        jpeg_data = b"\xff\xd8\xff\xe0" + b"\x00" * 50
+        img_path = tmp_path / "photo.jpeg"
+        img_path.write_bytes(jpeg_data)
+
+        backend = LocalBackend(root_dir=tmp_path)
+        result = backend._read_bytes("photo.jpeg")
+        assert result == jpeg_data
+
+    def test_read_image_gif_local_backend(self, tmp_path: Path):
+        """Test reading a GIF image."""
+        gif_data = b"GIF89a" + b"\x00" * 50
+        img_path = tmp_path / "anim.gif"
+        img_path.write_bytes(gif_data)
+
+        backend = LocalBackend(root_dir=tmp_path)
+        result = backend._read_bytes("anim.gif")
+        assert result == gif_data
+
+    def test_read_image_webp_local_backend(self, tmp_path: Path):
+        """Test reading a WebP image."""
+        webp_data = b"RIFF" + b"\x00" * 4 + b"WEBP" + b"\x00" * 50
+        img_path = tmp_path / "image.webp"
+        img_path.write_bytes(webp_data)
+
+        backend = LocalBackend(root_dir=tmp_path)
+        result = backend._read_bytes("image.webp")
+        assert result == webp_data
+
+    def test_read_image_not_found(self, tmp_path: Path):
+        """Test reading nonexistent image returns empty bytes."""
+        backend = LocalBackend(root_dir=tmp_path)
+        result = backend._read_bytes("nonexistent.png")
+        assert result == b""
+
+    def test_read_text_file_with_image_support(self, tmp_path: Path):
+        """Test that text files still return text with image_support enabled."""
+        txt_path = tmp_path / "readme.txt"
+        txt_path.write_text("Hello, world!")
+
+        backend = LocalBackend(root_dir=tmp_path)
+        # Text files should still use the standard read() method
+        result = backend.read("readme.txt")
+        assert "Hello, world!" in result
+
+    def test_read_image_state_backend(self):
+        """Test reading image from StateBackend via _read_bytes."""
+        backend = StateBackend()
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        backend.write("/test.png", png_data)
+
+        result = backend._read_bytes("/test.png")
+        # StateBackend stores as text, so _read_bytes returns encoded text
+        assert isinstance(result, bytes)
+
+    def test_image_extension_case_insensitive(self):
+        """Test that image extension detection is case-insensitive."""
+        # The implementation uses .lower() so uppercase should work
+        path = "photo.PNG"
+        ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+        assert ext in IMAGE_EXTENSIONS
+
+    def test_no_extension_not_image(self):
+        """Test that files without extension are not treated as images."""
+        path = "Makefile"
+        ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+        assert ext not in IMAGE_EXTENSIONS
+
+    def test_binary_content_creation(self):
+        """Test creating BinaryContent from image data."""
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        content = BinaryContent(data=png_data, media_type="image/png")
+        assert content.data == png_data
+        assert content.media_type == "image/png"
+        assert content.is_image
+
+    def test_binary_content_jpg_media_type(self):
+        """Test BinaryContent with JPEG media type."""
+        jpg_data = b"\xff\xd8\xff\xe0" + b"\x00" * 50
+        content = BinaryContent(data=jpg_data, media_type="image/jpeg")
+        assert content.media_type == "image/jpeg"
+        assert content.is_image
+
+
+class TestImageExports:
+    """Test that image constants are exported from the package."""
+
+    def test_image_extensions_exported(self):
+        """Test IMAGE_EXTENSIONS is importable from package."""
+        from pydantic_ai_backends import IMAGE_EXTENSIONS as exported
+
+        assert exported == IMAGE_EXTENSIONS
+
+    def test_image_media_types_exported(self):
+        """Test IMAGE_MEDIA_TYPES is importable from package."""
+        from pydantic_ai_backends import IMAGE_MEDIA_TYPES as exported
+
+        assert exported == IMAGE_MEDIA_TYPES
+
+    def test_default_max_image_bytes_exported(self):
+        """Test DEFAULT_MAX_IMAGE_BYTES is importable from package."""
+        from pydantic_ai_backends import DEFAULT_MAX_IMAGE_BYTES as exported
+
+        assert exported == DEFAULT_MAX_IMAGE_BYTES
 
 
 class TestConsoleToolsetAlias:


### PR DESCRIPTION
## [0.1.7] - 2025-02-16

### Added

- **Image support in `read_file`**: When `image_support=True` is passed to `create_console_toolset()`, reading image files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`) returns a `BinaryContent` object that multimodal models can see, instead of garbled text.
  - `image_support` parameter on `create_console_toolset()` (default: `False`)
  - `max_image_bytes` parameter to limit image file size (default: 50MB)
  - `IMAGE_EXTENSIONS`, `IMAGE_MEDIA_TYPES`, `DEFAULT_MAX_IMAGE_BYTES` constants exported from the package
- **Documentation**: Expanded guides for backends, console toolset, permissions, and multi-user setups.
