### PR TITLE
Enable Fine Grained Permissions for `DockerSandbox`

### DIFF
--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -32,7 +32,12 @@ DEFAULT_MAX_IMAGE_BYTES: int = 50 * 1024 * 1024
 if TYPE_CHECKING:
     from pydantic_ai.toolsets import FunctionToolset
 
-    from pydantic_ai_backends.permissions.types import PermissionRuleset
+    from pydantic_ai_backends.permissions.checker import PermissionChecker
+    from pydantic_ai_backends.permissions.types import PermissionOperation, PermissionRuleset
+
+_CONSOLE_PERMISSION_OPS = frozenset(
+    {"read", "write", "edit", "execute", "ls", "glob", "grep"},
+)
 
 
 CONSOLE_SYSTEM_PROMPT = """\
@@ -263,14 +268,39 @@ def _requires_approval_from_ruleset(
     return op_perms.default == "ask"
 
 
+def _reject_ruleset_per_path_ask(ruleset: PermissionRuleset) -> None:
+    """Raise NotImplementedError if any operation uses per-path 'ask' rules.
+
+    Current implementation supports ask rules at the operation level only,
+    not per-path.
+    """
+    from pydantic_ai_backends.permissions.types import OperationPermissions
+
+    for op in _CONSOLE_PERMISSION_OPS:
+        op_perms: OperationPermissions | None = getattr(ruleset, op, None)
+        if op_perms is None:
+            continue
+        if op_perms.default == "ask":
+            continue
+        for rule in op_perms.rules:
+            if rule.action == "ask":
+                msg = (
+                    f"Per-path 'ask' rules are not supported for operation {op!r} "
+                    f"(found rule pattern {rule.pattern!r}). Use "
+                    f"OperationPermissions(default='ask') for whole-tool approval, "
+                    f"or use only 'allow'/'deny' in rules."
+                )
+                raise NotImplementedError(msg)
+
+
 def _is_denied_by_ruleset(
     ruleset: PermissionRuleset | None,
     operation: str,
 ) -> bool:
-    """Check if an operation is denied by the ruleset.
+    """Return True if the operation should omit console tools entirely.
 
-    Returns True when the operation's default action is "deny",
-    meaning the corresponding tools should not be registered at all.
+    Returns True only when the operation's default action is "deny",
+    and there is no "allow" rule that could permit a path.
     """
     from pydantic_ai_backends.permissions.types import OperationPermissions
 
