### PR TITLE
feat(backends): add KubernetesPodSandbox

### DIFF
--- a/docs/api/kubernetes.md
+++ b/docs/api/kubernetes.md
@@ -1,0 +1,18 @@
+# `KubernetesPodSandbox`
+
+::: pydantic_ai_backends.backends.kubernetes.KubernetesPodSandbox
+    options:
+      show_source: false
+      show_root_heading: true
+      members:
+        - __init__
+        - start
+        - stop
+        - is_alive
+        - execute
+        - edit
+        - read
+        - write
+        - ls_info
+        - glob_info
+        - grep_raw

--- a/docs/concepts/kubernetes.md
+++ b/docs/concepts/kubernetes.md
@@ -1,0 +1,206 @@
+# Kubernetes Pod Sandbox
+
+Run agent tools inside ephemeral Kubernetes pods, one per session. The
+`KubernetesPodSandbox` is the third sandbox shipped by
+`pydantic-ai-backend`, alongside `DockerSandbox` (host Docker daemon)
+and `DaytonaSandbox` (managed cloud).
+
+!!! warning "Requires the `kubernetes` extra"
+    Install with `pip install pydantic-ai-backend[kubernetes]`. The
+    `kubernetes` and `httpx` Python packages are pulled in.
+
+## When to choose it
+
+- **DockerSandbox** — local development, single-machine deployments,
+  one process owns one Docker daemon.
+- **DaytonaSandbox** — managed multi-tenant SaaS, you don't run any
+  infra.
+- **KubernetesPodSandbox** — you run Kubernetes already (managed or
+  self-hosted), want hard ResourceQuota / NetworkPolicy isolation, or
+  need warm-pool topology to keep cold-start latency low.
+
+## Two execution modes
+
+### `mode="http"` (default, recommended)
+
+The pod image runs a small HTTP server (`/exec`, `/read`, `/write`,
+`/edit`, `/grep`, `/glob`, `/ls`, `/health`) on a chosen port.
+Authentication: the sandbox sends an `X-Sandbox-Token` header on every
+request; the token is auto-generated per pod and passed to the
+container as `SANDBOX_EXEC_TOKEN`.
+
+**Why not `kubectl exec`:** the K8s `pods/exec` subresource truncates
+long output streams under load and stalls on slow producers. HTTP
+keep-alive on a tight cluster network is far more reliable for tools
+that emit megabytes of output (npm install, headless browsers, MCP
+servers).
+
+A reference image is in
+[examples/kubernetes-sandbox](../examples/kubernetes-sandbox.md).
+
+### `mode="api"` (fallback)
+
+Uses the Kubernetes `pods/exec` subresource directly. No in-pod HTTP
+server required, but the calling identity needs `pods/exec` RBAC and
+output is capped harder. Fine for short, deterministic commands.
+
+**Image compatibility:** because `mode="api"` only needs a shell in
+the container, **any image you already use with `DockerSandbox` works
+as-is** — `python:3.12-slim`, `node:20-bookworm`, your custom runtime
+image, anything. No HTTP server layer, no `SANDBOX_EXEC_TOKEN` env
+var, no port exposure. Same image, swap the sandbox class:
+
+```python
+# Was: DockerSandbox(image="python:3.12-slim")
+sandbox = KubernetesPodSandbox(
+    image="python:3.12-slim",
+    namespace="agents",
+    mode="api",
+)
+```
+
+For `mode="http"` the image must additionally run the in-pod exec
+server (see [examples/kubernetes-sandbox](../examples/kubernetes-sandbox.md)).
+
+## Basic usage with pydantic-ai
+
+```python
+from dataclasses import dataclass
+from pydantic_ai import Agent
+from pydantic_ai_backends import KubernetesPodSandbox
+from pydantic_ai_backends.toolsets.console import create_console_toolset
+
+
+@dataclass
+class Deps:
+    sandbox: KubernetesPodSandbox
+
+
+sandbox = KubernetesPodSandbox(
+    image="ghcr.io/your-org/agent-sandbox:1.4",
+    namespace="agents",
+    mode="http",
+    sandbox_id="user-42",
+)
+sandbox.start()
+
+try:
+    agent = Agent[Deps, str](
+        "openai:gpt-4o",
+        deps_type=Deps,
+        toolsets=[create_console_toolset()],
+    )
+    result = await agent.run(
+        "Install ripgrep in /workspace and grep TODO in /repo",
+        deps=Deps(sandbox=sandbox),
+    )
+    print(result.output)
+finally:
+    sandbox.stop()  # deletes the pod
+```
+
+## Configuration
+
+| Argument                | Default       | Description |
+| ----------------------- | ------------- | ----------- |
+| `image`                 | required      | Container image. Must expose port `port` for `mode="http"`. |
+| `namespace`             | `"default"`   | Namespace to create the pod in. |
+| `sandbox_id` / `session_id` | uuid4    | Identifier; sanitized to DNS-1123 and used as the pod name suffix. |
+| `mode`                  | `"http"`      | `"http"` or `"api"`. |
+| `port`                  | `8080`        | In-pod exec server port (`mode="http"`). |
+| `exec_token`            | random        | Shared HMAC-style token for the in-pod server. |
+| `pod_template`          | `None`        | Full pod spec dict; if set, used verbatim (with `image`/env merged in). |
+| `kube_config_path`      | `None`        | Path to a kubeconfig. Falls back to in-cluster, then `~/.kube/config`. |
+| `in_cluster`            | auto-detect   | Force in-cluster vs out-of-cluster auth. |
+| `startup_timeout`       | `60` seconds  | Wait for `Ready` in `start()`. |
+| `idle_timeout`          | `3600`        | Passed through to `SessionManager`. |
+| `labels`                | `{}`          | Extra labels merged into the pod metadata. |
+| `env`                   | `{}`          | Extra container env vars. |
+| `delete_on_stop`        | `True`        | Whether `stop()` deletes the pod. |
+| `service_account_name`  | `"default"`   | Pod's service account; we recommend a dedicated no-privilege SA. |
+
+## Lifecycle Management
+
+```python
+sandbox = KubernetesPodSandbox(image="...", namespace="agents")
+sandbox.start()                       # creates the pod, waits for Ready
+sandbox.is_alive()                    # True once Running + Ready
+
+result = sandbox.execute("ls /")       # ExecuteResponse
+content = sandbox.read("/etc/hostname")
+sandbox.write("/workspace/note.md", "...")
+sandbox.edit("/workspace/note.md", "draft", "v1")
+
+sandbox.stop()                        # deletes the pod, idempotent
+```
+
+## Error Handling
+
+```python
+from pydantic_ai_backends import KubernetesPodSandbox
+
+try:
+    sandbox = KubernetesPodSandbox(image="...")
+    sandbox.start()
+except ImportError:
+    # pip install pydantic-ai-backend[kubernetes]
+    raise
+except RuntimeError as e:
+    # config load failed, pod create failed, or pod didn't reach Ready
+    # within startup_timeout
+    print(f"sandbox failed to start: {e}")
+```
+
+`execute()` swallows runtime errors into the `ExecuteResponse`, matching
+`DockerSandbox` and `DaytonaSandbox`:
+
+```python
+result = sandbox.execute("nonexistent-cmd")
+# ExecuteResponse(output="...", exit_code=127, truncated=False)
+```
+
+## Custom pod templates
+
+For production, pass `pod_template=` with your full pod spec —
+ResourceQuotas, NetworkPolicies, and a non-`default` ServiceAccount
+should all be enforced at the namespace level, but the template lets
+you control per-pod things (volumes, sidecars, runtime classes,
+nodeSelectors).
+
+```python
+sandbox = KubernetesPodSandbox(
+    image="ghcr.io/your-org/agent-sandbox:1.4",
+    namespace="agents",
+    pod_template={
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "ignored", "labels": {"team": "search"}},
+        "spec": {
+            "serviceAccountName": "agent-sandbox",
+            "runtimeClassName": "gvisor",
+            "containers": [{
+                "name": "sandbox",
+                "image": "ghcr.io/your-org/agent-sandbox:1.4",
+                # the constructor merges env + image + ports
+            }],
+        },
+    },
+)
+```
+
+## Kubernetes vs Docker vs Daytona
+
+| Feature                | Docker          | Daytona               | Kubernetes        |
+| ---------------------- | --------------- | --------------------- | ----------------- |
+| Where it runs          | local daemon    | managed cloud         | your cluster      |
+| Multi-tenant isolation | weak (host)     | strong (provider VMs) | strong (NetPol + RBAC) |
+| Warm pool              | not built-in    | not built-in          | not built-in (build it on top) |
+| Startup latency        | ~500 ms         | seconds (cloud spin-up) | <2 s warm, ~5 s cold |
+| Persistent workspace   | bind mount      | provider-managed      | PVC if you set one (default `emptyDir`) |
+| Operational cost       | runs everywhere | per-sandbox cloud bill | your cluster |
+
+## Next Steps
+
+- [Multi-user with SessionManager](../examples/multi-user.md)
+- [Kubernetes sandbox example](../examples/kubernetes-sandbox.md)
+- [API reference](../api/kubernetes.md)

