### PR TITLE
feat: add docker and daytona session manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-04-11
+
+### Added
+
+- **`container_name` parameter on `DockerSandbox`** — stable Docker container name for reuse across restarts. When set, `_ensure_container()` looks for an existing container with that name and reattaches (running containers are reused, stopped containers are restarted). Implies `auto_remove=False` so installed packages, caches, and filesystem state persist between sessions
+- **`sandbox_factory` parameter on `SessionManager`** — accepts a `Callable[[str], Any]` to create sandboxes of any type (Docker, Daytona, or custom). When `None`, falls back to the default `DockerSandbox` behavior (fully backward compatible). Exported `SandboxFactory` type alias
+- **Lifecycle methods on `BaseSandbox`** — `start()`, `is_alive()`, `stop()`, and `_last_activity` tracking added to the base class so all sandbox types support session management out of the box
+- **`start()` method on `DaytonaSandbox`** — no-op (Daytona sandboxes auto-start on creation), added for `SessionManager` compatibility
+- **Activity tracking on `DaytonaSandbox`** — `_last_activity` updated on `execute()` calls for idle session cleanup
+
+### Changed
+
+- **`SessionManager` is now backend-agnostic** — no longer hardcoded to `DockerSandbox`. Works with any sandbox that has `start()`, `stop()`, `is_alive()`, and `_last_activity`. Type hints changed from `DockerSandbox` to `Any` for generic usage
+
 ## [0.2.3] - 2026-04-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ sandbox.start()
 sandbox.stop()
 ```
 
+### Reusable Named Container
+
+```python
+from pydantic_ai_backends import DockerSandbox
+
+# Named container persists between sessions (packages survive restarts)
+sandbox = DockerSandbox(
+    image="python:3.12-slim",
+    container_name="my-dev-env",  # implies auto_remove=False
+    volumes={"/my/project": "/workspace"},
+)
+# Next time: finds existing container and reattaches
+```
+
 ## Console Toolset
 
 Ready-to-use tools for pydantic-ai agents:
@@ -251,12 +265,27 @@ Multi-user web applications:
 ```python
 from pydantic_ai_backends import SessionManager
 
+# Docker (default)
 manager = SessionManager(
     default_runtime="python-datascience",
     workspace_root="/app/workspaces",
 )
 
 # Each user gets isolated sandbox
+sandbox = await manager.get_or_create("user-123")
+```
+
+### Custom Sandbox Factory
+
+Use any sandbox backend (Daytona, custom, etc.):
+
+```python
+from pydantic_ai_backends import SessionManager, DaytonaSandbox
+
+def daytona_factory(session_id: str) -> DaytonaSandbox:
+    return DaytonaSandbox(sandbox_id=session_id)
+
+manager = SessionManager(sandbox_factory=daytona_factory)
 sandbox = await manager.get_or_create("user-123")
 ```
 

--- a/docs/concepts/backends.md
+++ b/docs/concepts/backends.md
@@ -9,7 +9,7 @@ Backends provide file storage for your pydantic-ai agents. All backends implemen
 | `LocalBackend` | Persistent | Yes | CLI tools, local development |
 | `StateBackend` | Ephemeral | No | Unit testing, mocking |
 | `DockerSandbox` | Ephemeral* | Yes | Safe execution, multi-user |
-| `DaytonaSandbox` | Ephemeral | Yes | Cloud deployments, CI/CD |
+| `DaytonaSandbox` | Ephemeral | Yes | Cloud deployments, CI/CD, multi-user |
 | `CompositeBackend` | Mixed | Depends | Route by path prefix |
 
 ## LocalBackend

--- a/docs/concepts/docker.md
+++ b/docs/concepts/docker.md
@@ -135,6 +135,21 @@ sandbox = DockerSandbox(
 )
 ```
 
+### Named Containers (Reusable)
+
+Use `container_name` to create containers that persist between sessions.
+Installed packages, caches, and filesystem state survive restarts:
+
+```python
+sandbox = DockerSandbox(
+    image="python:3.12-slim",
+    container_name="my-dev-env",  # implies auto_remove=False
+    volumes={"/my/project": "/workspace"},
+)
+# First run: creates container "my-dev-env"
+# Next run: finds it, restarts if stopped, reattaches
+```
+
 With SessionManager, each user gets their own persistent directory:
 
 ```python
@@ -142,6 +157,24 @@ manager = SessionManager(
     workspace_root="/app/workspaces",  # Creates /app/workspaces/{user_id}/
 )
 ```
