### PR TITLE
feat: `.protocol.SandboxSessionManager`

### DIFF
--- a/src/pydantic_ai_backends/protocol.py
+++ b/src/pydantic_ai_backends/protocol.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
         ExecuteResponse,
         FileInfo,
         GrepMatch,
+        RuntimeConfig,
         WriteResult,
     )
 
@@ -164,4 +165,98 @@ class SandboxProtocol(BackendProtocol, Protocol):
     @property
     def id(self) -> str:
         """Unique identifier for this sandbox instance."""
+        ...
+
+
+@runtime_checkable
+class SandboxSessionManager(Protocol):
+    """Session management for SandboxProtocol sandboxes."""
+
+    @property
+    def sessions(self) -> dict[str, SandboxProtocol]:
+        """Active sessions dictionary (read-only access)."""
+        ...
+
+    @property
+    def session_count(self) -> int:
+        """Number of active sessions."""
+        ...
+
+    async def get_or_create(
+        self,
+        session_id: str,
+        runtime: RuntimeConfig | str | None = None,
+    ) -> SandboxProtocol:
+        """Get an existing sandbox or create a new one.
+
+        If a sandbox exists for the session_id and is still alive,
+        it will be returned. Otherwise, a new sandbox will be created.
+
+        Args:
+            session_id: Unique identifier for the session.
+            runtime: RuntimeConfig or name to use (defaults a runtime
+            configuration specified in the manager instance).
+
+        Returns:
+            SandboxProtocol instance for the session.
+
+        Raises:
+            ValueError: If no runtime specified and no default runtime set.
+        """
+        ...
+
+    async def release(self, session_id: str) -> bool:
+        """Release a session and stop its container.
+
+        Args:
+            session_id: Session identifier to release.
+
+        Returns:
+            True if session was found and released, False otherwise.
+        """
+        ...
+
+    async def cleanup_idle(self, max_idle: int | None = None) -> int:
+        """Clean up idle sessions.
+
+        Removes and stops sandboxes that have been idle for longer than
+        the specified time.
+
+        Args:
+            max_idle: Maximum idle time in seconds. Uses default if
+            not specified.
+
+        Returns:
+            Number of sessions cleaned up.
+        """
+        ...
+
+    def start_cleanup_loop(self, interval: int = 300) -> None:
+        """Start background cleanup loop.
+
+        Periodically cleans up idle sessions.
+
+        Args:
+            interval: Cleanup interval in seconds (default: 5 minutes).
+        """
+        ...
+
+    def stop_cleanup_loop(self) -> None:
+        """Stop the background cleanup loop."""
+        ...
+
+    async def shutdown(self) -> int:
+        """Shutdown all sessions and stop cleanup loop.
+
+        Returns:
+            Number of sessions that were stopped.
+        """
+        ...
+
+    def __contains__(self, session_id: str) -> bool:
+        """Check if a session exists."""
+        ...
+
+    def __len__(self) -> int:
+        """Return number of active sessions."""
         ...


### PR DESCRIPTION
## Changes

### Summary

Declare a protocol for sandbox session managers.

### Business Context

 Enable construction of alternate session manager to the one in `backends.docker`, e.g. one using `bubblewrap`.