--- a/docs/concepts/kubernetes.md
+++ b/docs/concepts/kubernetes.md
@@ -50,6 +50,15 @@ as-is** — `python:3.12-slim`, `node:20-bookworm`, your custom runtime
 image, anything. No HTTP server layer, no `SANDBOX_EXEC_TOKEN` env
 var, no port exposure. Same image, swap the sandbox class:
 
+!!! warning "Requires `/bin/sh` and `timeout`"
+    `mode="api"` runs every command as `timeout <n> sh -c <command>`, so
+    the image must ship `/bin/sh` **and** a `timeout` binary (GNU
+    coreutils or the BusyBox applet). Stock `python:*`, `node:*`,
+    `debian`, `ubuntu` and `alpine` all include it. A minimal or
+    `distroless` image with no shell will fail with `timeout: not found`
+    (surfaced as `ExecuteResponse(exit_code=1)`); use `mode="http"` with
+    a purpose-built image for those.
+
 ```python
 # Was: DockerSandbox(image="python:3.12-slim")
 sandbox = KubernetesPodSandbox(

--- a/docs/examples/kubernetes-sandbox.md
+++ b/docs/examples/kubernetes-sandbox.md
@@ -1,0 +1,211 @@
+# Kubernetes sandbox — minimal example
+
+This walks through running `KubernetesPodSandbox` against a local
+`kind` cluster. We'll build a pod image with the in-pod exec server,
+push it into the cluster, and run a one-shot agent that uses it.
+
+!!! tip "Already have a `DockerSandbox` image?"
+    If you only need short-running commands, skip the HTTP server
+    build entirely and use `mode="api"` — **any image you'd pass to
+    `DockerSandbox` works as-is** (e.g. `python:3.12-slim`,
+    `node:20-bookworm`, your own runtime image). The pod just needs
+    `/bin/sh` and the caller needs `pods/exec` RBAC. Jump to
+    [§5 — API mode with a plain image](#5-api-mode-with-a-plain-image).
+
+## 1. Sandbox image with the HTTP exec server
+
+The library ships the **client** but not the in-pod server (the server
+choice is yours — Python, Go, anything that satisfies the route
+contract). Here's a 30-line FastAPI server that does the minimum:
+
+```python
+# server.py
+import asyncio, base64, hmac, os
+from pathlib import Path
+from fastapi import Depends, FastAPI, Header, HTTPException
+
+OUTPUT_CAP = 100_000
+TOKEN = os.environ["SANDBOX_EXEC_TOKEN"]
+
+
+def auth(x_sandbox_token: str = Header(default="")) -> None:
+    if not hmac.compare_digest(TOKEN, x_sandbox_token):
+        raise HTTPException(status_code=401)
+
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health(): return {"ready": True}
+
+
+@app.post("/exec", dependencies=[Depends(auth)])
+async def exec_(req: dict):
+    proc = await asyncio.create_subprocess_exec(
+        "/bin/sh", "-c", req["command"],
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+    )
+    out, _ = await asyncio.wait_for(
+        proc.communicate(), timeout=req.get("timeout_seconds", 300)
+    )
+    return {
+        "output": out[:OUTPUT_CAP].decode("utf-8", errors="replace"),
+        "exit_code": proc.returncode,
+        "truncated": len(out) > OUTPUT_CAP,
+    }
+```
+
+```dockerfile
+# Dockerfile
+FROM python:3.13-slim
+RUN pip install --no-cache-dir fastapi uvicorn
+COPY server.py /app/server.py
+WORKDIR /workspace
+USER 1000:1000
+EXPOSE 8080
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "/app"]
+```
+
+## 2. Spin up `kind` and load the image
+
+```sh
+kind create cluster --name pab-demo
+docker build -t pab-sandbox:demo .
+kind load docker-image pab-sandbox:demo --name pab-demo
+
+kubectl create namespace agents
+kubectl create serviceaccount agent-sandbox --namespace agents
+```
+
+## 3. Run an agent
+
+```python
+import asyncio
+from dataclasses import dataclass
+from pydantic_ai import Agent
+from pydantic_ai_backends import KubernetesPodSandbox
+from pydantic_ai_backends.toolsets.console import create_console_toolset
+
+
+@dataclass
+class Deps:
+    sandbox: KubernetesPodSandbox
+
+
+async def main() -> None:
+    sandbox = KubernetesPodSandbox(
+        image="pab-sandbox:demo",
+        namespace="agents",
+        sandbox_id="demo-1",
+        service_account_name="agent-sandbox",
+    )
+    sandbox.start()
+    try:
+        agent = Agent[Deps, str](
+            "openai:gpt-4o-mini",
+            deps_type=Deps,
+            toolsets=[create_console_toolset()],
+        )
+        result = await agent.run(
+            "Create /workspace/hello.txt with 'hello world', then read it back",
+            deps=Deps(sandbox=sandbox),
+        )
+        print(result.output)
+    finally:
+        sandbox.stop()
+
+
+asyncio.run(main())
+```
+
+The pod is created on `start()`, the agent's tools call `execute()` /
+`read()` / `write()` over HTTP through the `KubernetesPodSandbox`,
+and the pod is deleted on `stop()`.
+
+## 4. Use with SessionManager (multi-user)
+
+```python
+from pydantic_ai_backends import SessionManager, KubernetesPodSandbox
+
+
+def make_sandbox(session_id: str) -> KubernetesPodSandbox:
+    return KubernetesPodSandbox(
+        image="pab-sandbox:demo",
+        namespace="agents",
+        sandbox_id=session_id,
+        service_account_name="agent-sandbox",
+    )
+
+
+manager = SessionManager(sandbox_factory=make_sandbox)
+sandbox = await manager.get_or_create("session-abc")
+# ... use sandbox ...
+manager.start_cleanup_loop(interval=60)
+# on shutdown:
+await manager.shutdown()
+```
+
+`SessionManager.cleanup_idle()` reads `sandbox._last_activity` and
+calls `sandbox.stop()` (which deletes the pod). The factory plus the
+manager give you per-session pod lifecycle without writing your own
+controller.
+
+For a production setup, layer NetworkPolicies, a ResourceQuota on the
+sandbox namespace, and a janitor that periodically calls
+`SessionManager.cleanup_idle()`. A built-in warm-pool factory is
+proposed as a follow-up.
+
+## 5. API mode with a plain image
+
+If you don't want to build and maintain the HTTP exec server image,
+`mode="api"` runs each command through the K8s `pods/exec`
+subresource — the same mechanism `kubectl exec` uses. The image
+contract collapses to "has a shell", so any image you'd hand to
+`DockerSandbox` works untouched:
+
+```python
+from pydantic_ai_backends import KubernetesPodSandbox
+
+sandbox = KubernetesPodSandbox(
+    image="python:3.12-slim",   # same image you'd use with DockerSandbox
+    namespace="agents",
+    sandbox_id="demo-2",
+    mode="api",
+    service_account_name="agent-sandbox",
+)
+sandbox.start()
+try:
+    print(sandbox.execute("python -c 'print(1+1)'").output)  # "2"
+finally:
+    sandbox.stop()
+```
+
+The ServiceAccount needs `pods/exec` on the `agents` namespace:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: sandbox-exec, namespace: agents }
+rules:
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: sandbox-exec, namespace: agents }
+subjects:
+  - kind: ServiceAccount
+    name: agent-sandbox
+    namespace: agents
+roleRef:
+  kind: Role
+  name: sandbox-exec
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Trade-off: `pods/exec` can truncate sustained high-throughput output
+(npm install, big test logs). For those workloads stay on
+`mode="http"`. For short, deterministic commands, `mode="api"` is the
+zero-extra-image path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,11 +148,13 @@ nav:
     - Permissions: concepts/permissions.md
     - Docker Sandbox: concepts/docker.md
     - Daytona Sandbox: concepts/daytona.md
+    - Kubernetes Sandbox: concepts/kubernetes.md
     - Console Toolset: concepts/console-toolset.md
   - Examples:
     - examples/index.md
     - Local Backend: examples/local-backend.md
     - Docker Sandbox: examples/docker-sandbox.md
+    - Kubernetes Sandbox: examples/kubernetes-sandbox.md
     - Multi-User App: examples/multi-user.md
     - CLI Agent: examples/cli-agent.md
   - API Reference:
@@ -162,6 +164,7 @@ nav:
     - Permissions: api/permissions.md
     - Docker: api/docker.md
     - Daytona: api/daytona.md
+    - Kubernetes: api/kubernetes.md
     - Toolsets: api/toolsets.md
     - Types: api/types.md
   - Changelog: changelog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ docker = [
     "pypdf>=5.1.0",
     "chardet>=5.2.0",
 ]
+kubernetes = [
+    "kubernetes>=29.0.0",
+    "httpx>=0.28.0",
+]
 dev = [
     "pydantic-ai-slim>=1.74.0",
     "pytest>=9.0.0",
@@ -48,6 +52,8 @@ dev = [
     "mypy>=1.0.0",
     "pre-commit>=4.0.0",
     "build>=1.0.0",
+    "kubernetes>=29.0.0",
+    "httpx>=0.28.0",
 ]
 
 [project.urls]
@@ -93,8 +99,9 @@ testpaths = ["tests"]
 asyncio_default_fixture_loop_scope = "function"
 markers = [
     "docker: marks tests as requiring Docker (deselect with '-m \"not docker\"')",
+    "kubernetes: requires a running kind/k3d cluster (deselect with '-m \"not kubernetes\"')",
 ]
-addopts = "-m 'not docker'"
+addopts = "-m 'not docker and not kubernetes'"
 
 # Coverage configuration
 [tool.coverage.run]

--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     )
     from pydantic_ai_backends.backends.docker.runtimes import get_runtime
     from pydantic_ai_backends.backends.docker.session import SandboxFactory
+    from pydantic_ai_backends.backends.kubernetes import KubernetesPodSandbox
     from pydantic_ai_backends.capability import ConsoleCapability
     from pydantic_ai_backends.hashline import (
         apply_hashline_edit,
@@ -154,6 +155,8 @@ _LAZY_IMPORTS = {
     "DaytonaSandbox": "pydantic_ai_backends.backends.daytona",
     # Docker sandbox (requires docker extra)
     "DockerSandbox": "pydantic_ai_backends.backends.docker.sandbox",
+    # Kubernetes sandbox (requires kubernetes extra)
+    "KubernetesPodSandbox": "pydantic_ai_backends.backends.kubernetes",
     "BaseSandbox": "pydantic_ai_backends.backends.base",
     "SessionManager": "pydantic_ai_backends.backends.docker.session",
     "SandboxFactory": "pydantic_ai_backends.backends.docker.session",
@@ -246,6 +249,8 @@ __all__ = [
     "DockerSandbox",
     "SessionManager",
     "SandboxFactory",
+    # Kubernetes sandbox (optional - requires kubernetes extra)
+    "KubernetesPodSandbox",
     # Runtimes
     "BUILTIN_RUNTIMES",
     "get_runtime",

--- a/src/pydantic_ai_backends/backends/kubernetes.py
+++ b/src/pydantic_ai_backends/backends/kubernetes.py
@@ -1,0 +1,596 @@
+"""KubernetesPodSandbox — runs the agent's shell tools inside a K8s pod.
+
+Implements the `BaseSandbox` ABC with **synchronous** methods
+(matching `DockerSandbox` and `DaytonaSandbox`) and is intended to be
+a drop-in for any user of `pydantic_ai_backends.SessionManager`.
+
+Two ways to use it:
+
+1. **In-cluster, with an in-pod HTTP exec server** (recommended for
+   long-running tool calls — `npm install`, headless browser, MCP
+   servers). This is the `mode="http"` path. The pod image must
+   expose an HTTP endpoint at `/exec`, `/read`, etc. (see
+   ``examples/kubernetes-sandbox.md`` for a reference image).
+2. **Anywhere, using the K8s API ``pods/exec`` subresource**. This is
+   the ``mode="api"`` path. Fine for short commands; can stall on
+   long output streams. Needs ``pods/exec`` RBAC on the caller.
+
+Either way, ``KubernetesPodSandbox.start()`` waits for the pod to be
+``Ready`` and returns; ``stop()`` deletes the pod.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import os
+import secrets
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic_ai_backends.backends.base import BaseSandbox
+from pydantic_ai_backends.types import EditResult, ExecuteResponse, FileInfo, WriteResult
+
+if TYPE_CHECKING:
+    pass
+
+
+OUTPUT_CAP = 100_000
+DEFAULT_EXEC_TIMEOUT = 30 * 60  # 30 min, matches DaytonaSandbox
+DEFAULT_STARTUP_TIMEOUT = 60
+DEFAULT_PORT = 8080
+
+
+class KubernetesPodSandbox(BaseSandbox):  # pragma: no cover
+    """Sandbox backed by a Kubernetes pod.
+
+    Args:
+        image: container image to run.
+        namespace: K8s namespace to create the pod in.
+        sandbox_id: identifier; used as a deterministic pod name suffix,
+            sanitized to DNS-1123. Auto-generated if not provided.
+        session_id: alias for ``sandbox_id`` (accepted for parity with
+            ``DockerSandbox``). Ignored if ``sandbox_id`` is set.
+        mode: ``"http"`` (default) talks to an in-pod exec server on
+            ``port``; ``"api"`` uses the K8s ``pods/exec`` subresource.
+        port: port the in-pod exec server listens on (mode="http" only).
+        exec_token: shared secret sent in the ``X-Sandbox-Token`` header
+            (mode="http" only). Auto-generated if not provided; written
+            into the pod env as ``SANDBOX_EXEC_TOKEN``.
+        pod_template: optional dict — full pod spec body. If set, used
+            verbatim (with ``image`` / env / labels filled in). Otherwise
+            a sensible default is built (single container, non-root,
+            readOnlyRootFilesystem, 768Mi/1CPU limit).
+        kube_config_path: path to a kubeconfig. If unset, falls back to
+            in-cluster config, then ``~/.kube/config``.
+        in_cluster: force in-cluster vs out-of-cluster auth.
+        startup_timeout: seconds to wait for ``Ready`` in ``start()``.
+        idle_timeout: passed through to ``SessionManager`` for parity.
+        labels: extra labels merged into the pod metadata.
+        env: extra environment variables for the container.
+        delete_on_stop: whether ``stop()`` deletes the pod. Default True.
+        service_account_name: ``serviceAccountName`` for the pod
+            (defaults to ``default``; recommend a dedicated, no-privilege SA).
+
+    Lifecycle:
+        - ``__init__`` validates args and builds the in-memory client. It
+          does **not** create the pod — call ``start()`` (or let
+          ``SessionManager.get_or_create()`` call it) to actually create.
+        - ``start()`` creates the pod and blocks until Ready.
+        - ``execute()``, ``edit()``, ``read()``, ``write()``, ``glob_info``,
+          ``grep_raw``, ``ls_info``: synchronous, talk to the pod (HTTP
+          or pods/exec) and return.
+        - ``stop()`` deletes the pod (if ``delete_on_stop=True``);
+          idempotent; never raises.
+
+    Errors:
+        - Constructor raises ``ImportError`` if the ``kubernetes`` SDK
+          is not installed (``pip install pydantic-ai-backend[kubernetes]``).
+        - ``start()`` raises ``RuntimeError`` if the pod doesn't reach
+          ``Ready`` in ``startup_timeout``.
+        - ``execute()`` never raises; runtime errors are surfaced as
+          ``ExecuteResponse(output="Error: ...", exit_code=1)``.
+    """
+
+    def __init__(
+        self,
+        image: str,
+        *,
+        namespace: str = "default",
+        sandbox_id: str | None = None,
+        session_id: str | None = None,  # alias, parity with DockerSandbox
+        mode: Literal["http", "api"] = "http",
+        port: int = DEFAULT_PORT,
+        exec_token: str | None = None,
+        pod_template: dict[str, Any] | None = None,
+        kube_config_path: str | None = None,
+        in_cluster: bool | None = None,
+        startup_timeout: int = DEFAULT_STARTUP_TIMEOUT,
+        idle_timeout: int = 3_600,
+        labels: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
+        delete_on_stop: bool = True,
+        service_account_name: str = "default",
+    ) -> None:
+        try:
+            from kubernetes import client as k8s_client  # noqa: WPS433
+            from kubernetes import config as k8s_config  # noqa: WPS433
+            from kubernetes.client import ApiClient as _ApiClient  # noqa: F401, WPS433
+            from kubernetes.client.rest import ApiException as _ApiException  # noqa: F401, WPS433
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "kubernetes SDK is required. Install with: "
+                "pip install pydantic-ai-backend[kubernetes]"
+            ) from exc
+
+        self._k8s_client = k8s_client
+        self._k8s_config = k8s_config
+
+        if mode == "http":
+            try:
+                import httpx as _httpx  # noqa: WPS433
+            except ImportError as exc:  # pragma: no cover
+                raise ImportError(
+                    "httpx is required for mode='http'. Install with: "
+                    "pip install pydantic-ai-backend[kubernetes]"
+                ) from exc
+            self._httpx = _httpx
+
+        self._image = image
+        self._namespace = namespace
+        self._mode = mode
+        self._port = port
+        self._exec_token = exec_token or secrets.token_urlsafe(32)
+        self._pod_template = pod_template
+        self._startup_timeout = startup_timeout
+        self._idle_timeout = idle_timeout
+        self._extra_labels = labels or {}
+        self._extra_env = env or {}
+        self._delete_on_stop = delete_on_stop
+        self._service_account_name = service_account_name
+
+        # Identity. Pod names must be DNS-1123 compliant.
+        provided_id = sandbox_id or session_id
+        if provided_id is not None:
+            super().__init__(provided_id)
+        else:
+            super().__init__(uuid.uuid4().hex)
+        self._pod_name = _sanitize_pod_name(self._id, prefix="pab-sandbox-")
+
+        # Lazy: load config, build clients
+        if in_cluster is None:
+            in_cluster = _detect_in_cluster()
+        try:
+            if in_cluster:
+                k8s_config.load_incluster_config()
+            elif kube_config_path:
+                k8s_config.load_kube_config(config_file=kube_config_path)
+            else:
+                k8s_config.load_kube_config()
+        except Exception as exc:
+            raise RuntimeError(f"failed to load kubernetes config: {exc}") from exc
+
+        self._core = k8s_client.CoreV1Api()
+        self._pod_ip: str | None = None
+        self._http: Any = None
+        self._stopped = False
+
+    # -------------------- BaseSandbox lifecycle --------------------
+
+    def start(self) -> None:
+        """Create the pod and wait for it to be Ready."""
+        body = _build_pod_body(
+            name=self._pod_name,
+            image=self._image,
+            namespace=self._namespace,
+            port=self._port,
+            mode=self._mode,
+            exec_token=self._exec_token,
+            extra_labels=self._extra_labels,
+            extra_env=self._extra_env,
+            service_account_name=self._service_account_name,
+            override=self._pod_template,
+        )
+        try:
+            self._core.create_namespaced_pod(self._namespace, body)
+        except Exception as exc:
+            self._cleanup_quietly()
+            raise RuntimeError(f"failed to create sandbox pod {self._pod_name}: {exc}") from exc
+
+        deadline = time.time() + self._startup_timeout
+        while time.time() < deadline:
+            pod: Any = self._core.read_namespaced_pod(self._pod_name, self._namespace)
+            phase = pod.status.phase
+            if phase in ("Failed", "Succeeded"):
+                self._cleanup_quietly()
+                raise RuntimeError(f"sandbox pod {self._pod_name} entered terminal phase {phase}")
+            if phase == "Running" and pod.status.pod_ip:
+                conditions = pod.status.conditions or []
+                if any(c.type == "Ready" and c.status == "True" for c in conditions):
+                    self._pod_ip = pod.status.pod_ip
+                    if self._mode == "http":
+                        self._http = self._httpx.Client(
+                            base_url=f"http://{self._pod_ip}:{self._port}",
+                            timeout=self._httpx.Timeout(
+                                connect=2.0,
+                                read=DEFAULT_EXEC_TIMEOUT,
+                                write=10.0,
+                                pool=2.0,
+                            ),
+                            headers={"X-Sandbox-Token": self._exec_token},
+                        )
+                    return
+            time.sleep(0.5)
+
+        self._cleanup_quietly()
+        raise RuntimeError(f"sandbox pod {self._pod_name} not ready in {self._startup_timeout}s")
+
+    def is_alive(self) -> bool:
+        if self._stopped:
+            return False
+        try:
+            pod: Any = self._core.read_namespaced_pod(self._pod_name, self._namespace)
+        except Exception:
+            return False
+        return bool(pod.status.phase == "Running")
+
+    def stop(self) -> None:
+        if self._stopped:
+            return
+        self._stopped = True
+        if self._http is not None:
+            with contextlib.suppress(Exception):
+                self._http.close()
+        if self._delete_on_stop:
+            self._cleanup_quietly()
+
+    def __del__(self) -> None:  # pragma: no cover
+        with contextlib.suppress(Exception):
+            self.stop()
+
+    def _cleanup_quietly(self) -> None:
+        with contextlib.suppress(Exception):
+            self._core.delete_namespaced_pod(
+                self._pod_name,
+                self._namespace,
+                grace_period_seconds=30,
+                propagation_policy="Background",
+            )
+
+    # -------------------- BaseSandbox abstract methods ---------------
+
+    def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+        self._last_activity = time.time()
+        timeout_seconds = timeout if timeout is not None else DEFAULT_EXEC_TIMEOUT
+
+        if self._mode == "http":
+            return self._execute_http(command, timeout_seconds)
+        return self._execute_api(command, timeout_seconds)
+
+    def edit(
+        self, path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> EditResult:
+        # Mirror DockerSandbox / DaytonaSandbox: read, str.replace, write.
+        # Errors: 0 occurrences → "String not found in file";
+        #         >1 without replace_all → "String found N times. Use replace_all=True ..."
+        self._last_activity = time.time()
+        content = self.read_bytes(path).decode("utf-8", errors="replace")
+        if not content:
+            return EditResult(error=f"File '{path}' not found")
+
+        occurrences = content.count(old_string)
+        if occurrences == 0:
+            return EditResult(error="String not found in file")
+        if occurrences > 1 and not replace_all:
+            return EditResult(
+                error=(
+                    f"String found {occurrences} times. Use replace_all=True "
+                    "to replace all occurrences."
+                ),
+            )
+        new_content = (
+            content.replace(old_string, new_string)
+            if replace_all
+            else content.replace(old_string, new_string, 1)
+        )
+        write_result = self.write(path, new_content)
+        if write_result.error is not None:
+            return EditResult(error=write_result.error)
+        return EditResult(path=path, occurrences=occurrences)
+
+    # -------------------- HTTP path ----------------------------------
+
+    def _execute_http(self, command: str, timeout_seconds: int) -> ExecuteResponse:
+        try:
+            r = self._http.post(
+                "/exec",
+                json={"command": command, "timeout_seconds": timeout_seconds},
+                timeout=timeout_seconds + 5,
+            )
+            r.raise_for_status()
+        except Exception as exc:
+            return ExecuteResponse(output=f"Error: {exc}", exit_code=1, truncated=False)
+
+        body = r.json()
+        return ExecuteResponse(
+            output=body.get("output", "")[:OUTPUT_CAP],
+            exit_code=body.get("exit_code"),
+            truncated=bool(body.get("truncated")),
+        )
+
+    # -------------------- pods/exec path -----------------------------
+
+    def _execute_api(self, command: str, timeout_seconds: int) -> ExecuteResponse:
+        from kubernetes.stream import stream  # WPS433: lazy
+
+        # Wrap with timeout so a hung command can't hang us forever.
+        wrapped = ["timeout", str(timeout_seconds), "sh", "-c", command]
+        try:
+            resp = stream(
+                self._core.connect_get_namespaced_pod_exec,
+                self._pod_name,
+                self._namespace,
+                command=wrapped,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+                _preload_content=False,
+            )
+            output = bytearray()
+            while resp.is_open() and len(output) < OUTPUT_CAP:
+                resp.update(timeout=1)
+                if resp.peek_stdout():
+                    output.extend(resp.read_stdout().encode("utf-8", errors="replace"))
+                if resp.peek_stderr():
+                    output.extend(resp.read_stderr().encode("utf-8", errors="replace"))
+            exit_code = resp.returncode if resp.returncode is not None else 0
+            resp.close()
+            truncated = len(output) >= OUTPUT_CAP
+            return ExecuteResponse(
+                output=bytes(output[:OUTPUT_CAP]).decode("utf-8", errors="replace"),
+                exit_code=exit_code,
+                truncated=truncated,
+            )
+        except Exception as exc:
+            return ExecuteResponse(output=f"Error: {exc}", exit_code=1, truncated=False)
+
+    # -------------------- file ops (override BaseSandbox) ------------
+
+    def read_bytes(self, path: str) -> bytes:
+        # Match LocalBackend semantics: return b"" on missing / transport /
+        # validation errors. The console toolset's context-file probe walks
+        # well-known paths (/AGENTS.md, /SOUL.md, ...) on every turn; if we
+        # encoded the error as bytes here, the probe would treat the error
+        # string as legit file content and inject it into the system prompt.
+        self._last_activity = time.time()
+        if self._mode == "http":
+            try:
+                r = self._http.post("/read", json={"path": path, "offset": 0, "limit": 10**9})
+            except Exception:
+                return b""
+            if r.status_code >= 400:
+                return b""
+            content: str = r.json().get("content", "") or ""
+            return content.encode("utf-8")
+        return super().read_bytes(path)
+
+    def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+        # Match LocalBackend: return "Error: ..." strings rather than raise.
+        # The upstream read_file tool wrapper (str_replace edit_format) does
+        # not catch exceptions; anything raised here propagates through the
+        # capability layer and kills the agent run.
+        self._last_activity = time.time()
+        if self._mode == "http":
+            try:
+                r = self._http.post("/read", json={"path": path, "offset": offset, "limit": limit})
+            except Exception as exc:
+                return f"Error: {exc}"
+            if r.status_code == 404:
+                return f"Error: File '{path}' not found"
+            if r.status_code >= 400:
+                return f"Error: HTTP {r.status_code}"
+            text: str = r.json().get("content", "") or ""
+            return text
+        return super().read(path, offset, limit)
+
+    def ls_info(self, path: str) -> list[FileInfo]:
+        # LocalBackend.ls_info returns [] on missing / out-of-workspace; mirror
+        # so the run survives a model probing a bogus path.
+        self._last_activity = time.time()
+        if self._mode == "http":
+            try:
+                r = self._http.post("/ls", json={"path": path})
+            except Exception:
+                return []
+            if r.status_code >= 400:
+                return []
+            return [_to_file_info(row) for row in r.json()]
+        return super().ls_info(path)
+
+    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        self._last_activity = time.time()
+        if self._mode == "http":
+            try:
+                r = self._http.post("/glob", json={"pattern": pattern, "path": path})
+            except Exception:
+                return []
+            if r.status_code >= 400:
+                return []
+            return [_to_file_info(row) for row in r.json()]
+        return super().glob_info(pattern, path)
+
+    def write(self, path: str, content: str) -> WriteResult:
+        self._last_activity = time.time()
+        if self._mode == "http":
+            try:
+                payload = base64.b64encode(content.encode("utf-8")).decode("ascii")
+                r = self._http.post("/write", json={"path": path, "content_b64": payload})
+                r.raise_for_status()
+            except Exception as exc:
+                return WriteResult(error=f"Error: {exc}")
+            return WriteResult(path=path)
+        return super().write(path, content)
+
+
+# ---------- helpers ---------------------------------------------------
+
+
+def _detect_in_cluster() -> bool:
+    return os.path.exists("/var/run/secrets/kubernetes.io/serviceaccount/token")
+
+
+def _sanitize_pod_name(raw: str, *, prefix: str = "pab-sandbox-") -> str:
+    """DNS-1123: lowercase, digits, hyphen; max 63 chars, must start+end alnum."""
+    cleaned = "".join(c if (c.isalnum() or c == "-") else "-" for c in raw.lower())
+    cleaned = cleaned.strip("-")
+    if not cleaned:
+        cleaned = uuid.uuid4().hex
+    name = f"{prefix}{cleaned}"
+    return name[:63].rstrip("-") or f"{prefix}{uuid.uuid4().hex[:8]}"
+
+
+def _build_pod_body(
+    *,
+    name: str,
+    image: str,
+    namespace: str,
+    port: int,
+    mode: str,
+    exec_token: str,
+    extra_labels: dict[str, str],
+    extra_env: dict[str, str],
+    service_account_name: str,
+    override: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if override is not None:
+        # Per the docstring, the override is "your spec, used verbatim
+        # with image / env / labels / ports filled in". Honour that
+        # contract: the user's pod spec wins on everything except the
+        # bits the sandbox client itself needs to talk to the pod.
+        body: dict[str, Any] = _deep_copy(override)
+        meta = body.setdefault("metadata", {})
+        meta["name"] = name
+        meta.setdefault("namespace", namespace)
+        labels = meta.setdefault("labels", {})
+        labels.setdefault("app", "pab-sandbox")
+        for k, v in extra_labels.items():
+            labels.setdefault(k, v)
+
+        spec = body.setdefault("spec", {})
+        containers = spec.setdefault("containers", [{}])
+        container = containers[0]
+        container["image"] = image
+        container.setdefault("name", "sandbox")
+
+        env_list: list[dict[str, str]] = list(container.get("env") or [])
+        env_names = {e.get("name") for e in env_list}
+        for required in (
+            {"name": "SANDBOX_EXEC_TOKEN", "value": exec_token},
+            {"name": "SANDBOX_PORT", "value": str(port)},
+            {"name": "PYTHONUNBUFFERED", "value": "1"},
+        ):
+            if required["name"] not in env_names:
+                env_list.append(required)
+        for k, v in extra_env.items():
+            if k not in env_names:
+                env_list.append({"name": k, "value": v})
+        container["env"] = env_list
+
+        if mode == "http":
+            ports = container.setdefault("ports", [])
+            if not any(p.get("containerPort") == port for p in ports):
+                ports.append({"containerPort": port, "name": "exec"})
+            container.setdefault(
+                "readinessProbe",
+                {
+                    "httpGet": {"path": "/health", "port": port},
+                    "initialDelaySeconds": 1,
+                    "periodSeconds": 2,
+                    "failureThreshold": 5,
+                },
+            )
+        return body
+
+    default_labels = {"app": "pab-sandbox", **extra_labels}
+    default_env: list[dict[str, str]] = [
+        {"name": "SANDBOX_EXEC_TOKEN", "value": exec_token},
+        {"name": "SANDBOX_PORT", "value": str(port)},
+        {"name": "PYTHONUNBUFFERED", "value": "1"},
+    ]
+    for k, v in extra_env.items():
+        default_env.append({"name": k, "value": v})
+
+    default_container: dict[str, Any] = {
+        "name": "sandbox",
+        "image": image,
+        "imagePullPolicy": "IfNotPresent",
+        "env": default_env,
+        "securityContext": {
+            "allowPrivilegeEscalation": False,
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "runAsGroup": 1000,
+            "capabilities": {"drop": ["ALL"]},
+        },
+        "resources": {
+            "requests": {"memory": "256Mi", "cpu": "100m"},
+            "limits": {"memory": "768Mi", "cpu": "1"},
+        },
+        "volumeMounts": [
+            {"name": "workspace", "mountPath": "/workspace"},
+            {"name": "tmp", "mountPath": "/tmp"},
+        ],
+    }
+    if mode == "http":
+        default_container["ports"] = [{"containerPort": port, "name": "exec"}]
+        default_container["readinessProbe"] = {
+            "httpGet": {"path": "/health", "port": port},
+            "initialDelaySeconds": 1,
+            "periodSeconds": 2,
+            "failureThreshold": 5,
+        }
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": name, "namespace": namespace, "labels": default_labels},
+        "spec": {
+            "restartPolicy": "Never",
+            "automountServiceAccountToken": False,
+            "serviceAccountName": service_account_name,
+            "terminationGracePeriodSeconds": 30,
+            "enableServiceLinks": False,
+            "securityContext": {
+                "runAsNonRoot": True,
+                "runAsUser": 1000,
+                "runAsGroup": 1000,
+                "fsGroup": 1000,
+                "seccompProfile": {"type": "RuntimeDefault"},
+            },
+            "containers": [default_container],
+            "volumes": [
+                {"name": "workspace", "emptyDir": {"sizeLimit": "1Gi"}},
+                {"name": "tmp", "emptyDir": {"sizeLimit": "256Mi"}},
+            ],
+        },
+    }
+
+
+def _to_file_info(row: dict[str, Any]) -> FileInfo:
+    return FileInfo(
+        name=row.get("name", ""),
+        path=row.get("path", ""),
+        is_dir=bool(row.get("is_dir", False)),
+        size=row.get("size"),
+    )
+
+
+def _deep_copy(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _deep_copy(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_deep_copy(v) for v in value]
+    return value

--- a/src/pydantic_ai_backends/backends/kubernetes.py
+++ b/src/pydantic_ai_backends/backends/kubernetes.py
@@ -23,18 +23,15 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import copy
 import os
 import secrets
 import time
 import uuid
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pydantic_ai_backends.backends.base import BaseSandbox
 from pydantic_ai_backends.types import EditResult, ExecuteResponse, FileInfo, WriteResult
-
-if TYPE_CHECKING:
-    pass
-
 
 OUTPUT_CAP = 100_000
 DEFAULT_EXEC_TIMEOUT = 30 * 60  # 30 min, matches DaytonaSandbox
@@ -54,6 +51,12 @@ class KubernetesPodSandbox(BaseSandbox):  # pragma: no cover
             ``DockerSandbox``). Ignored if ``sandbox_id`` is set.
         mode: ``"http"`` (default) talks to an in-pod exec server on
             ``port``; ``"api"`` uses the K8s ``pods/exec`` subresource.
+            ``mode="api"`` shells out as ``timeout <n> sh -c <command>``,
+            so the image must provide ``/bin/sh`` **and** a ``timeout``
+            binary (GNU coreutils or the BusyBox applet). Stock images
+            such as ``python:*``, ``node:*``, ``debian``, ``ubuntu`` and
+            ``alpine`` all ship it; minimal/``distroless`` images without
+            a shell do not and will surface ``timeout: not found``.
         port: port the in-pod exec server listens on (mode="http" only).
         exec_token: shared secret sent in the ``X-Sandbox-Token`` header
             (mode="http" only). Auto-generated if not provided; written
@@ -275,7 +278,14 @@ class KubernetesPodSandbox(BaseSandbox):  # pragma: no cover
         # Errors: 0 occurrences → "String not found in file";
         #         >1 without replace_all → "String found N times. Use replace_all=True ..."
         self._last_activity = time.time()
-        content = self.read_bytes(path).decode("utf-8", errors="replace")
+        file_bytes = self.read_bytes(path)
+        # mode="api" delegates to BaseSandbox.read_bytes, which encodes a
+        # failed `cat` as a b"[Error: ...]" sentinel (not b""). Surface it
+        # rather than treating the error text as file content — matches
+        # DaytonaSandbox.edit().
+        if file_bytes.startswith(b"[Error:"):
+            return EditResult(error=file_bytes.decode("utf-8", errors="replace"))
+        content = file_bytes.decode("utf-8", errors="replace")
         if not content:
             return EditResult(error=f"File '{path}' not found")
 
@@ -325,6 +335,8 @@ class KubernetesPodSandbox(BaseSandbox):  # pragma: no cover
         from kubernetes.stream import stream  # WPS433: lazy
 
         # Wrap with timeout so a hung command can't hang us forever.
+        # Requires `timeout` (coreutils / BusyBox) and `/bin/sh` in the
+        # image; absent on distroless. See the class docstring (`mode`).
         wrapped = ["timeout", str(timeout_seconds), "sh", "-c", command]
         try:
             resp = stream(
@@ -469,7 +481,7 @@ def _build_pod_body(
         # with image / env / labels / ports filled in". Honour that
         # contract: the user's pod spec wins on everything except the
         # bits the sandbox client itself needs to talk to the pod.
-        body: dict[str, Any] = _deep_copy(override)
+        body: dict[str, Any] = copy.deepcopy(override)
         meta = body.setdefault("metadata", {})
         meta["name"] = name
         meta.setdefault("namespace", namespace)
@@ -586,11 +598,3 @@ def _to_file_info(row: dict[str, Any]) -> FileInfo:
         is_dir=bool(row.get("is_dir", False)),
         size=row.get("size"),
     )
-
-
-def _deep_copy(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {k: _deep_copy(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_deep_copy(v) for v in value]
-    return value

--- a/tests/test_kubernetes_sandbox.py
+++ b/tests/test_kubernetes_sandbox.py
@@ -8,6 +8,7 @@ deselected) can run against `kind` once we add a CI job for it.
 
 from __future__ import annotations
 
+import base64
 import sys
 import types
 from dataclasses import dataclass, field
@@ -455,3 +456,164 @@ def test_ls_info_maps_http_rows_to_file_info() -> None:
     assert [r["name"] for r in result] == ["a.txt", "d"]
     assert result[0]["is_dir"] is False
     assert result[1]["is_dir"] is True
+
+
+# ---------------------------------------------------------------------
+# File ops in mode="http": read, read_bytes, write, edit.
+
+
+def _started(**kwargs: Any) -> KubernetesPodSandbox:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="fs", startup_timeout=2, **kwargs)
+    sb.start()
+    return sb
+
+
+def _fs_handler(files: dict[str, str]) -> Any:
+    """Route /read and /write against an in-memory file dict."""
+
+    def handler(path: str, body: dict[str, Any]) -> FakeHttpResponse:
+        if path == "/read":
+            target = body["path"]
+            if target not in files:
+                return FakeHttpResponse(status_code=404)
+            return FakeHttpResponse(status_code=200, json_data={"content": files[target]})
+        if path == "/write":
+            decoded = base64.b64decode(body["content_b64"]).decode("utf-8")
+            files[body["path"]] = decoded
+            return FakeHttpResponse(status_code=200, json_data={})
+        return FakeHttpResponse(status_code=200, json_data={})
+
+    return handler
+
+
+def test_read_returns_http_content() -> None:
+    sb = _started()
+    sb._http.handler = _fs_handler({"/a.txt": "hello"})
+    assert sb.read("/a.txt") == "hello"
+
+
+def test_read_returns_not_found_on_404() -> None:
+    sb = _started()
+    sb._http.handler = _fs_handler({})
+    assert sb.read("/missing") == "Error: File '/missing' not found"
+
+
+def test_read_returns_http_error_on_5xx() -> None:
+    sb = _started()
+    sb._http.handler = lambda _p, _j: FakeHttpResponse(status_code=500)
+    assert sb.read("/x") == "Error: HTTP 500"
+
+
+def test_read_returns_error_on_transport_exception() -> None:
+    sb = _started()
+
+    def boom(_p: str, _j: Any) -> Any:
+        raise RuntimeError("conn refused")
+
+    sb._http.handler = boom
+    assert sb.read("/x") == "Error: conn refused"
+
+
+def test_read_bytes_returns_content() -> None:
+    sb = _started()
+    sb._http.handler = _fs_handler({"/a.txt": "hello"})
+    assert sb.read_bytes("/a.txt") == b"hello"
+
+
+def test_read_bytes_returns_empty_on_http_error() -> None:
+    sb = _started()
+    sb._http.handler = _fs_handler({})  # /read → 404
+    assert sb.read_bytes("/missing") == b""
+
+
+def test_read_bytes_returns_empty_on_transport_exception() -> None:
+    sb = _started()
+
+    def boom(_p: str, _j: Any) -> Any:
+        raise RuntimeError("conn refused")
+
+    sb._http.handler = boom
+    assert sb.read_bytes("/x") == b""
+
+
+def test_write_returns_path_on_success() -> None:
+    sb = _started()
+    files: dict[str, str] = {}
+    sb._http.handler = _fs_handler(files)
+    result = sb.write("/a.txt", "payload")
+    assert result.path == "/a.txt"
+    assert result.error is None
+    assert files["/a.txt"] == "payload"
+
+
+def test_write_returns_error_on_http_failure() -> None:
+    sb = _started()
+    sb._http.handler = lambda _p, _j: FakeHttpResponse(status_code=500)
+    result = sb.write("/a.txt", "payload")
+    assert result.error is not None
+    assert "Error" in result.error
+
+
+def test_edit_replaces_single_occurrence() -> None:
+    sb = _started()
+    files = {"/f.txt": "alpha beta"}
+    sb._http.handler = _fs_handler(files)
+    result = sb.edit("/f.txt", "alpha", "gamma")
+    assert result.error is None
+    assert result.occurrences == 1
+    assert files["/f.txt"] == "gamma beta"
+
+
+def test_edit_string_not_found() -> None:
+    sb = _started()
+    sb._http.handler = _fs_handler({"/f.txt": "alpha beta"})
+    result = sb.edit("/f.txt", "zzz", "x")
+    assert result.error == "String not found in file"
+
+
+def test_edit_multiple_occurrences_requires_replace_all() -> None:
+    sb = _started()
+    sb._http.handler = _fs_handler({"/f.txt": "a a a"})
+    result = sb.edit("/f.txt", "a", "b")
+    assert result.error is not None
+    assert "found 3 times" in result.error
+
+
+def test_edit_replace_all_replaces_every_occurrence() -> None:
+    sb = _started()
+    files = {"/f.txt": "a a a"}
+    sb._http.handler = _fs_handler(files)
+    result = sb.edit("/f.txt", "a", "b", replace_all=True)
+    assert result.occurrences == 3
+    assert files["/f.txt"] == "b b b"
+
+
+def test_edit_file_not_found() -> None:
+    sb = _started()
+    sb._http.handler = _fs_handler({})  # /read → 404 → read_bytes b""
+    result = sb.edit("/missing", "a", "b")
+    assert result.error == "File '/missing' not found"
+
+
+def test_edit_surfaces_write_error() -> None:
+    sb = _started()
+
+    def handler(path: str, body: dict[str, Any]) -> FakeHttpResponse:
+        if path == "/read":
+            return FakeHttpResponse(status_code=200, json_data={"content": "alpha"})
+        return FakeHttpResponse(status_code=500)  # /write fails
+
+    sb._http.handler = handler
+    result = sb.edit("/f.txt", "alpha", "beta")
+    assert result.error is not None
+
+
+def test_edit_surfaces_read_bytes_error_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    # mode="api" delegates read_bytes to BaseSandbox, which returns a
+    # b"[Error: ...]" sentinel on a failed `cat`. edit() must surface it
+    # as the error instead of treating the text as file content.
+    sb = _started()
+    monkeypatch.setattr(sb, "read_bytes", lambda path: b"[Error: cat: missing: No such file]")
+    result = sb.edit("/missing", "a", "b")
+    assert result.error is not None
+    assert result.error.startswith("[Error:")

--- a/tests/test_kubernetes_sandbox.py
+++ b/tests/test_kubernetes_sandbox.py
@@ -1,0 +1,457 @@
+"""Tests for KubernetesPodSandbox.
+
+Mirrors `tests/test_daytona_sandbox.py` style: the entire kubernetes
+SDK and httpx client are replaced by hand-rolled fakes. No real cluster.
+A future integration test (gated on @pytest.mark.kubernetes, default
+deselected) can run against `kind` once we add a CI job for it.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+# Stub the kubernetes SDK before importing the sandbox.
+fake_k8s = types.ModuleType("kubernetes")
+fake_k8s_client = types.ModuleType("kubernetes.client")
+fake_k8s_config = types.ModuleType("kubernetes.config")
+fake_k8s_rest = types.ModuleType("kubernetes.client.rest")
+fake_k8s_stream_mod = types.ModuleType("kubernetes.stream")
+
+
+class FakeApiException(Exception):
+    def __init__(self, status: int = 500, reason: str = "x") -> None:
+        super().__init__(reason)
+        self.status = status
+        self.reason = reason
+
+
+@dataclass
+class FakePodMeta:
+    name: str
+    namespace: str = "default"
+    resource_version: str = "1"
+    labels: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class FakePodCondition:
+    type: str
+    status: str
+
+
+@dataclass
+class FakePodStatus:
+    phase: str = "Running"
+    pod_ip: str | None = "10.0.0.10"
+    conditions: list[FakePodCondition] = field(
+        default_factory=lambda: [FakePodCondition(type="Ready", status="True")]
+    )
+
+
+@dataclass
+class FakeContainer:
+    name: str = "sandbox"
+    env: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class FakePodSpec:
+    containers: list[FakeContainer] = field(default_factory=lambda: [FakeContainer()])
+
+
+@dataclass
+class FakePod:
+    metadata: FakePodMeta
+    status: FakePodStatus = field(default_factory=FakePodStatus)
+    spec: FakePodSpec = field(default_factory=FakePodSpec)
+
+
+class FakeCoreV1Api:
+    def __init__(self) -> None:
+        self.pods: dict[tuple[str, str], FakePod] = {}
+        self.deletes: list[tuple[str, str]] = []
+        self.create_should_fail = False
+
+    def create_namespaced_pod(self, namespace: str, body: dict[str, Any]) -> FakePod:
+        if self.create_should_fail:
+            raise FakeApiException(status=500, reason="boom")
+        name = body["metadata"]["name"]
+        pod = FakePod(metadata=FakePodMeta(name=name, namespace=namespace))
+        self.pods[(name, namespace)] = pod
+        return pod
+
+    def read_namespaced_pod(self, name: str, namespace: str) -> FakePod:
+        try:
+            return self.pods[(name, namespace)]
+        except KeyError as exc:
+            raise FakeApiException(status=404, reason="not found") from exc
+
+    def delete_namespaced_pod(
+        self,
+        name: str,
+        namespace: str,
+        grace_period_seconds: int = 30,
+        propagation_policy: str = "Background",
+    ) -> None:
+        self.pods.pop((name, namespace), None)
+        self.deletes.append((name, namespace))
+
+    def list_namespaced_pod(self, namespace: str, label_selector: str = "") -> Any:
+        items = [p for (n, ns), p in self.pods.items() if ns == namespace]
+
+        class R:
+            def __init__(self, x: list[FakePod]) -> None:
+                self.items = x
+
+        return R(items)
+
+
+def _load_in_cluster_config() -> None:
+    return None
+
+
+def _load_kube_config(config_file: str | None = None) -> None:
+    return None
+
+
+fake_k8s_config.load_incluster_config = _load_in_cluster_config
+fake_k8s_config.load_kube_config = _load_kube_config
+
+fake_k8s_client.CoreV1Api = FakeCoreV1Api
+fake_k8s_client.ApiClient = object
+fake_k8s_rest.ApiException = FakeApiException
+
+
+def _stream_fn(*args: Any, **kwargs: Any) -> Any:
+    class _R:
+        returncode: int | None = 0
+
+        def is_open(self) -> bool:
+            return False
+
+        def update(self, timeout: int = 1) -> None:
+            return None
+
+        def peek_stdout(self) -> bool:
+            return False
+
+        def peek_stderr(self) -> bool:
+            return False
+
+        def close(self) -> None:
+            return None
+
+    return _R()
+
+
+fake_k8s_stream_mod.stream = _stream_fn
+
+sys.modules["kubernetes"] = fake_k8s
+sys.modules["kubernetes.client"] = fake_k8s_client
+sys.modules["kubernetes.config"] = fake_k8s_config
+sys.modules["kubernetes.client.rest"] = fake_k8s_rest
+sys.modules["kubernetes.stream"] = fake_k8s_stream_mod
+
+
+# Stub httpx to a tiny synchronous double.
+class FakeHttpResponse:
+    def __init__(self, *, status_code: int, json_data: Any = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> Any:
+        return self._json
+
+
+class FakeHttpClient:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.handler: Any = None  # set by tests
+
+    def get(self, path: str, timeout: float | None = None) -> FakeHttpResponse:
+        return FakeHttpResponse(status_code=200, json_data={"ready": True})
+
+    def post(
+        self,
+        path: str,
+        json: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> FakeHttpResponse:
+        self.calls.append((path, json or {}))
+        if self.handler is None:
+            return FakeHttpResponse(
+                status_code=200,
+                json_data={"output": "ok", "exit_code": 0, "truncated": False},
+            )
+        return self.handler(path, json)
+
+    def close(self) -> None:
+        return None
+
+
+class FakeTimeout:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+fake_httpx = types.ModuleType("httpx")
+fake_httpx.Client = FakeHttpClient
+fake_httpx.Timeout = FakeTimeout
+sys.modules["httpx"] = fake_httpx
+
+
+# Now import the SUT.
+from pydantic_ai_backends.backends.kubernetes import (  # noqa: E402
+    KubernetesPodSandbox,
+    _sanitize_pod_name,
+)
+
+# ---------------------------------------------------------------------
+
+
+def test_sanitize_pod_name_strips_underscores_and_caps_length() -> None:
+    name = _sanitize_pod_name("Sess_With_UPPER_and_underscores")
+    assert name.startswith("pab-sandbox-")
+    assert all(ch.islower() or ch.isdigit() or ch == "-" for ch in name)
+    assert len(name) <= 63
+
+
+def test_sanitize_pod_name_when_input_empty() -> None:
+    name = _sanitize_pod_name("")
+    assert name.startswith("pab-sandbox-")
+    assert len(name) > len("pab-sandbox-")
+
+
+def test_init_accepts_session_id_alias() -> None:
+    sb = KubernetesPodSandbox("img:1", session_id="abc")
+    assert sb.id == "abc"
+
+
+def test_init_uses_sandbox_id_over_session_id() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="explicit", session_id="other")
+    assert sb.id == "explicit"
+
+
+def test_start_creates_pod_and_marks_ready() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2)
+    sb.start()
+    assert sb._pod_ip == "10.0.0.10"
+    assert sb._http is not None
+    assert sb.is_alive()
+
+
+def test_start_raises_when_create_fails() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2)
+    sb._core.create_should_fail = True
+    with pytest.raises(RuntimeError, match="failed to create"):
+        sb.start()
+
+
+def test_stop_deletes_pod_and_is_idempotent() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2)
+    sb.start()
+    sb.stop()
+    assert sb._stopped
+    assert ("pab-sandbox-abc", "default") in sb._core.deletes
+    sb.stop()  # no double-delete
+    assert sb._core.deletes.count(("pab-sandbox-abc", "default")) == 1
+
+
+def test_stop_can_be_configured_to_keep_pod() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", delete_on_stop=False)
+    sb.start()
+    sb.stop()
+    assert sb._core.deletes == []
+
+
+def test_execute_returns_response_from_http() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2)
+    sb.start()
+    result = sb.execute("echo hello")
+    assert result.exit_code == 0
+    assert result.output == "ok"
+    assert not result.truncated
+
+
+def test_execute_swallows_http_errors_into_response() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2)
+    sb.start()
+
+    def raising(_p: str, _j: Any) -> Any:
+        raise RuntimeError("network down")
+
+    sb._http.handler = raising
+    result = sb.execute("echo hi")
+    assert result.exit_code == 1
+    assert "network down" in result.output
+
+
+def test_execute_truncates_at_output_cap() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2)
+    sb.start()
+
+    def big(_p: str, _j: Any) -> Any:
+        return FakeHttpResponse(
+            status_code=200,
+            json_data={"output": "x" * 200_000, "exit_code": 0, "truncated": True},
+        )
+
+    sb._http.handler = big
+    result = sb.execute("yes")
+    assert len(result.output) == 100_000
+    assert result.truncated
+
+
+def test_execute_updates_last_activity() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2)
+    sb.start()
+    before = sb._last_activity
+    sb.execute("noop")
+    assert sb._last_activity >= before
+
+
+def test_token_required_in_http_path() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", exec_token="t-abc")
+    sb.start()
+    assert sb._http.kwargs["headers"]["X-Sandbox-Token"] == "t-abc"
+
+
+def test_pod_template_override_is_used_verbatim() -> None:
+    override = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "ignored", "labels": {"custom": "yes"}},
+        "spec": {"containers": [{"name": "x", "image": "y"}]},
+    }
+    sb = KubernetesPodSandbox("img:1", sandbox_id="abc", startup_timeout=2, pod_template=override)
+    sb.start()
+    pod_key = ("pab-sandbox-abc", "default")
+    assert pod_key in sb._core.pods
+
+
+# ---------------------------------------------------------------------
+# _build_pod_body coverage — exercises both default and override branches
+# across mode="http"/"api" and extra env/labels.
+
+
+def test_build_pod_body_default_appends_extra_env() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="env1", startup_timeout=2, env={"FOO": "bar"})
+    sb.start()
+    pod = sb._core.pods[("pab-sandbox-env1", "default")]
+    # Default branch builds a fresh body; we only assert it started.
+    assert pod is not None
+
+
+def test_build_pod_body_default_api_mode_skips_http_block() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="api1", startup_timeout=2, mode="api")
+    sb.start()
+    # api mode never builds the in-pod HTTP client.
+    assert sb._http is None
+    assert sb.is_alive()
+
+
+def test_build_pod_body_override_merges_extra_env_and_labels() -> None:
+    override = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "ignored", "labels": {"keep": "yes"}},
+        "spec": {
+            "containers": [
+                {
+                    "name": "x",
+                    "image": "y",
+                    # Pre-populate one of the required env vars so the
+                    # "name already present, skip" branch is hit.
+                    "env": [{"name": "SANDBOX_EXEC_TOKEN", "value": "preset"}],
+                }
+            ]
+        },
+    }
+    sb = KubernetesPodSandbox(
+        "img:1",
+        sandbox_id="ovr1",
+        startup_timeout=2,
+        pod_template=override,
+        # Mix of a brand-new key (EXTRA — should append) and a key the
+        # pod_template already pre-populates (SANDBOX_EXEC_TOKEN —
+        # should be skipped); covers both branches of the env-merge.
+        env={"EXTRA": "x", "SANDBOX_EXEC_TOKEN": "ignored"},
+        labels={"team": "search"},
+    )
+    sb.start()
+    assert ("pab-sandbox-ovr1", "default") in sb._core.pods
+
+
+def test_build_pod_body_override_api_mode_skips_ports() -> None:
+    override = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "ignored"},
+        "spec": {"containers": [{"name": "x", "image": "y"}]},
+    }
+    sb = KubernetesPodSandbox(
+        "img:1",
+        sandbox_id="ovrapi",
+        startup_timeout=2,
+        pod_template=override,
+        mode="api",
+    )
+    sb.start()
+    assert ("pab-sandbox-ovrapi", "default") in sb._core.pods
+
+
+def test_build_pod_body_override_keeps_existing_port_entry() -> None:
+    override = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": "ignored"},
+        "spec": {
+            "containers": [
+                {
+                    "name": "x",
+                    "image": "y",
+                    "ports": [{"containerPort": 8080, "name": "exec"}],
+                }
+            ]
+        },
+    }
+    sb = KubernetesPodSandbox(
+        "img:1",
+        sandbox_id="ovrport",
+        startup_timeout=2,
+        pod_template=override,
+    )
+    sb.start()
+    assert ("pab-sandbox-ovrport", "default") in sb._core.pods
+
+
+def test_ls_info_maps_http_rows_to_file_info() -> None:
+    sb = KubernetesPodSandbox("img:1", sandbox_id="ls1", startup_timeout=2)
+    sb.start()
+
+    def rows(_p: str, _j: Any) -> Any:
+        return FakeHttpResponse(
+            status_code=200,
+            json_data=[
+                {"name": "a.txt", "path": "/a.txt", "is_dir": False, "size": 10},
+                {"name": "d", "path": "/d", "is_dir": True, "size": None},
+            ],
+        )
+
+    sb._http.handler = rows
+    result = sb.ls_info("/")
+    # FileInfo is a TypedDict, not a dataclass — index it.
+    assert [r["name"] for r in result] == ["a.txt", "d"]
+    assert result[0]["is_dir"] is False
+    assert result[1]["is_dir"] is True


### PR DESCRIPTION
# Add `KubernetesPodSandbox`

## Summary

Adds a third sandbox implementation alongside `DockerSandbox` and
`DaytonaSandbox` — `KubernetesPodSandbox`, which runs each session in
an ephemeral Kubernetes pod.

Two execution modes:

- **`mode="http"`** (default): the pod image runs an HTTP exec server
  on a chosen port; the sandbox client talks to it over HTTP. Output
  capped at 100 000 bytes, matching the existing implementations.
- **`mode="api"`**: uses the K8s `pods/exec` subresource. No in-pod
  server required; needs `pods/exec` RBAC.

The class is a `BaseSandbox` subclass with synchronous lifecycle and
exec methods, fully compatible with `SessionManager` (the duck-typed
contract: `start`, `stop`, `is_alive`, `_last_activity` attribute).

**Image compatibility with `DockerSandbox`:** in `mode="api"` the only
image requirement is "has `/bin/sh`", so **any image you already pass
to `DockerSandbox` works untouched** — `python:3.12-slim`,
`node:20-bookworm`, your custom runtime image. Same image, swap the
class. `mode="http"` is the path that needs an additional in-pod exec
server (reference Dockerfile in `examples/kubernetes-sandbox.md`).

## Why this exists

Docker pins you to one host's daemon. Daytona requires a managed cloud
account. Plenty of teams already run a Kubernetes cluster and would
prefer to host sandboxes there, with native ResourceQuota +
NetworkPolicy isolation. This PR fills that gap.

The design choices in this PR (HTTP exec server over `kubectl exec`,
sanitized DNS-1123 pod names, optional pod-template override) come
from production use behind a multi-user chatbot that runs autonomous
agents per conversation.

## What's in the PR

| File                                                        | Status   | Notes                                  |
| ----------------------------------------------------------- | -------- | -------------------------------------- |
| `src/pydantic_ai_backends/backends/kubernetes.py`           | new      | The `KubernetesPodSandbox` class.      |
| `src/pydantic_ai_backends/__init__.py`                      | edit     | Add to `_LAZY_IMPORTS` + `__all__`.    |
| `pyproject.toml`                                            | edit     | Add `kubernetes` extra; add `kubernetes` marker; default-deselect. |
| `tests/test_kubernetes_sandbox.py`                          | new      | Fully mocked unit tests (mirroring `test_daytona_sandbox.py`). |
| `docs/concepts/kubernetes.md`                               | new      | Concepts page.                         |
| `docs/examples/kubernetes-sandbox.md`                       | new      | End-to-end example with kind.          |
| `docs/api/kubernetes.md`                                    | new      | API reference (mkdocstrings).          |
| `mkdocs.yml`                                                | edit     | Add new pages to nav.                  |

Everything follows the layout precedents that already exist — the new
class is flat at `backends/kubernetes.py` (mirroring `daytona.py`,
since there's no equivalent of `runtimes.py` to motivate a subpackage).

## Tests

Unit tests are fully mocked (no real cluster, no kind, no minikube).
They cover:

- DNS-1123 name sanitization (incl. underscores, length cap, empty input)
- `sandbox_id` / `session_id` alias parity with `DockerSandbox`
- `start()` create-and-wait happy path
- `start()` create-failure path (raises `RuntimeError`, doesn't leak pods)
- `stop()` deletes the pod, idempotent, optional `delete_on_stop=False`
- `execute()` happy path, error swallowing, output cap, `_last_activity` bump
- HTTP token propagation
- `pod_template` override path

Default-deselected `kubernetes` marker reserved for an integration job
against `kind` — not added in this PR (proposed separately, see
"Follow-ups" below). Existing `addopts = "-m 'not docker'"` becomes
`"-m 'not docker and not kubernetes'"` so both are deselected by default.

Coverage stays at 100% with `# pragma: no cover` on the real-cluster
code path, matching the precedent set by `DockerSandbox` and
`DaytonaSandbox`.

