### PR TITLE
fix: add async_execute with Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-05-14
+
+### Added
+
+- **`LocalBackend.async_execute()` — async, cancellable shell execution** ([#36](https://github.com/vstorm-co/pydantic-ai-backend/pull/36), related to [pydantic-deepagents#93](https://github.com/vstorm-co/pydantic-deepagents/issues/93)) — uses `asyncio.create_subprocess_exec` so that cancelling the calling task immediately kills the subprocess instead of waiting for the thread to finish. The console toolset's `execute` tool now prefers `backend.async_execute(...)` when available and falls back to `asyncio.to_thread(backend.execute, ...)` for backends that don't expose the new method, so third-party backend implementations are unaffected.
+  - On Unix, the subprocess is launched with `start_new_session=True` and cancellation/timeout calls `os.killpg(proc.pid, SIGKILL)` so the entire process tree (including grandchildren the shell forked, e.g. `sh -c "sleep 60"`) is reaped. Windows relies on `cmd /c` lifecycle to terminate child processes.
+  - Cleanup `await proc.communicate()` after `kill()` is wrapped in `asyncio.shield` so a second cancellation can't leave subprocess pipes dangling.
+  - Output is decoded with `errors="replace"` to tolerate non-UTF-8 bytes.
+
+- **Cross-platform shell selection in `LocalBackend`** ([#36](https://github.com/vstorm-co/pydantic-ai-backend/pull/36)) — new static helper `LocalBackend._shell_cmd(command)` returns `["cmd", "/c", command]` on Windows and `["sh", "-c", command]` elsewhere. Both `execute()` and `async_execute()` route through it.
+
+### Fixed
+
+- **`[WinError 2]` crash on Windows when calling `LocalBackend.execute()`** ([#36](https://github.com/vstorm-co/pydantic-ai-backend/pull/36)) — the execute path hardcoded `["sh", "-c", command]`, which is not available on Windows. Now routes through `_shell_cmd()` and uses `cmd /c` on `win32`.
+
+- **Agent task cancellation didn't reach the running subprocess** ([#36](https://github.com/vstorm-co/pydantic-ai-backend/pull/36)) — previously, `execute()` ran on a worker thread via `asyncio.to_thread`, so cancelling the calling task only marked the future as cancelled while the subprocess kept running until completion or timeout. With `async_execute()`, cancellation propagates through to `proc.kill()` (or `killpg` on Unix) immediately.
+
+- **`timeout=0` was silently rewritten to 120 seconds** ([#36](https://github.com/vstorm-co/pydantic-ai-backend/pull/36)) — `execute()` used `timeout or 120`, which treated `0` as falsy and substituted the default. Now uses an explicit `None` check so `0` is honoured (will trigger immediate timeout).
+
+### Changed
+
+- **Extracted `MAX_EXECUTE_OUTPUT = 100_000`** constant in `local.py`, shared by both `execute()` and `async_execute()` truncation paths.
+
 ## [0.2.6] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.6"
+version = "0.2.7"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import uuid
@@ -627,8 +630,12 @@ class LocalBackend:
     async def async_execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
         """Async, cancellable version of execute().
 
-        Uses asyncio.create_subprocess_exec so that cancelling the calling task
-        immediately kills the subprocess rather than waiting for the thread to finish.
+        Uses ``asyncio.create_subprocess_exec`` so that cancelling the calling
+        task immediately kills the subprocess rather than waiting for a thread
+        to finish. On Unix, the subprocess runs in its own session so the entire
+        process tree (including any grandchildren the shell forked) is reaped
+        on cancellation or timeout. Defaults to a 120-second timeout when
+        ``timeout`` is ``None``.
         """
         if not self._enable_execute:
             raise RuntimeError(
@@ -646,6 +653,9 @@ class LocalBackend:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self._root,
+                # New session so we can kill the entire process group on Unix.
+                # Windows kills the process tree via the cmd /c lifecycle.
+                start_new_session=(sys.platform != "win32"),
             )
 
             try:
@@ -653,12 +663,15 @@ class LocalBackend:
                     proc.communicate(), timeout=timeout if timeout is not None else 120
                 )
             except asyncio.CancelledError:
-                proc.kill()
-                await proc.communicate()
+                self._kill_proc_tree(proc)
+                # Shield cleanup so a second cancel can't leave pipes dangling.
+                with contextlib.suppress(BaseException):
+                    await asyncio.shield(asyncio.ensure_future(proc.communicate()))
                 raise
             except asyncio.TimeoutError:
-                proc.kill()
-                await proc.communicate()
+                self._kill_proc_tree(proc)
+                with contextlib.suppress(BaseException):
+                    await proc.communicate()
                 return ExecuteResponse(
                     output="Error: Command timed out",
                     exit_code=124,
@@ -680,3 +693,18 @@ class LocalBackend:
             )
         except Exception as e:  # pragma: no cover
             return ExecuteResponse(output=f"Error: {e}", exit_code=1, truncated=False)
+
+    @staticmethod
+    def _kill_proc_tree(proc: asyncio.subprocess.Process) -> None:
+        """Kill the subprocess and (on Unix) every grandchild it forked.
+
+        On Unix the process is launched with ``start_new_session=True``, so we
+        can ``killpg`` the whole tree. On Windows ``proc.kill()`` is sufficient
+        because ``cmd /c`` already terminates child processes when it dies.
+        """
+        if sys.platform == "win32":
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            return
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -33,6 +33,8 @@ AskCallback = Callable[["PermissionOperation", str, str], Awaitable[bool]]
 # Fallback behavior when ask_callback is not provided
 AskFallback = Literal["deny", "error"]
 
+MAX_EXECUTE_OUTPUT = 100_000
+
 
 class LocalBackend:
     """Local filesystem backend with optional shell execution.
@@ -125,6 +127,10 @@ class LocalBackend:
         # If no allowed_directories specified, restrict to root_dir only
         if self._allowed_directories is None:
             self._allowed_directories = [self._root]
+
+    @staticmethod
+    def _shell_cmd(command: str) -> list[str]:
+        return ["cmd", "/c", command] if sys.platform == "win32" else ["sh", "-c", command]
 
     @property
     def id(self) -> str:
@@ -585,22 +591,20 @@ class LocalBackend:
             )
 
         try:
-            shell_cmd = ["cmd", "/c", command] if sys.platform == "win32" else ["sh", "-c", command]
             result = subprocess.run(
-                shell_cmd,
+                self._shell_cmd(command),
                 cwd=self._root,
                 capture_output=True,
                 text=True,
-                timeout=timeout or 120,
+                timeout=timeout if timeout is not None else 120,
             )
 
             output = result.stdout + result.stderr
 
             # Truncate if too long
-            max_output = 100000
-            truncated = len(output) > max_output
+            truncated = len(output) > MAX_EXECUTE_OUTPUT
             if truncated:  # pragma: no cover
-                output = output[:max_output]
+                output = output[:MAX_EXECUTE_OUTPUT]
 
             return ExecuteResponse(
                 output=output,
@@ -636,11 +640,9 @@ class LocalBackend:
         if perm_error:
             return ExecuteResponse(output=f"Error: {perm_error}", exit_code=1, truncated=False)
 
-        shell_args = ["cmd", "/c", command] if sys.platform == "win32" else ["sh", "-c", command]
-
         try:
             proc = await asyncio.create_subprocess_exec(
-                *shell_args,
+                *self._shell_cmd(command),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self._root,
@@ -648,7 +650,7 @@ class LocalBackend:
 
             try:
                 stdout_b, stderr_b = await asyncio.wait_for(
-                    proc.communicate(), timeout=timeout or 120
+                    proc.communicate(), timeout=timeout if timeout is not None else 120
                 )
             except asyncio.CancelledError:
                 proc.kill()
@@ -667,17 +669,14 @@ class LocalBackend:
                 "utf-8", errors="replace"
             )
 
-            max_output = 100000
-            truncated = len(output) > max_output
+            truncated = len(output) > MAX_EXECUTE_OUTPUT
             if truncated:  # pragma: no cover
-                output = output[:max_output]
+                output = output[:MAX_EXECUTE_OUTPUT]
 
             return ExecuteResponse(
                 output=output,
-                exit_code=proc.returncode,
+                exit_code=proc.returncode if proc.returncode is not None else 1,
                 truncated=truncated,
             )
-        except asyncio.CancelledError:
-            raise
         except Exception as e:  # pragma: no cover
             return ExecuteResponse(output=f"Error: {e}", exit_code=1, truncated=False)

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import shutil
 import subprocess
+import sys
 import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -583,8 +585,9 @@ class LocalBackend:
             )
 
         try:
+            shell_cmd = ["cmd", "/c", command] if sys.platform == "win32" else ["sh", "-c", command]
             result = subprocess.run(
-                ["sh", "-c", command],
+                shell_cmd,
                 cwd=self._root,
                 capture_output=True,
                 text=True,
@@ -616,3 +619,65 @@ class LocalBackend:
                 exit_code=1,
                 truncated=False,
             )
+
+    async def async_execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+        """Async, cancellable version of execute().
+
+        Uses asyncio.create_subprocess_exec so that cancelling the calling task
+        immediately kills the subprocess rather than waiting for the thread to finish.
+        """
+        if not self._enable_execute:
+            raise RuntimeError(
+                "Shell execution is disabled for this backend. "
+                "Initialize with enable_execute=True to enable."
+            )
+
+        perm_error = self._check_permission_sync("execute", command)
+        if perm_error:
+            return ExecuteResponse(output=f"Error: {perm_error}", exit_code=1, truncated=False)
+
+        shell_args = ["cmd", "/c", command] if sys.platform == "win32" else ["sh", "-c", command]
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *shell_args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._root,
+            )
+
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(
+                    proc.communicate(), timeout=timeout or 120
+                )
+            except asyncio.CancelledError:
+                proc.kill()
+                await proc.communicate()
+                raise
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.communicate()
+                return ExecuteResponse(
+                    output="Error: Command timed out",
+                    exit_code=124,
+                    truncated=False,
+                )
+
+            output = stdout_b.decode("utf-8", errors="replace") + stderr_b.decode(
+                "utf-8", errors="replace"
+            )
+
+            max_output = 100000
+            truncated = len(output) > max_output
+            if truncated:  # pragma: no cover
+                output = output[:max_output]
+
+            return ExecuteResponse(
+                output=output,
+                exit_code=proc.returncode,
+                truncated=truncated,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # pragma: no cover
+            return ExecuteResponse(output=f"Error: {e}", exit_code=1, truncated=False)

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -705,7 +705,10 @@ for long-running builds or test suites.
                 return "Error: Shell execution is disabled for this backend"
 
             try:
-                result = await asyncio.to_thread(backend.execute, command, timeout)  # pyright: ignore[reportAttributeAccessIssue]
+                if hasattr(backend, "async_execute"):
+                    result = await backend.async_execute(command, timeout)  # pyright: ignore[reportAttributeAccessIssue]
+                else:
+                    result = await asyncio.to_thread(backend.execute, command, timeout)  # pyright: ignore[reportAttributeAccessIssue]
             except RuntimeError as e:
                 return f"Error: {e}"
 

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -375,6 +375,35 @@ class TestLocalBackendAsyncExecute:
             os.kill(grandchild_pid, 0)
 
 
+class TestKillProcTree:
+    """Test _kill_proc_tree platform branches."""
+
+    def test_kill_proc_tree_windows_calls_proc_kill(self, monkeypatch: pytest.MonkeyPatch):
+        """On Windows, _kill_proc_tree delegates to proc.kill() directly."""
+        from unittest.mock import MagicMock
+
+        import pydantic_ai_backends.backends.local as local_mod
+
+        monkeypatch.setattr(local_mod.sys, "platform", "win32")
+        proc = MagicMock()
+        LocalBackend._kill_proc_tree(proc)
+        proc.kill.assert_called_once_with()
+
+    def test_kill_proc_tree_windows_swallows_process_lookup_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """ProcessLookupError from a race with a process that already exited is suppressed."""
+        from unittest.mock import MagicMock
+
+        import pydantic_ai_backends.backends.local as local_mod
+
+        monkeypatch.setattr(local_mod.sys, "platform", "win32")
+        proc = MagicMock()
+        proc.kill.side_effect = ProcessLookupError
+        # Must not raise.
+        LocalBackend._kill_proc_tree(proc)
+
+
 class TestShellCmd:
     """Test _shell_cmd platform selection."""
 

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -335,6 +335,70 @@ class TestLocalBackendAsyncExecute:
         with pytest.raises(asyncio.CancelledError):
             await task
 
+    async def test_async_execute_cancel_kills_grandchildren(self, tmp_path: Path):
+        """On Unix, cancelling must reap the entire process group, not just the shell."""
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("Process-group semantics are Unix-specific")
+
+        import os
+
+        backend = LocalBackend(root_dir=tmp_path)
+
+        # Write the grandchild's PID to a file before sleeping so we can verify
+        # the kill reaches it. The shell ($$) is the parent; we want the actual
+        # sleep grandchild.
+        pid_file = tmp_path / "pid"
+        cmd = f'(sleep 60 & echo $! > "{pid_file}"; wait)'
+
+        task = asyncio.create_task(backend.async_execute(cmd))
+
+        # Wait for the pid file to appear (grandchild has been spawned).
+        for _ in range(50):
+            await asyncio.sleep(0.05)
+            if pid_file.exists() and pid_file.read_text().strip():
+                break
+        else:
+            task.cancel()
+            pytest.fail("grandchild never wrote pid file")
+
+        grandchild_pid = int(pid_file.read_text().strip())
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Give the OS a moment to deliver SIGKILL.
+        await asyncio.sleep(0.1)
+        # os.kill(pid, 0) raises ProcessLookupError if the process is gone.
+        with pytest.raises(ProcessLookupError):
+            os.kill(grandchild_pid, 0)
+
+
+class TestShellCmd:
+    """Test _shell_cmd platform selection."""
+
+    def test_shell_cmd_unix(self, monkeypatch: pytest.MonkeyPatch):
+        """On non-Windows platforms, returns sh -c."""
+        import pydantic_ai_backends.backends.local as local_mod
+
+        monkeypatch.setattr(local_mod.sys, "platform", "linux")
+        assert LocalBackend._shell_cmd("ls -la") == ["sh", "-c", "ls -la"]
+
+    def test_shell_cmd_windows(self, monkeypatch: pytest.MonkeyPatch):
+        """On Windows, returns cmd /c."""
+        import pydantic_ai_backends.backends.local as local_mod
+
+        monkeypatch.setattr(local_mod.sys, "platform", "win32")
+        assert LocalBackend._shell_cmd("dir") == ["cmd", "/c", "dir"]
+
+    def test_shell_cmd_darwin(self, monkeypatch: pytest.MonkeyPatch):
+        """On macOS, returns sh -c (non-Windows branch)."""
+        import pydantic_ai_backends.backends.local as local_mod
+
+        monkeypatch.setattr(local_mod.sys, "platform", "darwin")
+        assert LocalBackend._shell_cmd("echo hi") == ["sh", "-c", "echo hi"]
+
 
 class TestLocalBackendPathResolution:
     """Test LocalBackend path resolution and non-existent file handling."""

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -1,5 +1,6 @@
 """Tests for LocalBackend."""
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -282,6 +283,57 @@ class TestLocalBackendExecute:
         result = backend.execute("pwd")
         assert result.exit_code == 0
         assert str(tmp_path) in result.output
+
+
+class TestLocalBackendAsyncExecute:
+    """Test LocalBackend async shell execution."""
+
+    async def test_async_execute_basic(self, tmp_path: Path):
+        """Test basic async command execution."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await backend.async_execute("echo 'hello'")
+        assert result.exit_code == 0
+        assert "hello" in result.output
+
+    async def test_async_execute_disabled_raises(self, tmp_path: Path):
+        """Test that async_execute raises RuntimeError when disabled."""
+        backend = LocalBackend(root_dir=tmp_path, enable_execute=False)
+
+        with pytest.raises(RuntimeError, match="disabled"):
+            await backend.async_execute("echo 'hello'")
+
+    async def test_async_execute_permission_denied(self, tmp_path: Path):
+        """Test async execute returns error when permission denies."""
+        from pydantic_ai_backends.permissions import OperationPermissions, PermissionRuleset
+
+        ruleset = PermissionRuleset(execute=OperationPermissions(default="deny"))
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        result = await backend.async_execute("echo hello")
+
+        assert result.exit_code == 1
+        assert "Error" in result.output
+        assert "Permission denied" in result.output
+
+    async def test_async_execute_timeout_exceeded(self, tmp_path: Path):
+        """Test async command execution timeout returns timed-out response."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await backend.async_execute("sleep 10", timeout=1)
+        assert result.exit_code == 124
+        assert "timed out" in result.output
+
+    async def test_async_execute_cancelled(self, tmp_path: Path):
+        """Test that CancelledError propagates from async_execute."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        task = asyncio.create_task(backend.async_execute("sleep 60"))
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
 
 
 class TestLocalBackendPathResolution:


### PR DESCRIPTION
## Summary
Adds cross-platform shell support and cancellable async subprocess execution to `LocalBackend`. Previously the execute tool hardcoded `sh -c` which broke on Windows, and subprocess calls were blocking threads making them impossible to interrupt mid-run.

## Added
- `LocalBackend.async_execute()` — async subprocess execution via `asyncio.create_subprocess_exec`; on `CancelledError` the subprocess is killed immediately before re-raising, enabling true mid-execution cancellation
- Windows support: uses `["cmd", "/c", command]` on `win32`, `["sh", "-c", command]` elsewhere

## Changed
- `console.py` execute tool: prefers `await backend.async_execute(...)` when the backend exposes it, falls back to `asyncio.to_thread(backend.execute, ...)` for older/custom backends

## Fixed
- `[WinError 2]` crash on Windows caused by hardcoded `sh -c`
- Agent task cancellation (e.g. Esc key) now propagates through to the running subprocess immediately instead of waiting for the process to finish

## Testing
- New tests in `tests/test_local_backend.py` covering: normal execution, timeout, Windows path selection, cancellation via `CancelledError`
- [x] All tests pass locally: `make test`
- [x] Linting passes: `make lint`
- [x] Type checking passes: `make typecheck`
- [x] Full check suite passes: `make all`

## Related Issues
Related to vstorm-co/pydantic-deepagents#93

## Notes for Reviewers
`async_execute` is additive — the `execute` sync method is unchanged and still used by non-async callers. The console toolset detects capability with `hasattr(backend, "async_execute")` so third-party backend implementations are not affected.