### PR TITLE
feat: improve prompts and docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2026-02-20
+
+### Changed
+
+- **Stronger tool preference language in system prompts** — Changed "ALWAYS prefer specialized tools" to "You MUST use specialized tools" in both `CONSOLE_SYSTEM_PROMPT` and `HASHLINE_CONSOLE_PROMPT`. Models now receive a stronger directive to use `read_file`, `glob`, `grep` etc. instead of shell equivalents like `cat`, `find`, `grep`.
+- **Stronger execute tool description** — Changed "Do NOT use it for file operations" to "You MUST avoid using file operation commands in the shell" with each tool preference bullet prefixed with "You MUST use". Reduces unwanted `cat`/`grep`/`find` usage in shell.
+- **Re-read after edit guideline** — Added "After editing a file, re-read it before making subsequent edits" to both `CONSOLE_SYSTEM_PROMPT` and `HASHLINE_CONSOLE_PROMPT` file operations best practices. Prevents stale-read bugs when auto-formatters or pre-commit hooks modify files on disk after an edit.
+
 ## [0.1.9] - 2026-02-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.1.9"
+version = "0.1.10"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -39,7 +39,7 @@ CONSOLE_SYSTEM_PROMPT = """\
 
 You have access to console tools for file operations and command execution.
 
-### Tool Preferences — ALWAYS prefer specialized tools over shell equivalents:
+### Tool Preferences — You MUST use specialized tools instead of shell equivalents:
 - **File search**: Use `glob` (NOT `find` or `ls`)
 - **Content search**: Use `grep` (NOT shell `grep` or `rg`)
 - **Read files**: Use `read_file` (NOT `cat`, `head`, or `tail`)
@@ -50,6 +50,8 @@ You have access to console tools for file operations and command execution.
 
 ### File Operations Best Practices
 - **ALWAYS read a file before editing it** — understand existing content first
+- After editing a file, **re-read it before making subsequent edits** to the same file — \
+auto-formatters or pre-commit hooks may have changed the content on disk
 - Use `edit_file` for targeted changes (replacing a function, fixing a bug)
 - Use `write_file` only for complete file rewrites or new files
 - Use `glob` to discover files before operating on them
@@ -118,7 +120,7 @@ hashline_edit(path, start_line=2, start_hash="f1", new_content="")
 (line numbers shift after each edit)
 - Use `write_file` for complete file rewrites or new files
 
-### Tool Preferences — ALWAYS prefer specialized tools over shell equivalents:
+### Tool Preferences — You MUST use specialized tools instead of shell equivalents:
 - **File search**: Use `glob` (NOT `find` or `ls`)
 - **Content search**: Use `grep` (NOT shell `grep` or `rg`)
 - **Read files**: Use `read_file` (NOT `cat`, `head`, or `tail`)
@@ -128,6 +130,8 @@ hashline_edit(path, start_line=2, start_hash="f1", new_content="")
 (builds, tests, git commands, package installs, running scripts)
 
 ### File Operations Best Practices
+- After editing a file, **re-read it before making subsequent edits** to the same file — \
+auto-formatters or pre-commit hooks may have changed the content on disk
 - When reading large files (>200 lines), use pagination: start with \
 `read_file(path, limit=100)` to scan structure, then read targeted sections \
 with `offset` and `limit`
@@ -629,13 +633,15 @@ shell `grep` or `rg` commands.
             """Execute a shell command in the working directory.
 
             IMPORTANT: This tool is for operations that REQUIRE a real shell — \
-running tests, builds, git commands, package installs, running scripts. \
-Do NOT use it for file operations — use specialized tools instead:
-- Use `read_file` instead of `cat`, `head`, `tail`
-- Use `edit_file` instead of `sed`, `awk`
-- Use `write_file` instead of `echo >` or `cat <<EOF`
-- Use `glob` instead of `find` or `ls`
-- Use `grep` instead of shell `grep` or `rg`
+running tests, builds, git commands, package installs, running scripts.
+
+            You MUST avoid using file operation commands in the shell. \
+Use the specialized tools instead:
+- You MUST use `read_file` instead of `cat`, `head`, `tail`
+- You MUST use `edit_file`/`hashline_edit` instead of `sed`, `awk`
+- You MUST use `write_file` instead of `echo >` or `cat <<EOF`
+- You MUST use `glob` instead of `find` or `ls`
+- You MUST use `grep` instead of shell `grep` or `rg`
 
             Usage:
 - Always quote file paths containing spaces with double quotes.


### PR DESCRIPTION
## [0.1.10] - 2026-02-20

### Changed

- **Stronger tool preference language in system prompts** — Changed "ALWAYS prefer specialized tools" to "You MUST use specialized tools" in both `CONSOLE_SYSTEM_PROMPT` and `HASHLINE_CONSOLE_PROMPT`. Models now receive a stronger directive to use `read_file`, `glob`, `grep` etc. instead of shell equivalents like `cat`, `find`, `grep`.
- **Stronger execute tool description** — Changed "Do NOT use it for file operations" to "You MUST avoid using file operation commands in the shell" with each tool preference bullet prefixed with "You MUST use". Reduces unwanted `cat`/`grep`/`find` usage in shell.
- **Re-read after edit guideline** — Added "After editing a file, re-read it before making subsequent edits" to both `CONSOLE_SYSTEM_PROMPT` and `HASHLINE_CONSOLE_PROMPT` file operations best practices. Prevents stale-read bugs when auto-formatters or pre-commit hooks modify files on disk after an edit.