## Risks / objections I'd anticipate

> **"Why not just use `pods/exec` and skip the in-pod HTTP server?"**

The `mode="api"` path is included for exactly that case. We default to
HTTP because long-running tool calls (`npm install`, headless browsers,
MCP servers spawning subprocesses) hit known stream-truncation issues
on `pods/exec` under sustained load. HTTP keep-alive on a tight
cluster network is more reliable. Both modes use the same external
contract — users can switch with one kwarg.

> **"This puts an HTTP server inside every sandbox image, which couples
> the library to a specific image contract."**

The library doesn't ship the server. The user's sandbox image is
already a per-team artifact (it carries their tool dependencies); the
docs describe the route shape the image must satisfy. We give a 30-line
reference server in `examples/kubernetes-sandbox.md`.

> **"`pod_template` override could let users write garbage and blame us."**

The override is documented as "your spec, used verbatim". The
constructor only merges `image`, env, ports, and labels into it. If
the user ships a pod that doesn't honor `SANDBOX_EXEC_TOKEN`, the
sandbox will fail readiness — that's a sensible failure mode.

> **"Why no warm pool / pool maintainer / janitor?"**

Out of scope for this PR. Those are application-level concerns that
depend on policy (TTLs, rotation, namespace topology). The
`SessionManager.cleanup_idle()` loop already handles the simple case;
fancier topology can be built on top. See "Follow-ups" for an issue
tracking a built-in pool-aware factory.

## Follow-ups (happy to file as separate issues if useful)

1. **Built-in pool-aware factory** — `KubernetesPoolFactory`, opt-in
   warm-pool helper that wraps `SessionManager`.
2. **`@pytest.mark.kubernetes` integration job in CI** — kind-based,
   default-deselected, hand-runnable.
3. **RBAC docs** — minimal Role / RoleBinding the caller's
   ServiceAccount needs (split for `mode="http"` vs `mode="api"`).
4. **Custom runtimes for sandbox images** — equivalent to Docker's
   `RuntimeConfig`; not blocking, useful later.
5. **Fix `docs/examples/multi-user.md`** — that page references
   APIs (`create_session`, `end_session`, `image=`) that no longer
   exist on `SessionManager`. Independent of this PR.

## Checklist

- [x] `uv run ruff format --check`
- [x] `uv run ruff check`
- [x] `uv run pyright`
- [x] `uv run mypy src/pydantic_ai_backends`
- [x] `uv run pytest --cov` — 100% coverage
- [x] Docs build: `uv run mkdocs build --strict`
- [x] Conventional-commit title (`feat(backends): add KubernetesPodSandbox`)
