### PR TITLE
 fix: normalize trailing slashes in CompositeBackend route matching

### DIFF
--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     )
     from pydantic_ai_backends.backends.docker.runtimes import get_runtime
     from pydantic_ai_backends.backends.docker.session import SandboxFactory
+    from pydantic_ai_backends.capability import ConsoleCapability
     from pydantic_ai_backends.hashline import (
         apply_hashline_edit,
         apply_hashline_edit_with_summary,
@@ -95,7 +96,6 @@ if TYPE_CHECKING:
         PermissionRuleset,
         create_ruleset,
     )
-    from pydantic_ai_backends.capability import ConsoleCapability
     from pydantic_ai_backends.toolsets.console import (
         DEFAULT_MAX_IMAGE_BYTES,
         EDIT_FILE_DESCRIPTION,

--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
         PermissionRuleset,
         create_ruleset,
     )
+    from pydantic_ai_backends.capability import ConsoleCapability
     from pydantic_ai_backends.toolsets.console import (
         DEFAULT_MAX_IMAGE_BYTES,
         EDIT_FILE_DESCRIPTION,

--- a/src/pydantic_ai_backends/backends/composite.py
+++ b/src/pydantic_ai_backends/backends/composite.py
@@ -50,24 +50,34 @@ class CompositeBackend:
         # Sort routes by length (longest first) for correct matching
         self._sorted_prefixes = sorted(self._routes.keys(), key=len, reverse=True)
 
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        """Normalize path to consistent format."""
+        if not path.startswith("/"):
+            path = "/" + path
+        if len(path) > 1 and path.endswith("/"):
+            path = path.rstrip("/")
+        return path
+
     def _get_backend(self, path: str) -> BackendProtocol:
         """Get the appropriate backend for a path."""
+        normalized = self._normalize_path(path)
         for prefix in self._sorted_prefixes:
-            if path.startswith(prefix):
+            normalized_prefix = self._normalize_path(prefix)
+            if normalized == normalized_prefix or normalized.startswith(normalized_prefix + "/"):
                 return self._routes[prefix]
         return self._default
 
     def ls_info(self, path: str) -> list[FileInfo]:
         """List files, aggregating from all relevant backends."""
-        # If path matches a specific route, use that backend
-        backend = self._get_backend(path)
+        normalized = self._normalize_path(path)
 
         # For root path, aggregate from all backends
-        if path == "/" or path == "":
+        if normalized == "/":
             all_entries: dict[str, FileInfo] = {}
 
             # First, get entries from default backend
-            for entry in self._default.ls_info(path):
+            for entry in self._default.ls_info(normalized):
                 all_entries[entry["path"]] = entry
 
             # Then, add virtual directories for route prefixes
@@ -87,7 +97,9 @@ class CompositeBackend:
 
             return sorted(all_entries.values(), key=lambda x: (not x["is_dir"], x["name"]))
 
-        return backend.ls_info(path)
+        # Route to appropriate backend
+        backend = self._get_backend(normalized)
+        return backend.ls_info(normalized)
 
     def _read_bytes(self, path: str) -> bytes:
         """Read bytes from the appropriate backend."""

--- a/src/pydantic_ai_backends/backends/docker/sandbox.py
+++ b/src/pydantic_ai_backends/backends/docker/sandbox.py
@@ -317,6 +317,8 @@ class DockerSandbox(BaseSandbox):  # pragma: no cover
                 workdir=self._work_dir,
             )
 
+            if not isinstance(output, bytes):
+                output = b"".join(output)
             output_str = output.decode("utf-8", errors="replace")
 
             # Truncate if too long

--- a/tests/test_backends_extended.py
+++ b/tests/test_backends_extended.py
@@ -587,3 +587,80 @@ class TestCompositeBackendExtended:
         names = [e["name"] for e in entries]
         # special should appear only once
         assert names.count("special") == 1