@@ -280,7 +310,57 @@ def _is_denied_by_ruleset(
     op_perms: OperationPermissions | None = getattr(ruleset, operation, None)
     if op_perms is None:
         return ruleset.default == "deny"
-    return op_perms.default == "deny"
+    if op_perms.default != "deny":
+        return False
+    return not any(rule.action == "allow" for rule in op_perms.rules)
+
+
+def _evaluate_toolset_permission(
+    checker: PermissionChecker,
+    backend: BackendProtocol,
+    operation: PermissionOperation,
+    target: str,
+) -> str | None:
+    """Return an error message if the toolset-level check denies, else None.
+
+    Skips when the backend already has a ``permission_checker`` (LocalBackend).
+    When the ruleset resolves to `ask`` without an ``ask_callback``, raises
+    ``PermissionError`` (``ask_fallback=\"error\"`` on ``PermissionChecker``).
+    """
+    from pydantic_ai_backends.permissions.checker import PermissionError
+
+    if getattr(backend, "permission_checker", None) is not None:
+        return None
+
+    action = checker.check_sync(operation, target)
+    if action == "allow":
+        return None
+    if action == "deny":
+        rule = checker._find_matching_rule(operation, target)
+        if rule and rule.description:
+            return f"Permission denied: {rule.description}"
+        return f"Permission denied for {operation} on '{target}'"
+    raise PermissionError(operation, target, "Approval required but no callback")
+
+
+def _toolset_permission_prefix_error(
+    checker: PermissionChecker | None,
+    backend: BackendProtocol,
+    operation: PermissionOperation,
+    target: str,
+) -> str | None:
+    """Return ``Error: ...`` string or None. Catches ``PermissionError``."""
+    from pydantic_ai_backends.permissions.checker import PermissionError
+
+    if checker is None:
+        return None
+    try:
+        msg = _evaluate_toolset_permission(checker, backend, operation, target)
+    except PermissionError as e:
+        return f"Error: {e}"
+    if msg:
+        return f"Error: {msg}"
+    return None
 
 
 def create_console_toolset(  # noqa: C901
@@ -314,6 +394,12 @@ def create_console_toolset(  # noqa: C901
         permissions: Optional permission ruleset to determine tool approval requirements.
             If provided, overrides require_write_approval and require_execute_approval
             based on whether the operation's default action is "ask".
+            Enforced inside tools when the backend has no `permission_checker`
+            (e.g. DockerSandbox). Rules cannot use per-path action='ask' unless
+            that operation's default is also 'ask'.
+            If a path resolves to ``ask`` without an ``ask_callback``, tools
+            return an error string from ``PermissionError`` (``ask_fallback=\"error\"``
+            on the internal ``PermissionChecker``).
         max_retries: Maximum number of retries for each tool during a run.
             When the model sends invalid arguments (e.g. missing required fields),
             the validation error is fed back and the model can retry up to this
@@ -363,7 +449,20 @@ def create_console_toolset(  # noqa: C901
     """
     from pydantic_ai.toolsets import FunctionToolset
 
+    from pydantic_ai_backends.permissions.checker import PermissionChecker
+
     _descs = descriptions or {}
+
+    if permissions is not None:
+        _reject_ruleset_per_path_ask(permissions)
+
+    toolset_checker: PermissionChecker | None = None
+    if permissions is not None:
+        toolset_checker = PermissionChecker(
+            ruleset=permissions,
+            ask_callback=None,
+            ask_fallback="error",
+        )
 
     # Determine approval requirements and denied operations
     write_approval = _requires_approval_from_ruleset(permissions, "write", require_write_approval)
@@ -391,6 +490,10 @@ def create_console_toolset(  # noqa: C901
         Args:
             path: Directory path to list. Defaults to current directory.
         """
+        err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "ls", path)
+        if err:
+            return err
+
         entries = await asyncio.to_thread(ctx.deps.backend.ls_info, path)
 
         if not entries:
@@ -427,6 +530,11 @@ def create_console_toolset(  # noqa: C901
             if image_support:
                 ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
                 if ext in IMAGE_EXTENSIONS:
+                    err = _toolset_permission_prefix_error(
+                        toolset_checker, ctx.deps.backend, "read", path
+                    )
+                    if err:
+                        return err
                     raw = await asyncio.to_thread(ctx.deps.backend._read_bytes, path)
                     if not raw:
                         return f"Error: Image file '{path}' not found or empty"
@@ -439,6 +547,10 @@ def create_console_toolset(  # noqa: C901
                         )
                     media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
                     return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
+
+            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "read", path)
+            if err:
+                return err
 
             from pydantic_ai_backends.hashline import format_hashline_output
 
@@ -467,6 +579,11 @@ def create_console_toolset(  # noqa: C901
             if image_support:
                 ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
                 if ext in IMAGE_EXTENSIONS:
+                    err = _toolset_permission_prefix_error(
+                        toolset_checker, ctx.deps.backend, "read", path
+                    )
+                    if err:
+                        return err
                     raw = await asyncio.to_thread(ctx.deps.backend._read_bytes, path)
                     if not raw:
                         return f"Error: Image file '{path}' not found or empty"
@@ -479,6 +596,9 @@ def create_console_toolset(  # noqa: C901
                         )
                     media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
                     return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
+            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "read", path)
+            if err:
+                return err
             return await asyncio.to_thread(ctx.deps.backend.read, path, offset, limit)
 
     # --- write_file tool ---
@@ -497,6 +617,10 @@ def create_console_toolset(  # noqa: C901
             path: Path to the file to write.
             content: Complete content to write to the file.
         """
+        err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "write", path)
+        if err:
+            return err
+
         result = await asyncio.to_thread(ctx.deps.backend.write, path, content)
 
         if result.error:
@@ -534,6 +658,10 @@ def create_console_toolset(  # noqa: C901
                 insert_after: If True, insert new_content after start_line instead \
 of replacing it.
             """
+            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "edit", path)
+            if err:
+                return err
+
             from pydantic_ai_backends.hashline import apply_hashline_edit_with_summary
 
             # Read current file content
@@ -587,6 +715,10 @@ including whitespace and indentation.
                 replace_all: If True, replace all occurrences. If False (default), \
 the old_string must appear exactly once in the file.
             """
+            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "edit", path)
+            if err:
+                return err
+
             result = await asyncio.to_thread(
                 ctx.deps.backend.edit, path, old_string, new_string, replace_all
             )
@@ -608,6 +740,10 @@ the old_string must appear exactly once in the file.
             pattern: Glob pattern to match.
             path: Base directory to search from. Defaults to current directory.
         """
+        err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "glob", path)
+        if err:
+            return err
+
         entries = await asyncio.to_thread(ctx.deps.backend.glob_info, pattern, path)
 
         if not entries:
@@ -640,6 +776,13 @@ the old_string must appear exactly once in the file.
             output_mode: Output format — `"content"`, `"files_with_matches"`, or `"count"`.
             ignore_hidden: Whether to skip hidden files/directories.
         """
+        grep_target = path if path is not None else "."
+        err = _toolset_permission_prefix_error(
+            toolset_checker, ctx.deps.backend, "grep", grep_target
+        )
+        if err:
+            return err
+
         result = await asyncio.to_thread(
             ctx.deps.backend.grep_raw, pattern, path, glob_pattern, ignore_hidden
         )
@@ -703,6 +846,10 @@ for long-running builds or test suites.
             # Check if execute is enabled (for LocalBackend)
             if hasattr(backend, "execute_enabled") and not backend.execute_enabled:  # pyright: ignore[reportAttributeAccessIssue]
                 return "Error: Shell execution is disabled for this backend"
+
+            err = _toolset_permission_prefix_error(toolset_checker, backend, "execute", command)
+            if err:
+                return err
 
             try:
                 result = await asyncio.to_thread(backend.execute, command, timeout)  # pyright: ignore[reportAttributeAccessIssue]

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -323,9 +323,9 @@ def _evaluate_toolset_permission(
 ) -> str | None:
     """Return an error message if the toolset-level check denies, else None.
 
-    Skips when the backend already has a ``permission_checker`` (LocalBackend).
-    When the ruleset resolves to `ask`` without an ``ask_callback``, raises
-    ``PermissionError`` (``ask_fallback=\"error\"`` on ``PermissionChecker``).
+    Skips when the backend already has a `permission_checker` (LocalBackend).
+    When the ruleset resolves to `ask` without an `ask_callback`, raises
+    `PermissionError` (`ask_fallback="error"` on `PermissionChecker`).
     """
     from pydantic_ai_backends.permissions.checker import PermissionError
 
@@ -397,9 +397,8 @@ def create_console_toolset(  # noqa: C901
             Enforced inside tools when the backend has no `permission_checker`
             (e.g. DockerSandbox). Rules cannot use per-path action='ask' unless
             that operation's default is also 'ask'.
-            If a path resolves to ``ask`` without an ``ask_callback``, tools
-            return an error string from ``PermissionError`` (``ask_fallback=\"error\"``
-            on the internal ``PermissionChecker``).
+            If a path resolves to `ask` without an `ask_callback`, tools
+            return an error string from `PermissionError`.
         max_retries: Maximum number of retries for each tool during a run.
             When the model sends invalid arguments (e.g. missing required fields),
             the validation error is fed back and the model can retry up to this
@@ -490,7 +489,9 @@ def create_console_toolset(  # noqa: C901
         Args:
             path: Directory path to list. Defaults to current directory.
         """
-        err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "ls", path)
+        err = _toolset_permission_prefix_error(
+            toolset_checker, ctx.deps.backend, "ls", path
+        )
         if err:
             return err
 
@@ -531,8 +532,7 @@ def create_console_toolset(  # noqa: C901
                 ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
                 if ext in IMAGE_EXTENSIONS:
                     err = _toolset_permission_prefix_error(
-                        toolset_checker, ctx.deps.backend, "read", path
-                    )
+                        toolset_checker, ctx.deps.backend, "read", path)
                     if err:
                         return err
                     raw = await asyncio.to_thread(ctx.deps.backend._read_bytes, path)
@@ -548,7 +548,8 @@ def create_console_toolset(  # noqa: C901
                     media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
                     return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
 
-            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "read", path)
+            err = _toolset_permission_prefix_error(
+                toolset_checker, ctx.deps.backend, "read", path)
             if err:
                 return err
 
@@ -580,8 +581,7 @@ def create_console_toolset(  # noqa: C901
                 ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
                 if ext in IMAGE_EXTENSIONS:
                     err = _toolset_permission_prefix_error(
-                        toolset_checker, ctx.deps.backend, "read", path
-                    )
+                        toolset_checker, ctx.deps.backend, "read", path)
                     if err:
                         return err
                     raw = await asyncio.to_thread(ctx.deps.backend._read_bytes, path)
@@ -596,7 +596,8 @@ def create_console_toolset(  # noqa: C901
                         )
                     media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
                     return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
-            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "read", path)
+            err = _toolset_permission_prefix_error(
+                toolset_checker, ctx.deps.backend, "read", path)
             if err:
                 return err
             return await asyncio.to_thread(ctx.deps.backend.read, path, offset, limit)
@@ -617,7 +618,9 @@ def create_console_toolset(  # noqa: C901
             path: Path to the file to write.
             content: Complete content to write to the file.
         """
-        err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "write", path)
+        err = _toolset_permission_prefix_error(
+            toolset_checker, ctx.deps.backend, "write", path
+        )
         if err:
             return err
 
@@ -658,7 +661,8 @@ def create_console_toolset(  # noqa: C901
                 insert_after: If True, insert new_content after start_line instead \
 of replacing it.
             """
-            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "edit", path)
+            err = _toolset_permission_prefix_error(
+                toolset_checker, ctx.deps.backend, "edit", path)
             if err:
                 return err
 
@@ -715,7 +719,8 @@ including whitespace and indentation.
                 replace_all: If True, replace all occurrences. If False (default), \
 the old_string must appear exactly once in the file.
             """
-            err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "edit", path)
+            err = _toolset_permission_prefix_error(
+                toolset_checker, ctx.deps.backend, "edit", path)
             if err:
                 return err
 
@@ -740,7 +745,9 @@ the old_string must appear exactly once in the file.
             pattern: Glob pattern to match.
             path: Base directory to search from. Defaults to current directory.
         """
-        err = _toolset_permission_prefix_error(toolset_checker, ctx.deps.backend, "glob", path)
+        err = _toolset_permission_prefix_error(
+            toolset_checker, ctx.deps.backend, "glob", path
+        )
         if err:
             return err
 
@@ -847,7 +854,9 @@ for long-running builds or test suites.
             if hasattr(backend, "execute_enabled") and not backend.execute_enabled:  # pyright: ignore[reportAttributeAccessIssue]
                 return "Error: Shell execution is disabled for this backend"
 
-            err = _toolset_permission_prefix_error(toolset_checker, backend, "execute", command)
+            err = _toolset_permission_prefix_error(
+                toolset_checker, backend, "execute", command
+            )
             if err:
                 return err
 

--- a/tests/test_console_permissions.py
+++ b/tests/test_console_permissions.py
@@ -1,11 +1,30 @@
 """Tests for console toolset permission integration."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from pydantic_ai import RunContext
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from pydantic_ai_backends import LocalBackend, StateBackend
 from pydantic_ai_backends.permissions import (
+    PERMISSIVE_RULESET,
+    READONLY_RULESET,
     OperationPermissions,
+    PermissionError,
+    PermissionRule,
     PermissionRuleset,
 )
+from pydantic_ai_backends.permissions.checker import PermissionChecker
 from pydantic_ai_backends.toolsets.console import (
+    _evaluate_toolset_permission,
+    _is_denied_by_ruleset,
+    _reject_ruleset_per_path_ask,
     _requires_approval_from_ruleset,
+    _toolset_permission_prefix_error,
     create_console_toolset,
 )
 
@@ -124,3 +143,454 @@ class TestCreateConsoleToolsetWithPermissions:
         )
 
         assert toolset is not None
+
+
+class TestIsDeniedByRuleset:
+    """Tests for _is_denied_by_ruleset."""
+
+    def test_none_ruleset(self):
+        assert _is_denied_by_ruleset(None, "write") is False
+
+    def test_global_default_deny_missing_op(self):
+        rs = PermissionRuleset(default="deny")
+        assert _is_denied_by_ruleset(rs, "write") is True
+
+    def test_write_unconditional_deny_empty_rules(self):
+        rs = PermissionRuleset(
+            write=OperationPermissions(default="deny", rules=[]),
+        )
+        assert _is_denied_by_ruleset(rs, "write") is True
+
+    def test_write_unconditional_deny_only_deny_rules(self):
+        rs = PermissionRuleset(
+            write=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/.env", action="deny")],
+            ),
+        )
+        assert _is_denied_by_ruleset(rs, "write") is True
+
+    def test_write_default_deny_with_allow_rule_not_stripped(self):
+        rs = PermissionRuleset(
+            write=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/ok.txt", action="allow")],
+            ),
+        )
+        assert _is_denied_by_ruleset(rs, "write") is False
+
+    def test_write_default_allow(self):
+        rs = PermissionRuleset(
+            write=OperationPermissions(default="allow"),
+        )
+        assert _is_denied_by_ruleset(rs, "write") is False
+
+
+class TestRejectRulesetPerPathAsk:
+    """Rulesets with per-path ask (rule action ask, default != ask) must fail."""
+
+    def test_allow_default_with_ask_rule_raises(self):
+        rs = PermissionRuleset(
+            write=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/x", action="ask")],
+            ),
+        )
+        with pytest.raises(NotImplementedError, match="Per-path 'ask'"):
+            _reject_ruleset_per_path_ask(rs)
+
+    def test_deny_default_with_ask_rule_raises(self):
+        rs = PermissionRuleset(
+            write=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/x", action="ask")],
+            ),
+        )
+        with pytest.raises(NotImplementedError, match="Per-path 'ask'"):
+            _reject_ruleset_per_path_ask(rs)
+
+    def test_ask_default_with_ask_rule_ok(self):
+        rs = PermissionRuleset(
+            write=OperationPermissions(
+                default="ask",
+                rules=[PermissionRule(pattern="**/x", action="ask")],
+            ),
+        )
+        _reject_ruleset_per_path_ask(rs)
+
+    def test_create_toolset_raises_for_per_path_ask(self):
+        rs = PermissionRuleset(
+            read=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/s", action="ask")],
+            ),
+        )
+        with pytest.raises(NotImplementedError):
+            create_console_toolset(permissions=rs)
+
+
+class TestEvaluateToolsetPermission:
+    """Direct tests for _evaluate_toolset_permission branches."""
+
+    def test_skips_when_backend_has_permission_checker(self):
+        checker = PermissionChecker(ruleset=PermissionRuleset(default="deny"))
+
+        class BackendWithChecker:
+            permission_checker = object()
+
+        assert _evaluate_toolset_permission(checker, BackendWithChecker(), "read", "/x") is None
+
+    def test_allow_action(self):
+        checker = PermissionChecker(
+            ruleset=PermissionRuleset(
+                read=OperationPermissions(default="allow"),
+            )
+        )
+
+        class NoChecker:
+            pass
+
+        assert _evaluate_toolset_permission(checker, NoChecker(), "read", "/a") is None
+
+    def test_deny_with_rule_description(self):
+        checker = PermissionChecker(
+            ruleset=PermissionRuleset(
+                read=OperationPermissions(
+                    default="allow",
+                    rules=[
+                        PermissionRule(
+                            pattern="**/blocked.txt",
+                            action="deny",
+                            description="no way",
+                        )
+                    ],
+                )
+            )
+        )
+
+        class NoChecker:
+            pass
+
+        msg = _evaluate_toolset_permission(checker, NoChecker(), "read", "/tmp/blocked.txt")
+        assert msg is not None
+        assert "no way" in msg
+
+    def test_deny_without_description(self):
+        checker = PermissionChecker(
+            ruleset=PermissionRuleset(
+                read=OperationPermissions(
+                    default="allow",
+                    rules=[
+                        PermissionRule(pattern="**/z.txt", action="deny"),
+                    ],
+                )
+            )
+        )
+
+        class NoChecker:
+            pass
+
+        msg = _evaluate_toolset_permission(checker, NoChecker(), "read", "/z.txt")
+        assert msg is not None
+        assert "Permission denied for read" in msg
+
+    def test_ask_without_callback_raises(self):
+        checker = PermissionChecker(ruleset=PermissionRuleset(default="ask"))
+
+        class NoChecker:
+            pass
+
+        with pytest.raises(PermissionError):
+            _evaluate_toolset_permission(checker, NoChecker(), "read", "/any")
+
+
+class TestToolsetPermissionPrefixError:
+    def test_none_checker(self):
+        class NoChecker:
+            pass
+
+        assert _toolset_permission_prefix_error(None, NoChecker(), "read", "/x") is None
+
+    def test_wraps_permission_error(self):
+        checker = PermissionChecker(ruleset=PermissionRuleset(default="ask"))
+
+        class NoChecker:
+            pass
+
+        out = _toolset_permission_prefix_error(checker, NoChecker(), "read", "/p")
+        assert out is not None
+        assert out.startswith("Error: Permission required")
+
+
+@dataclass
+class _MockDeps:
+    backend: LocalBackend | StateBackend
+
+
+def _run_ctx(deps: _MockDeps) -> RunContext[_MockDeps]:
+    return RunContext(deps=deps, model=TestModel(), usage=RunUsage())
+
+
+class TestToolRegistrationWithAllowRules:
+    def test_write_tools_present_when_default_deny_with_allow_rule(self):
+        rs = PermissionRuleset(
+            default="deny",
+            read=OperationPermissions(default="allow"),
+            write=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/w.txt", action="allow")],
+            ),
+            edit=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/w.txt", action="allow")],
+            ),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(permissions=rs, include_execute=False)
+        assert "write_file" in ts.tools
+        assert "edit_file" in ts.tools
+        assert "execute" not in ts.tools
+
+
+class TestConsoleToolsetEnforcementStateBackend:
+    @pytest.mark.anyio
+    async def test_write_denied_outside_allow_list(self):
+        backend = StateBackend()
+        rs = PermissionRuleset(
+            read=OperationPermissions(default="allow"),
+            write=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/ok.txt", action="allow")],
+            ),
+            edit=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/ok.txt", action="allow")],
+            ),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(permissions=rs, include_execute=False)
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        bad = await ts.tools["write_file"].function(c, "bad.txt", "x")
+        assert "Error" in bad
+        assert "Permission" in bad
+
+    @pytest.mark.anyio
+    async def test_write_allowed_for_matched_path(self):
+        backend = StateBackend()
+        rs = PermissionRuleset(
+            read=OperationPermissions(default="allow"),
+            write=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/ok.txt", action="allow")],
+            ),
+            edit=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/ok.txt", action="allow")],
+            ),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(permissions=rs, include_execute=False)
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        ok = await ts.tools["write_file"].function(c, "ok.txt", "line\n")
+        assert ok.startswith("Wrote")
+
+    @pytest.mark.anyio
+    async def test_read_denied(self):
+        backend = StateBackend()
+        backend.write("/x.txt", "a")
+        rs = PermissionRuleset(
+            read=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/y.txt", action="allow")],
+            ),
+            write=OperationPermissions(default="allow"),
+            edit=OperationPermissions(default="allow"),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(permissions=rs, include_execute=False)
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        out = await ts.tools["read_file"].function(c, "/x.txt")
+        assert "Error" in out
+
+    @pytest.mark.anyio
+    async def test_ls_glob_grep_execute(self, tmp_path):
+        backend = LocalBackend(root_dir=tmp_path, enable_execute=True)
+        (tmp_path / "a.txt").write_text("hi", encoding="utf-8")
+        rs = PermissionRuleset(
+            read=OperationPermissions(default="allow"),
+            write=OperationPermissions(default="allow"),
+            edit=OperationPermissions(default="allow"),
+            execute=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="echo*", action="allow")],
+            ),
+            ls=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern=".", action="allow")],
+            ),
+            glob=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern=".", action="allow")],
+            ),
+            grep=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern=".", action="allow")],
+            ),
+        )
+        ts = create_console_toolset(permissions=rs, require_execute_approval=False)
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+
+        ls_bad = await ts.tools["ls"].function(c, "..")
+        assert "Error" in ls_bad
+
+        ls_ok = await ts.tools["ls"].function(c, ".")
+        assert "Contents" in ls_ok
+
+        glob_bad = await ts.tools["glob"].function(c, "*.txt", "..")
+        assert "Error" in glob_bad
+
+        glob_ok = await ts.tools["glob"].function(c, "*.txt", ".")
+        assert "Found" in glob_ok
+
+        grep_bad = await ts.tools["grep"].function(c, "hi", path="..")
+        assert "Error" in grep_bad
+
+        grep_ok = await ts.tools["grep"].function(c, "hi", path=".")
+        assert "hi" in grep_ok or "Files containing" in grep_ok
+
+        ex_bad = await ts.tools["execute"].function(c, "rm -f a.txt", timeout=5)
+        assert "Error" in ex_bad
+
+        ex_ok = await ts.tools["execute"].function(c, "echo ok", timeout=5)
+        assert "ok" in ex_ok
+
+
+class TestBackendPermissionCheckerWins:
+    @pytest.mark.anyio
+    async def test_local_backend_readonly_blocks_write_despite_permissive_toolset(self, tmp_path):
+        (tmp_path / "f.txt").write_text("a", encoding="utf-8")
+        backend = LocalBackend(root_dir=tmp_path, permissions=READONLY_RULESET)
+        ts = create_console_toolset(
+            permissions=PERMISSIVE_RULESET,
+            require_execute_approval=False,
+        )
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        out = await ts.tools["write_file"].function(c, "f.txt", "b")
+        assert "Error" in out
+
+
+class TestHashlineFormatPermissions:
+    @pytest.mark.anyio
+    async def test_read_denied_hashline_branch(self):
+        backend = StateBackend()
+        backend.write("/f.txt", "x\n")
+        rs = PermissionRuleset(
+            read=OperationPermissions(default="deny"),
+            write=OperationPermissions(default="allow"),
+            edit=OperationPermissions(default="allow"),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(
+            edit_format="hashline",
+            permissions=rs,
+            include_execute=False,
+        )
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        out = await ts.tools["read_file"].function(c, "/f.txt")
+        assert "Error" in out
+
+    @pytest.mark.anyio
+    async def test_hashline_edit_respects_edit_permission(self):
+        from pydantic_ai_backends.hashline import line_hash
+
+        backend = StateBackend()
+        backend.write("/w.txt", "one\n")
+        rs = PermissionRuleset(
+            read=OperationPermissions(default="allow"),
+            write=OperationPermissions(default="allow"),
+            edit=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/other.txt", action="allow")],
+            ),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(
+            edit_format="hashline",
+            permissions=rs,
+            include_execute=False,
+        )
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        h = line_hash("one")
+        bad = await ts.tools["hashline_edit"].function(c, "/w.txt", 1, h, "two", None, None, False)
+        assert "Error" in bad
+        assert "Permission" in bad
+
+    @pytest.mark.anyio
+    async def test_hashline_edit_allowed(self):
+        from pydantic_ai_backends.hashline import line_hash
+
+        backend = StateBackend()
+        backend.write("/w.txt", "one\n")
+        rs = PermissionRuleset(
+            read=OperationPermissions(default="allow"),
+            write=OperationPermissions(default="allow"),
+            edit=OperationPermissions(
+                default="deny",
+                rules=[PermissionRule(pattern="**/w.txt", action="allow")],
+            ),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(
+            edit_format="hashline",
+            permissions=rs,
+            include_execute=False,
+        )
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        h = line_hash("one")
+        ok = await ts.tools["hashline_edit"].function(c, "/w.txt", 1, h, "two", None, None, False)
+        assert ok.startswith("Edited")
+
+
+class TestAskOnToolsetWithoutCallback:
+    @pytest.mark.anyio
+    async def test_global_ask_returns_error_string(self):
+        backend = StateBackend()
+        rs = PermissionRuleset(default="ask")
+        ts = create_console_toolset(
+            permissions=rs,
+            include_execute=False,
+        )
+        deps = _MockDeps(backend=backend)
+        c = _run_ctx(deps)
+        out = await ts.tools["read_file"].function(c, "/nope.txt")
+        assert "Error" in out
+        assert "Permission required" in out

--- a/tests/test_console_permissions_docker.py
+++ b/tests/test_console_permissions_docker.py
@@ -1,0 +1,79 @@
+"""Docker integration tests for console toolset + permissions (opt-in: pytest -m docker)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from pydantic_ai import RunContext
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from pydantic_ai_backends import DockerSandbox, create_console_toolset
+from pydantic_ai_backends.permissions import (
+    OperationPermissions,
+    PermissionRule,
+    PermissionRuleset,
+)
+
+
+@pytest.fixture(scope="module")
+def docker_volume_console(tmp_path_factory):
+    pytest.importorskip("docker")
+    host = tmp_path_factory.mktemp("console_perm_vol")
+    (host / "allowed.txt").write_text("seed\n", encoding="utf-8")
+    sandbox = DockerSandbox(volumes={str(host): "/shared"})
+    yield sandbox, host
+    sandbox.stop()
+
+
+@dataclass
+class _Deps:
+    backend: DockerSandbox
+
+
+def _ctx(deps: _Deps) -> RunContext[_Deps]:
+    return RunContext(deps=deps, model=TestModel(), usage=RunUsage())
+
+
+@pytest.mark.docker
+class TestConsolePermissionsDockerIntegration:
+    @pytest.mark.anyio
+    async def test_write_allowed_and_denied_paths(self, docker_volume_console):
+        sandbox, _host = docker_volume_console
+        rs = PermissionRuleset(
+            read=OperationPermissions(default="allow"),
+            write=OperationPermissions(
+                default="deny",
+                rules=[
+                    PermissionRule(pattern="**/allowed.txt", action="allow"),
+                ],
+            ),
+            edit=OperationPermissions(
+                default="deny",
+                rules=[
+                    PermissionRule(pattern="**/allowed.txt", action="allow"),
+                ],
+            ),
+            execute=OperationPermissions(default="deny"),
+            ls=OperationPermissions(default="allow"),
+            glob=OperationPermissions(default="allow"),
+            grep=OperationPermissions(default="allow"),
+        )
+        ts = create_console_toolset(
+            permissions=rs,
+            include_execute=False,
+            require_execute_approval=False,
+        )
+        deps = _Deps(backend=sandbox)
+        c = _ctx(deps)
+
+        denied = await ts.tools["write_file"].function(c, "/shared/other.txt", "nope")
+        assert "Error" in denied
+        assert "Permission" in denied
+
+        ok = await ts.tools["write_file"].function(c, "/shared/allowed.txt", "updated\n")
+        assert "Wrote" in ok
+
+        content = sandbox.read("/shared/allowed.txt")
+        assert "updated" in content


### PR DESCRIPTION
## Changes

### Summary

#### Problem & scope

- **Default-deny + allow rules:** Tool registration must not drop write/edit/execute when `OperationPermissions.default == "deny"` but the ruleset still has **`allow`** rules (path allow-lists). Those tools should stay registered; enforcement applies per target, like `LocalBackend`.

- **Sandbox gap:** `DockerSandbox` does not run `PermissionRuleset` checks; `LocalBackend` does via `permission_checker` / `_check_permission_sync`.

#### This PR

- **Where we enforce:** In the **console toolset** when `permissions=` is set and `getattr(backend, "permission_checker", None)` is **missing**—same sync allow/deny/ask semantics as `LocalBackend`, without adding `permissions` to `DockerSandbox` (avoids two competing rulesets when callers only pass rules to `create_console_toolset`).

#### Out of scope

- **Per-path `ask` → PydanticAI deferred approval:** Not implemented. Rulesets with **per-path `ask`** (while the operation default is not `ask`) raise **`NotImplementedError` at toolset construction**. **Whole-tool** approval remains **`requires_approval_from_ruleset`** (operation **default** `ask` only).

### Business Context

I need multiple agents using the same docker backend with different fine grained permissions.

### Changes

- `pydantic_ai_backends/toolsets/console.py`

  - `_is_denied_by_ruleset`: only strip write/edit/execute tools when the operation is default deny and there is no `allow` rule at all (so default-deny + allow-list keeps tools).
  - Tools (`ls`, `read_file`, `write_file`, `edit_file` / `hashline_edit`, `glob`, `grep`, `execute`): call the prefix helper so denials surface as `Error: ...` strings.
  - After registration: pop tools listed in `_denied_tools` only if the ruleset fully denies that operation. 
  - `_evaluate_toolset_permission` / `_toolset_permission_prefix_error`: when `permissions` is set and the deps backend has no `permission_checker`, run a `PermissionChecker` (`ask_callback=None`) before each tool’s work; skip entirely if the backend already has a checker (e.g. `LocalBackend`).
  - `_reject_ruleset_per_path_ask`: at `create_console_toolset(...)` time, reject rulesets that use per-path `ask` when the operation default is not `ask` (`NotImplementedError`).
  
### Verification
```bash
uv sync --all-extras   # or minimal + docker extra for docker tests
uv run ruff check .
uv run ruff format --check .
uv run pyright
uv run mypy
uv run coverage run -m pytest
uv run coverage report --fail-under=100
# Optional:
uv run pytest -m docker tests/test_console_permissions_docker.py
```
### Linked Issues

#23