+
+### Custom Sandbox Factory
+
+`SessionManager` accepts a `sandbox_factory` callable to use any sandbox
+backend (Daytona, custom implementations, etc.):
+
+```python
+from pydantic_ai_backends import SessionManager, DaytonaSandbox
+
+def daytona_factory(session_id: str) -> DaytonaSandbox:
+    return DaytonaSandbox(sandbox_id=session_id)
+
+manager = SessionManager(sandbox_factory=daytona_factory)
+sandbox = await manager.get_or_create("user-123")
+```
+
+When no factory is provided, `SessionManager` defaults to creating
+`DockerSandbox` instances (fully backward compatible).
 
 ## Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.3"
+version = "0.2.4"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
         SessionManager,
     )
     from pydantic_ai_backends.backends.docker.runtimes import get_runtime
+    from pydantic_ai_backends.backends.docker.session import SandboxFactory
     from pydantic_ai_backends.hashline import (
         apply_hashline_edit,
         apply_hashline_edit_with_summary,
@@ -147,6 +148,7 @@ _LAZY_IMPORTS = {
     "DockerSandbox": "pydantic_ai_backends.backends.docker.sandbox",
     "BaseSandbox": "pydantic_ai_backends.backends.base",
     "SessionManager": "pydantic_ai_backends.backends.docker.session",
+    "SandboxFactory": "pydantic_ai_backends.backends.docker.session",
     "BUILTIN_RUNTIMES": "pydantic_ai_backends.backends.docker.runtimes",
     "get_runtime": "pydantic_ai_backends.backends.docker.runtimes",
     # Permissions system
@@ -230,6 +232,7 @@ __all__ = [
     "BaseSandbox",
     "DockerSandbox",
     "SessionManager",
+    "SandboxFactory",
     # Runtimes
     "BUILTIN_RUNTIMES",
     "get_runtime",

--- a/src/pydantic_ai_backends/backends/base.py
+++ b/src/pydantic_ai_backends/backends/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shlex
+import time
 import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
@@ -85,11 +86,30 @@ class BaseSandbox(ABC):
             sandbox_id: Unique identifier for this sandbox. Generated if not provided.
         """
         self._id = sandbox_id or str(uuid.uuid4())  # pragma: no cover
+        self._last_activity = time.time()  # pragma: no cover
 
     @property
     def id(self) -> str:
         """Unique identifier for this sandbox."""
         return self._id  # pragma: no cover
+
+    def start(self) -> None:  # pragma: no cover  # noqa: B027
+        """Start the sandbox.
+
+        Override for eager initialization. The default is a no-op
+        (sandboxes start lazily on first operation).
+        """
+
+    def is_alive(self) -> bool:  # pragma: no cover
+        """Check if the sandbox is running.
+
+        Returns:
+            True if the sandbox is running and responsive, False otherwise.
+        """
+        return False
+
+    def stop(self) -> None:  # pragma: no cover  # noqa: B027
+        """Stop and clean up the sandbox."""
 
     @abstractmethod
     def execute(

--- a/src/pydantic_ai_backends/backends/daytona.py
+++ b/src/pydantic_ai_backends/backends/daytona.py
@@ -99,6 +99,9 @@ class DaytonaSandbox(BaseSandbox):  # pragma: no cover
     # SandboxProtocol — execute
     # ------------------------------------------------------------------
 
+    def start(self) -> None:
+        """No-op — Daytona sandboxes start automatically on creation."""
+
     def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
         """Execute a command inside the Daytona sandbox.
 
@@ -109,6 +112,7 @@ class DaytonaSandbox(BaseSandbox):  # pragma: no cover
         Returns:
             :class:`ExecuteResponse` with output, exit code, and truncation flag.
         """
+        self._last_activity = time.time()
         effective_timeout = timeout if timeout is not None else 30 * 60
         try:
             result = self._sandbox.process.exec(

--- a/src/pydantic_ai_backends/backends/docker/sandbox.py
+++ b/src/pydantic_ai_backends/backends/docker/sandbox.py
@@ -67,6 +67,7 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
         idle_timeout: int = 3600,
         volumes: dict[str, str] | None = None,
         network_mode: str | None = None,
+        container_name: str | None = None,
     ):
         """Initialize Docker sandbox.
 
@@ -74,7 +75,8 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
             image: Docker image to use (ignored if runtime is provided).
             sandbox_id: Unique identifier for this sandbox.
             work_dir: Working directory inside container (ignored if runtime is provided).
-            auto_remove: Remove container when stopped.
+            auto_remove: Remove container when stopped. Forced to ``False``
+                when ``container_name`` is set (reusable containers).
             runtime: RuntimeConfig or name of built-in runtime.
             session_id: Alias for sandbox_id (for session management).
             idle_timeout: Timeout in seconds for idle cleanup (default: 1 hour).
@@ -82,12 +84,18 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
                      Format: {"/host/path": "/container/path"}
             network_mode: Docker network mode ("bridge", "none", "host",
                          "container:<name|id>"). None uses Docker default.
+            container_name: Stable Docker container name for reuse across
+                restarts. When set, ``_ensure_container()`` looks for an existing
+                container with this name and reattaches (or starts it if stopped)
+                instead of creating a new one. Implies ``auto_remove=False``.
         """
         # session_id is an alias for sandbox_id
         effective_id = session_id or sandbox_id
         super().__init__(effective_id)
 
-        self._auto_remove = auto_remove
+        self._container_name = container_name
+        # Named containers must not be auto-removed (they're meant to be reused)
+        self._auto_remove = False if container_name else auto_remove
         self._container = None
         self._idle_timeout = idle_timeout
         self._last_activity = time.time()
@@ -125,12 +133,19 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
         return path
 
     def _ensure_container(self) -> None:
-        """Ensure Docker container is running."""
+        """Ensure Docker container is running.
+
+        When ``container_name`` is set, looks for an existing container with
+        that name and reattaches.  Stopped containers are restarted so that
+        installed packages, caches, and other filesystem state are preserved
+        across CLI sessions.
+        """
         if self._container is not None:
             return
 
         try:
             import docker
+            import docker.errors
         except ImportError as e:
             raise ImportError(
                 "Docker package not installed. "
@@ -138,6 +153,22 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
             ) from e
 
         client = docker.from_env()
+
+        # Try to reattach to an existing named container
+        if self._container_name:
+            try:
+                existing = client.containers.get(self._container_name)
+                status = existing.status
+                if status == "running":
+                    self._container = existing
+                    return
+                if status in ("created", "exited", "paused"):
+                    existing.start()
+                    self._container = existing
+                    return
+                # Other statuses (dead, removing) — fall through to create
+            except docker.errors.NotFound:
+                pass  # Will create a new container below
 
         # Get the appropriate image (build if needed for runtime)
         image = self._ensure_runtime_image(client)
@@ -161,6 +192,8 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
             environment=env_vars,
             volumes=docker_volumes if docker_volumes else None,
         )
+        if self._container_name is not None:
+            run_kwargs["name"] = self._container_name
         if self._network_mode is not None:
             run_kwargs["network_mode"] = self._network_mode
 

--- a/src/pydantic_ai_backends/backends/docker/session.py
+++ b/src/pydantic_ai_backends/backends/docker/session.py
@@ -1,23 +1,28 @@
-"""Session management for Docker sandboxes.
+"""Session management for sandbox backends.
 
-This module provides session management for multi-user applications,
-allowing multiple users to have their own isolated Docker containers.
+Provides session management for multi-user applications,
+allowing multiple users to have their own isolated sandboxes
+(Docker, Daytona, or any custom sandbox type).
 
-Example:
+Example with default Docker backend:
     ```python
-    from pydantic_ai_backends import SessionManager, RuntimeConfig
+    from pydantic_ai_backends import SessionManager
 
-    # Create a session manager with default runtime
     manager = SessionManager(default_runtime="python-datascience")
-
-    # Get or create a sandbox for a user session
     sandbox = await manager.get_or_create("user-123")
-
-    # Use the sandbox...
     result = sandbox.execute("python script.py")
-
-    # Release when done
     await manager.release("user-123")
+    ```
+
+Example with custom factory:
+    ```python
+    from pydantic_ai_backends import SessionManager, DaytonaSandbox
+
+    def daytona_factory(session_id: str) -> DaytonaSandbox:
+        return DaytonaSandbox(sandbox_id=session_id)
+
+    manager = SessionManager(sandbox_factory=daytona_factory)
+    sandbox = await manager.get_or_create("user-123")
     ```
 """
 
@@ -25,40 +30,49 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from pydantic_ai_backends.backends.docker.sandbox import DockerSandbox
     from pydantic_ai_backends.types import RuntimeConfig
+
+#: Factory callable: receives ``session_id`` and returns a sandbox instance.
+SandboxFactory = Callable[[str], Any]
 
 
 class SessionManager:
-    """Manages user sessions and their Docker containers.
+    """Manages user sessions and their sandbox containers.
 
-    This class provides a way to manage multiple Docker sandbox instances
+    This class provides a way to manage multiple sandbox instances
     for different user sessions. It handles:
+
     - Creating new sandboxes for new sessions
     - Reusing existing sandboxes for returning sessions
     - Cleaning up idle sessions automatically
+
+    By default, sandboxes are created using :class:`DockerSandbox`.
+    Pass a ``sandbox_factory`` callable to use a different backend
+    (e.g. :class:`DaytonaSandbox` or a custom implementation).
 
     Example:
         ```python
         from pydantic_ai_backends import SessionManager
 
+        # Docker (default)
         manager = SessionManager(default_runtime="python-datascience")
 
-        # Get sandbox for user
-        sandbox = await manager.get_or_create("user-123")
+        # Custom factory (e.g. Daytona)
+        manager = SessionManager(sandbox_factory=my_factory)
 
-        # Later: cleanup idle sessions
-        cleaned = await manager.cleanup_idle(max_idle=1800)  # 30 min
-        print(f"Cleaned up {cleaned} idle sessions")
+        sandbox = await manager.get_or_create("user-123")
+        cleaned = await manager.cleanup_idle(max_idle=1800)
         ```
     """
 
     def __init__(
         self,
+        sandbox_factory: SandboxFactory | None = None,
         default_runtime: RuntimeConfig | str | None = None,
         default_idle_timeout: int = 3600,
         workspace_root: str | Path | None = None,
@@ -66,21 +80,28 @@ class SessionManager:
         """Initialize the session manager.
 
         Args:
-            default_runtime: Default RuntimeConfig or name for new sandboxes.
+            sandbox_factory: Callable that receives a ``session_id`` string and
+                returns a sandbox instance with ``start()``, ``stop()``,
+                ``is_alive()`` methods and a ``_last_activity`` attribute.
+                When ``None``, defaults to creating :class:`DockerSandbox` instances.
+            default_runtime: Default RuntimeConfig or name for new Docker sandboxes.
+                Only used when ``sandbox_factory`` is ``None``.
             default_idle_timeout: Default idle timeout in seconds (default: 1 hour).
             workspace_root: Root directory for persistent session storage.
-                           If set, creates {workspace_root}/{session_id}/workspace
-                           and mounts it as a volume. Files persist across container restarts.
+                Only used when ``sandbox_factory`` is ``None``.
+                If set, creates ``{workspace_root}/{session_id}/workspace``
+                and mounts it as a Docker volume.
         """
-        self._sessions: dict[str, DockerSandbox] = {}
+        self._sessions: dict[str, Any] = {}
+        self._sandbox_factory = sandbox_factory
         self._default_runtime = default_runtime
         self._default_idle_timeout = default_idle_timeout
         self._cleanup_task: asyncio.Task[None] | None = None
         self._workspace_root = Path(workspace_root) if workspace_root else None
 
     @property
-    def sessions(self) -> dict[str, DockerSandbox]:
-        """Active sessions dictionary (read-only access)."""
+    def sessions(self) -> dict[str, Any]:
+        """Active sessions dictionary (read-only copy)."""
         return dict(self._sessions)
 
     @property
@@ -92,24 +113,20 @@ class SessionManager:
         self,
         session_id: str,
         runtime: RuntimeConfig | str | None = None,
-    ) -> DockerSandbox:
+    ) -> Any:
         """Get an existing sandbox or create a new one.
 
-        If a sandbox exists for the session_id and is still alive,
+        If a sandbox exists for the ``session_id`` and is still alive,
         it will be returned. Otherwise, a new sandbox will be created.
 
         Args:
             session_id: Unique identifier for the session.
-            runtime: RuntimeConfig or name to use (defaults to manager's default).
+            runtime: RuntimeConfig or name to use. Only applies when using
+                the default Docker factory (ignored with custom ``sandbox_factory``).
 
         Returns:
-            DockerSandbox instance for the session.
-
-        Raises:
-            ValueError: If no runtime specified and no default runtime set.
+            Sandbox instance for the session.
         """
-        from pydantic_ai_backends.backends.docker.sandbox import DockerSandbox
-
         # Check for existing session
         if session_id in self._sessions:
             sandbox = self._sessions[session_id]
@@ -119,6 +136,27 @@ class SessionManager:
             # Container died, remove from cache
             del self._sessions[session_id]
 
+        # Create via factory or default Docker path
+        if self._sandbox_factory is not None:
+            sandbox = self._sandbox_factory(session_id)
+        else:
+            sandbox = self._create_docker_sandbox(session_id, runtime)
+
+        sandbox.start()
+        self._sessions[session_id] = sandbox
+        return sandbox
+
+    def _create_docker_sandbox(
+        self,
+        session_id: str,
+        runtime: RuntimeConfig | str | None = None,
+    ) -> Any:
+        """Create a DockerSandbox with the legacy configuration.
+
+        This is the default path when no ``sandbox_factory`` is provided.
+        """
+        from pydantic_ai_backends.backends.docker.sandbox import DockerSandbox
+
         # Prepare volumes for persistent storage
         volumes: dict[str, str] | None = None
         if self._workspace_root:
@@ -126,20 +164,16 @@ class SessionManager:
             session_workspace.mkdir(parents=True, exist_ok=True)
             volumes = {str(session_workspace.resolve()): "/workspace"}
 
-        # Create new sandbox
         effective_runtime = runtime or self._default_runtime
-        sandbox = DockerSandbox(
+        return DockerSandbox(
             runtime=effective_runtime,
             session_id=session_id,
             idle_timeout=self._default_idle_timeout,
             volumes=volumes,
         )
-        sandbox.start()
-        self._sessions[session_id] = sandbox
-        return sandbox
 
     async def release(self, session_id: str) -> bool:
-        """Release a session and stop its container.
+        """Release a session and stop its sandbox.
 
         Args:
             session_id: Session identifier to release.

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -40,6 +40,30 @@ class MockDockerSandbox:
         self._alive = False
 
 
+class MockCustomSandbox:
+    """Mock sandbox for testing custom factory support."""
+
+    def __init__(self, session_id: str) -> None:
+        self._id = session_id
+        self._last_activity = time.time()
+        self._alive = True
+        self._started = False
+
+    @property
+    def session_id(self) -> str:
+        return self._id
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def start(self) -> None:
+        self._started = True
+        self._alive = True
+
+    def stop(self) -> None:
+        self._alive = False
+
+
 class TestSessionManager:
     """Tests for SessionManager class."""
 
@@ -66,6 +90,12 @@ class TestSessionManager:
         """Test initialization with custom timeout."""
         manager = SessionManager(default_idle_timeout=1800)
         assert manager._default_idle_timeout == 1800
+
+    def test_init_with_factory(self):
+        """Test initialization with custom sandbox factory."""
+        factory = lambda sid: MockCustomSandbox(sid)
+        manager = SessionManager(sandbox_factory=factory)
+        assert manager._sandbox_factory is factory
 
     @pytest.mark.asyncio
     async def test_get_or_create_new_session(self):
@@ -296,3 +326,156 @@ class TestSessionManager:
             # Check separate volumes
             assert str(dir1.resolve()) in sandbox1._volumes
             assert str(dir2.resolve()) in sandbox2._volumes
+
+
+class TestSessionManagerWithFactory:
+    """Tests for SessionManager with custom sandbox_factory."""
+
+    @pytest.mark.asyncio
+    async def test_factory_called_with_session_id(self):
+        """Test that factory receives the session_id."""
+        created_ids: list[str] = []
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            created_ids.append(session_id)
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        await manager.get_or_create("user-42")
+
+        assert created_ids == ["user-42"]
+
+    @pytest.mark.asyncio
+    async def test_factory_sandbox_started(self):
+        """Test that factory-created sandboxes get start() called."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        sandbox = await manager.get_or_create("user-1")
+        assert sandbox._started is True
+
+    @pytest.mark.asyncio
+    async def test_factory_sandbox_reused_when_alive(self):
+        """Test that alive factory sandboxes are reused."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        s1 = await manager.get_or_create("user-1")
+        s2 = await manager.get_or_create("user-1")
+        assert s1 is s2
+
+    @pytest.mark.asyncio
+    async def test_factory_sandbox_recreated_when_dead(self):
+        """Test that dead factory sandboxes are recreated."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        s1 = await manager.get_or_create("user-1")
+        s1._alive = False
+
+        s2 = await manager.get_or_create("user-1")
+        assert s1 is not s2
+        assert s2._started is True
+
+    @pytest.mark.asyncio
+    async def test_factory_release_stops_sandbox(self):
+        """Test that releasing a factory sandbox calls stop()."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        sandbox = await manager.get_or_create("user-1")
+        assert sandbox._alive is True
+
+        await manager.release("user-1")
+        assert sandbox._alive is False
+        assert "user-1" not in manager
+
+    @pytest.mark.asyncio
+    async def test_factory_cleanup_idle(self):
+        """Test idle cleanup with factory sandboxes."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(
+            sandbox_factory=factory,
+            default_idle_timeout=10,
+        )
+        s1 = await manager.get_or_create("user-1")
+        s2 = await manager.get_or_create("user-2")
+
+        s1._last_activity = time.time() - 20  # idle
+        s2._last_activity = time.time()  # active
+
+        cleaned = await manager.cleanup_idle()
+        assert cleaned == 1
+        assert "user-1" not in manager
+        assert "user-2" in manager
+
+    @pytest.mark.asyncio
+    async def test_factory_shutdown(self):
+        """Test shutdown with factory sandboxes."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        await manager.get_or_create("a")
+        await manager.get_or_create("b")
+
+        count = await manager.shutdown()
+        assert count == 2
+        assert manager.session_count == 0
+
+    @pytest.mark.asyncio
+    async def test_factory_ignores_runtime_param(self):
+        """Test that runtime param is ignored when using factory."""
+        factory_calls: list[str] = []
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            factory_calls.append(session_id)
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        # Pass runtime — should be ignored (factory doesn't receive it)
+        await manager.get_or_create("user-1", runtime="python-datascience")
+        assert factory_calls == ["user-1"]
+
+    @pytest.mark.asyncio
+    async def test_factory_ignores_workspace_root(self, tmp_path):
+        """Test that workspace_root doesn't affect factory-created sandboxes."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(
+            sandbox_factory=factory,
+            workspace_root=tmp_path,
+        )
+        await manager.get_or_create("user-1")
+
+        # workspace_root should NOT create directories for factory sandboxes
+        assert not (tmp_path / "user-1").exists()
+
+    @pytest.mark.asyncio
+    async def test_factory_activity_updated_on_reuse(self):
+        """Test that _last_activity is updated when reusing a session."""
+
+        def factory(session_id: str) -> MockCustomSandbox:
+            return MockCustomSandbox(session_id)
+
+        manager = SessionManager(sandbox_factory=factory)
+        sandbox = await manager.get_or_create("user-1")
+        sandbox._last_activity = time.time() - 100  # Simulate old activity
+
+        before = sandbox._last_activity
+        await manager.get_or_create("user-1")
+        assert sandbox._last_activity > before

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -93,7 +93,10 @@ class TestSessionManager:
 
     def test_init_with_factory(self):
         """Test initialization with custom sandbox factory."""
-        factory = lambda sid: MockCustomSandbox(sid)
+
+        def factory(sid: str) -> MockCustomSandbox:
+            return MockCustomSandbox(sid)
+
         manager = SessionManager(sandbox_factory=factory)
         assert manager._sandbox_factory is factory
 


### PR DESCRIPTION
## [0.2.4] - 2026-04-11

### Added

- **`container_name` parameter on `DockerSandbox`** — stable Docker container name for reuse across restarts. When set, `_ensure_container()` looks for an existing container with that name and reattaches (running containers are reused, stopped containers are restarted). Implies `auto_remove=False` so installed packages, caches, and filesystem state persist between sessions
- **`sandbox_factory` parameter on `SessionManager`** — accepts a `Callable[[str], Any]` to create sandboxes of any type (Docker, Daytona, or custom). When `None`, falls back to the default `DockerSandbox` behavior (fully backward compatible). Exported `SandboxFactory` type alias
- **Lifecycle methods on `BaseSandbox`** — `start()`, `is_alive()`, `stop()`, and `_last_activity` tracking added to the base class so all sandbox types support session management out of the box
- **`start()` method on `DaytonaSandbox`** — no-op (Daytona sandboxes auto-start on creation), added for `SessionManager` compatibility
- **Activity tracking on `DaytonaSandbox`** — `_last_activity` updated on `execute()` calls for idle session cleanup

### Changed

- **`SessionManager` is now backend-agnostic** — no longer hardcoded to `DockerSandbox`. Works with any sandbox that has `start()`, `stop()`, `is_alive()`, and `_last_activity`. Type hints changed from `DockerSandbox` to `Any` for generic usage