+
+    def test_ls_info_without_trailing_slash(self):
+        """Test ls_info without trailing slash matches route with trailing slash."""
+        default = StateBackend()
+        routed = StateBackend()
+
+        routed.write("/foo/bar.txt", "baz")
+
+        composite = CompositeBackend(default=default, routes={"/foo/": routed})
+
+        entries = composite.ls_info("/foo")
+        names = [e["name"] for e in entries]
+        assert "bar.txt" in names
+
+    def test_ls_info_with_trailing_slash(self):
+        """Test ls_info with trailing slash still works (regression guard)."""
+        default = StateBackend()
+        routed = StateBackend()
+
+        routed.write("/foo/bar.txt", "baz")
+
+        composite = CompositeBackend(default=default, routes={"/foo/": routed})
+
+        entries = composite.ls_info("/foo/")
+        names = [e["name"] for e in entries]
+        assert "bar.txt" in names
+
+    def test_read_without_trailing_slash(self):
+        """Test reading a file via path without trailing slash on route."""
+        default = StateBackend()
+        routed = StateBackend()
+
+        routed.write("/foo/bar.txt", "hello")
+
+        composite = CompositeBackend(default=default, routes={"/foo/": routed})
+
+        content = composite.read("/foo/bar.txt")
+        assert "hello" in content
+
+    def test_write_without_trailing_slash(self):
+        """Test writing routes correctly when path lacks trailing slash."""
+        default = StateBackend()
+        routed = StateBackend()
+
+        composite = CompositeBackend(default=default, routes={"/foo/": routed})
+
+        composite.write("/foo/test.txt", "written")
+
+        assert "/foo/test.txt" in routed.files
+        assert "/foo/test.txt" not in default.files
+
+    def test_route_without_trailing_slash(self):
+        """Test route registered without trailing slash matches both variants."""
+        default = StateBackend()
+        routed = StateBackend()
+
+        composite = CompositeBackend(default=default, routes={"/foo": routed})
+
+        # Both /foo and /foo/ should route to the same backend
+        composite.write("/foo/file.txt", "content")
+        composite.write("/foo/other.txt", "content2")
+
+        assert "/foo/file.txt" in routed.files
+        assert "/foo/other.txt" in routed.files
+        assert "/foo/file.txt" not in default.files
+
+    def test_no_false_positive_match(self):
+        """Test that /foobar does not match route /foo/."""
+        default = StateBackend()
+        routed = StateBackend()
+
+        composite = CompositeBackend(default=default, routes={"/foo/": routed})
+
+        composite.write("/foobar/test.txt", "default content")
+
+        assert "/foobar/test.txt" not in routed.files
+        assert "/foobar/test.txt" in default.files


### PR DESCRIPTION
## Changes

### Summary

Fixed CompositeBackend route matching so that paths with and without trailing slashes are treated equivalently (e.g. `/foo` matches route `/foo`). Added path normalization to `_get_backend()` and `ls_info()`.

### Business Context

LLM agents frequently query paths without trailing slashes (e.g. `/foo` rather than `/foo/`), which caused CompositeBackend to silently return empty results and fall through to the default backend. This broke file discovery and routing for any agent using the non-trailing-slash form.

### Changes

- Added `_normalize_path()` static method to `CompositeBackend` that ensures leading / and strips trailing / (mirrors the existing `StateBackend._normalize_path`).                                                                             
- Updated _get_backend() to normalize both the query path and route prefix before matching, using exact-or-child semantics (`==` or `startswith(prefix + "/")`) instead of bare `startswith.                                                   
- Updated `ls_info()` to normalize the path before the root check and before delegating to the resolved backend.
- Added 6 tests covering: `ls_info` with/without trailing slash, `read/write` routing, routes registered without trailing slash, and false-positive prevention (`/foobar` does not match `/foo/`).

### Verification

Added tests to prove the functionality

### Linked Issues

Closes #33 
