### PR TITLE
feat(console): return PDFs as BinaryContent in read_file

### DIFF
--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -98,7 +98,9 @@ if TYPE_CHECKING:
         create_ruleset,
     )
     from pydantic_ai_backends.toolsets.console import (
+        DEFAULT_MAX_DOCUMENT_BYTES,
         DEFAULT_MAX_IMAGE_BYTES,
+        DOCUMENT_EXTENSIONS,
         DOCUMENT_MEDIA_TYPES,
         EDIT_FILE_DESCRIPTION,
         EXECUTE_DESCRIPTION,
@@ -144,8 +146,10 @@ _LAZY_IMPORTS = {
     "EXECUTE_DESCRIPTION": "pydantic_ai_backends.toolsets.console",
     "IMAGE_EXTENSIONS": "pydantic_ai_backends.toolsets.console",
     "IMAGE_MEDIA_TYPES": "pydantic_ai_backends.toolsets.console",
-    "DOCUMENT_MEDIA_TYPES": "pydantic_ai_backends.toolsets.console",
     "DEFAULT_MAX_IMAGE_BYTES": "pydantic_ai_backends.toolsets.console",
+    "DOCUMENT_EXTENSIONS": "pydantic_ai_backends.toolsets.console",
+    "DOCUMENT_MEDIA_TYPES": "pydantic_ai_backends.toolsets.console",
+    "DEFAULT_MAX_DOCUMENT_BYTES": "pydantic_ai_backends.toolsets.console",
     # Daytona sandbox (requires daytona extra)
     "DaytonaSandbox": "pydantic_ai_backends.backends.daytona",
     # Docker sandbox (requires docker extra)
@@ -227,11 +231,14 @@ __all__ = [
     "GLOB_DESCRIPTION",
     "GREP_DESCRIPTION",
     "EXECUTE_DESCRIPTION",
-    # Image/document support constants
+    # Image support constants
     "IMAGE_EXTENSIONS",
     "IMAGE_MEDIA_TYPES",
-    "DOCUMENT_MEDIA_TYPES",
     "DEFAULT_MAX_IMAGE_BYTES",
+    # Document support constants
+    "DOCUMENT_EXTENSIONS",
+    "DOCUMENT_MEDIA_TYPES",
+    "DEFAULT_MAX_DOCUMENT_BYTES",
     # Daytona sandbox (optional - requires daytona extra)
     "DaytonaSandbox",
     # Docker sandbox (optional - requires docker extra)

--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
     )
     from pydantic_ai_backends.toolsets.console import (
         DEFAULT_MAX_IMAGE_BYTES,
+        DOCUMENT_MEDIA_TYPES,
         EDIT_FILE_DESCRIPTION,
         EXECUTE_DESCRIPTION,
         GLOB_DESCRIPTION,
@@ -143,6 +144,7 @@ _LAZY_IMPORTS = {
     "EXECUTE_DESCRIPTION": "pydantic_ai_backends.toolsets.console",
     "IMAGE_EXTENSIONS": "pydantic_ai_backends.toolsets.console",
     "IMAGE_MEDIA_TYPES": "pydantic_ai_backends.toolsets.console",
+    "DOCUMENT_MEDIA_TYPES": "pydantic_ai_backends.toolsets.console",
     "DEFAULT_MAX_IMAGE_BYTES": "pydantic_ai_backends.toolsets.console",
     # Daytona sandbox (requires daytona extra)
     "DaytonaSandbox": "pydantic_ai_backends.backends.daytona",
@@ -225,9 +227,10 @@ __all__ = [
     "GLOB_DESCRIPTION",
     "GREP_DESCRIPTION",
     "EXECUTE_DESCRIPTION",
-    # Image support constants
+    # Image/document support constants
     "IMAGE_EXTENSIONS",
     "IMAGE_MEDIA_TYPES",
+    "DOCUMENT_MEDIA_TYPES",
     "DEFAULT_MAX_IMAGE_BYTES",
     # Daytona sandbox (optional - requires daytona extra)
     "DaytonaSandbox",

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -28,6 +28,15 @@ IMAGE_MEDIA_TYPES: dict[str, str] = {
 }
 """Mapping of file extensions to MIME media types for images."""
 
+DOCUMENT_MEDIA_TYPES: dict[str, str] = {
+    "pdf": "application/pdf",
+}
+"""Mapping of file extensions to MIME media types for binary documents.
+
+These are returned as ``BinaryContent`` (like images) so that multimodal models
+capable of document understanding (OpenAI/Anthropic/Gemini) can read them
+directly instead of receiving garbled or empty text."""
+
 DEFAULT_MAX_IMAGE_BYTES: int = 50 * 1024 * 1024
 """Default maximum image file size (50MB)."""
 
@@ -288,6 +297,47 @@ def _is_denied_by_ruleset(
 _edit_locks: weakref.WeakKeyDictionary[Any, dict[str, asyncio.Lock]] = weakref.WeakKeyDictionary()
 
 
+async def _maybe_binary_content(
+    backend: BackendProtocol,
+    path: str,
+    image_support: bool,
+    max_image_bytes: int,
+) -> BinaryContent | str | None:
+    """Return viewable binary content for images and documents.
+
+    Shared by both ``read_file`` variants (str_replace and hashline) so the
+    image/document handling can't drift between them.
+
+    Returns:
+        - ``BinaryContent`` when ``path`` is a recognized image or document and
+          the file reads successfully within the size limit.
+        - An error string when the file is missing/empty or exceeds the limit.
+        - ``None`` when the file is not a recognized binary type (the caller
+          should fall through to the normal text read).
+    """
+    if not image_support:
+        return None
+
+    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    if ext in IMAGE_EXTENSIONS:
+        media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
+        kind = "Image"
+    elif ext in DOCUMENT_MEDIA_TYPES:
+        media_type = DOCUMENT_MEDIA_TYPES[ext]
+        kind = "Document"
+    else:
+        return None
+
+    raw = await asyncio.to_thread(backend.read_bytes, path)
+    if not raw:
+        return f"Error: {kind} file '{path}' not found or empty"
+    if len(raw) > max_image_bytes:
+        size_mb = len(raw) / (1024 * 1024)
+        limit_mb = max_image_bytes / (1024 * 1024)
+        return f"Error: {kind} '{path}' too large ({size_mb:.1f}MB, max {limit_mb:.1f}MB)"
+    return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
+
+
 def create_console_toolset(  # noqa: C901
     id: str | None = None,
     include_execute: bool = True,
@@ -323,13 +373,16 @@ def create_console_toolset(  # noqa: C901
             When the model sends invalid arguments (e.g. missing required fields),
             the validation error is fed back and the model can retry up to this
             many times. Defaults to 1.
-        image_support: Whether to enable image file handling in read_file.
-            When True, reading image files (.png, .jpg, .jpeg, .gif, .webp) returns
-            a BinaryContent object that multimodal models can see, instead of garbled
-            text. Defaults to False.
-        max_image_bytes: Maximum image file size in bytes (default: 50MB).
-            Images larger than this will return an error message instead.
-            Only used when image_support is True.
+        image_support: Whether to enable binary file handling in read_file.
+            When True, reading image files (.png, .jpg, .jpeg, .gif, .webp) and
+            binary documents (.pdf) returns a BinaryContent object that multimodal
+            models can see, instead of garbled or empty text. PDFs are treated as
+            "viewable binary" under this same flag so capable models
+            (OpenAI/Anthropic/Gemini) can perform document understanding.
+            Defaults to False.
+        max_image_bytes: Maximum binary file size in bytes (default: 50MB).
+            Images and documents larger than this will return an error message
+            instead. Only used when image_support is True.
         edit_format: File editing format to use.  `"str_replace"` (default) uses
             exact string matching.  `"hashline"` tags each line with a content hash
             so models can reference lines by number:hash instead of reproducing text.
@@ -428,21 +481,11 @@ def create_console_toolset(  # noqa: C901
                 offset: Line number to start reading from (0-indexed).
                 limit: Maximum number of lines to read. Defaults to 2000.
             """
-            if image_support:
-                ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
-                if ext in IMAGE_EXTENSIONS:
-                    raw = await asyncio.to_thread(ctx.deps.backend.read_bytes, path)
-                    if not raw:
-                        return f"Error: Image file '{path}' not found or empty"
-                    if len(raw) > max_image_bytes:
-                        size_mb = len(raw) / (1024 * 1024)
-                        limit_mb = max_image_bytes / (1024 * 1024)
-                        return (
-                            f"Error: Image '{path}' too large "
-                            f"({size_mb:.1f}MB, max {limit_mb:.1f}MB)"
-                        )
-                    media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
-                    return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
+            binary = await _maybe_binary_content(
+                ctx.deps.backend, path, image_support, max_image_bytes
+            )
+            if binary is not None:
+                return binary
 
             from pydantic_ai_backends.hashline import format_hashline_output
 
@@ -468,21 +511,11 @@ def create_console_toolset(  # noqa: C901
                 offset: Line number to start reading from (0-indexed).
                 limit: Maximum number of lines to read. Defaults to 2000.
             """
-            if image_support:
-                ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
-                if ext in IMAGE_EXTENSIONS:
-                    raw = await asyncio.to_thread(ctx.deps.backend.read_bytes, path)
-                    if not raw:
-                        return f"Error: Image file '{path}' not found or empty"
-                    if len(raw) > max_image_bytes:
-                        size_mb = len(raw) / (1024 * 1024)
-                        limit_mb = max_image_bytes / (1024 * 1024)
-                        return (
-                            f"Error: Image '{path}' too large "
-                            f"({size_mb:.1f}MB, max {limit_mb:.1f}MB)"
-                        )
-                    media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
-                    return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
+            binary = await _maybe_binary_content(
+                ctx.deps.backend, path, image_support, max_image_bytes
+            )
+            if binary is not None:
+                return binary
             return await asyncio.to_thread(ctx.deps.backend.read, path, offset, limit)
 
     # --- write_file tool ---

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -28,17 +28,27 @@ IMAGE_MEDIA_TYPES: dict[str, str] = {
 }
 """Mapping of file extensions to MIME media types for images."""
 
+DEFAULT_MAX_IMAGE_BYTES: int = 50 * 1024 * 1024
+"""Default maximum image file size (50MB)."""
+
+DOCUMENT_EXTENSIONS: frozenset[str] = frozenset({"pdf"})
+"""File extensions recognized as binary documents when document_support is enabled.
+
+Kept deliberately separate from IMAGE_EXTENSIONS: images and documents are
+distinct content kinds that may eventually be handled differently (e.g. OCR for
+images, native document understanding or text extraction for PDF/DOCX)."""
+
 DOCUMENT_MEDIA_TYPES: dict[str, str] = {
     "pdf": "application/pdf",
 }
-"""Mapping of file extensions to MIME media types for binary documents.
+"""Mapping of document file extensions to MIME media types.
 
-These are returned as ``BinaryContent`` (like images) so that multimodal models
-capable of document understanding (OpenAI/Anthropic/Gemini) can read them
-directly instead of receiving garbled or empty text."""
+Documents are returned as ``BinaryContent`` so that models capable of document
+understanding (OpenAI/Anthropic/Gemini) can read them directly instead of
+receiving garbled or empty text."""
 
-DEFAULT_MAX_IMAGE_BYTES: int = 50 * 1024 * 1024
-"""Default maximum image file size (50MB)."""
+DEFAULT_MAX_DOCUMENT_BYTES: int = 50 * 1024 * 1024
+"""Default maximum document file size (50MB)."""
 
 if TYPE_CHECKING:
     from pydantic_ai.toolsets import FunctionToolset
@@ -297,45 +307,86 @@ def _is_denied_by_ruleset(
 _edit_locks: weakref.WeakKeyDictionary[Any, dict[str, asyncio.Lock]] = weakref.WeakKeyDictionary()
 
 
-async def _maybe_binary_content(
+def _file_extension(path: str) -> str:
+    """Return the lowercase file extension (without the dot), or "" if none."""
+    return path.rsplit(".", 1)[-1].lower() if "." in path else ""
+
+
+async def _read_binary_within_limit(
     backend: BackendProtocol,
     path: str,
-    image_support: bool,
-    max_image_bytes: int,
-) -> BinaryContent | str | None:
-    """Return viewable binary content for images and documents.
+    max_bytes: int,
+    kind: str,
+) -> bytes | str:
+    """Read raw bytes, enforcing the not-found/empty and size-limit guards.
 
-    Shared by both ``read_file`` variants (str_replace and hashline) so the
-    image/document handling can't drift between them.
+    Args:
+        backend: Backend to read from.
+        path: File path to read.
+        max_bytes: Maximum allowed file size in bytes.
+        kind: Human-readable content kind ("Image" / "Document") for error text.
 
     Returns:
-        - ``BinaryContent`` when ``path`` is a recognized image or document and
-          the file reads successfully within the size limit.
-        - An error string when the file is missing/empty or exceeds the limit.
-        - ``None`` when the file is not a recognized binary type (the caller
-          should fall through to the normal text read).
+        The file bytes, or an error string when the file is missing/empty or
+        exceeds ``max_bytes``.
     """
-    if not image_support:
-        return None
-
-    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
-    if ext in IMAGE_EXTENSIONS:
-        media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
-        kind = "Image"
-    elif ext in DOCUMENT_MEDIA_TYPES:
-        media_type = DOCUMENT_MEDIA_TYPES[ext]
-        kind = "Document"
-    else:
-        return None
-
     raw = await asyncio.to_thread(backend.read_bytes, path)
     if not raw:
         return f"Error: {kind} file '{path}' not found or empty"
-    if len(raw) > max_image_bytes:
+    if len(raw) > max_bytes:
         size_mb = len(raw) / (1024 * 1024)
-        limit_mb = max_image_bytes / (1024 * 1024)
+        limit_mb = max_bytes / (1024 * 1024)
         return f"Error: {kind} '{path}' too large ({size_mb:.1f}MB, max {limit_mb:.1f}MB)"
-    return BinaryContent(data=raw, media_type=media_type)  # pyright: ignore[reportCallIssue]
+    return raw
+
+
+async def _maybe_image_content(
+    backend: BackendProtocol,
+    path: str,
+    max_image_bytes: int,
+) -> BinaryContent | str | None:
+    """Return image content for recognized image files.
+
+    Returns:
+        - ``BinaryContent`` when ``path`` is a recognized image read within limit.
+        - An error string when the file is missing/empty or exceeds the limit.
+        - ``None`` when ``path`` is not an image (caller should keep looking).
+    """
+    ext = _file_extension(path)
+    if ext not in IMAGE_EXTENSIONS:
+        return None
+
+    result = await _read_binary_within_limit(backend, path, max_image_bytes, "Image")
+    if isinstance(result, str):
+        return result
+    media_type = IMAGE_MEDIA_TYPES.get(ext, "application/octet-stream")
+    return BinaryContent(data=result, media_type=media_type)  # pyright: ignore[reportCallIssue]
+
+
+async def _maybe_document_content(
+    backend: BackendProtocol,
+    path: str,
+    max_document_bytes: int,
+) -> BinaryContent | str | None:
+    """Return document content for recognized binary document files.
+
+    Kept separate from image handling so document-specific behavior (e.g. OCR or
+    text extraction fallbacks via libraries) can evolve independently.
+
+    Returns:
+        - ``BinaryContent`` when ``path`` is a recognized document read within limit.
+        - An error string when the file is missing/empty or exceeds the limit.
+        - ``None`` when ``path`` is not a document (caller should keep looking).
+    """
+    ext = _file_extension(path)
+    if ext not in DOCUMENT_EXTENSIONS:
+        return None
+
+    result = await _read_binary_within_limit(backend, path, max_document_bytes, "Document")
+    if isinstance(result, str):
+        return result
+    media_type = DOCUMENT_MEDIA_TYPES[ext]
+    return BinaryContent(data=result, media_type=media_type)  # pyright: ignore[reportCallIssue]
 
 
 def create_console_toolset(  # noqa: C901
@@ -348,6 +399,8 @@ def create_console_toolset(  # noqa: C901
     max_retries: int = 1,
     image_support: bool = False,
     max_image_bytes: int = DEFAULT_MAX_IMAGE_BYTES,
+    document_support: bool = False,
+    max_document_bytes: int = DEFAULT_MAX_DOCUMENT_BYTES,
     edit_format: EditFormat = "str_replace",
     descriptions: dict[str, str] | None = None,
 ) -> FunctionToolset[ConsoleDeps]:
@@ -373,16 +426,23 @@ def create_console_toolset(  # noqa: C901
             When the model sends invalid arguments (e.g. missing required fields),
             the validation error is fed back and the model can retry up to this
             many times. Defaults to 1.
-        image_support: Whether to enable binary file handling in read_file.
-            When True, reading image files (.png, .jpg, .jpeg, .gif, .webp) and
-            binary documents (.pdf) returns a BinaryContent object that multimodal
-            models can see, instead of garbled or empty text. PDFs are treated as
-            "viewable binary" under this same flag so capable models
-            (OpenAI/Anthropic/Gemini) can perform document understanding.
+        image_support: Whether to enable image file handling in read_file.
+            When True, reading image files (.png, .jpg, .jpeg, .gif, .webp) returns
+            a BinaryContent object that multimodal models can see, instead of garbled
+            text. Defaults to False.
+        max_image_bytes: Maximum image file size in bytes (default: 50MB).
+            Images larger than this will return an error message instead.
+            Only used when image_support is True.
+        document_support: Whether to enable binary document handling in read_file.
+            When True, reading document files (.pdf) returns a BinaryContent object
+            that models capable of document understanding (OpenAI/Anthropic/Gemini)
+            can read, instead of the empty/garbled text produced by reading a binary
+            file as text. Kept separate from image_support so document handling can
+            evolve independently (e.g. OCR or text-extraction fallbacks).
             Defaults to False.
-        max_image_bytes: Maximum binary file size in bytes (default: 50MB).
-            Images and documents larger than this will return an error message
-            instead. Only used when image_support is True.
+        max_document_bytes: Maximum document file size in bytes (default: 50MB).
+            Documents larger than this will return an error message instead.
+            Only used when document_support is True.
         edit_format: File editing format to use.  `"str_replace"` (default) uses
             exact string matching.  `"hashline"` tags each line with a content hash
             so models can reference lines by number:hash instead of reproducing text.
@@ -412,6 +472,9 @@ def create_console_toolset(  # noqa: C901
 
         # With image support for multimodal models
         toolset = create_console_toolset(image_support=True)
+
+        # With document (PDF) support for document-understanding models
+        toolset = create_console_toolset(document_support=True)
 
         # Or with permissions
         from pydantic_ai_backends.permissions import DEFAULT_RULESET
@@ -481,11 +544,14 @@ def create_console_toolset(  # noqa: C901
                 offset: Line number to start reading from (0-indexed).
                 limit: Maximum number of lines to read. Defaults to 2000.
             """
-            binary = await _maybe_binary_content(
-                ctx.deps.backend, path, image_support, max_image_bytes
-            )
-            if binary is not None:
-                return binary
+            if image_support:
+                image = await _maybe_image_content(ctx.deps.backend, path, max_image_bytes)
+                if image is not None:
+                    return image
+            if document_support:
+                document = await _maybe_document_content(ctx.deps.backend, path, max_document_bytes)
+                if document is not None:
+                    return document
 
             from pydantic_ai_backends.hashline import format_hashline_output
 
@@ -511,11 +577,14 @@ def create_console_toolset(  # noqa: C901
                 offset: Line number to start reading from (0-indexed).
                 limit: Maximum number of lines to read. Defaults to 2000.
             """
-            binary = await _maybe_binary_content(
-                ctx.deps.backend, path, image_support, max_image_bytes
-            )
-            if binary is not None:
-                return binary
+            if image_support:
+                image = await _maybe_image_content(ctx.deps.backend, path, max_image_bytes)
+                if image is not None:
+                    return image
+            if document_support:
+                document = await _maybe_document_content(ctx.deps.backend, path, max_document_bytes)
+                if document is not None:
+                    return document
             return await asyncio.to_thread(ctx.deps.backend.read, path, offset, limit)
 
     # --- write_file tool ---

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -4,7 +4,7 @@ import inspect
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic_ai import BinaryContent
+from pydantic_ai import BinaryContent, RunContext
 
 from pydantic_ai_backends import (
     LocalBackend,
@@ -14,10 +14,15 @@ from pydantic_ai_backends import (
 )
 from pydantic_ai_backends.toolsets.console import (
     DEFAULT_MAX_IMAGE_BYTES,
+    DOCUMENT_MEDIA_TYPES,
     IMAGE_EXTENSIONS,
     IMAGE_MEDIA_TYPES,
     ConsoleDeps,
+    _maybe_binary_content,
 )
+
+# Minimal valid-ish PDF payload (header + EOF marker).
+PDF_DATA = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n<<>>\nendobj\n%%EOF\n"
 
 
 @dataclass
@@ -327,3 +332,182 @@ class TestConsoleToolsetAlias:
 
         toolset = ConsoleToolset()
         assert len(toolset.tools) > 0
+
+
+class TestDocumentConstants:
+    """Test document-related constants."""
+
+    def test_document_media_types(self):
+        """Test DOCUMENT_MEDIA_TYPES maps pdf to application/pdf."""
+        assert DOCUMENT_MEDIA_TYPES["pdf"] == "application/pdf"
+
+    def test_pdf_not_in_image_extensions(self):
+        """PDFs are documents, not images."""
+        assert "pdf" not in IMAGE_EXTENSIONS
+
+    def test_document_media_types_exported(self):
+        """Test DOCUMENT_MEDIA_TYPES is importable from package."""
+        from pydantic_ai_backends import DOCUMENT_MEDIA_TYPES as exported
+
+        assert exported == DOCUMENT_MEDIA_TYPES
+
+
+class TestMaybeBinaryContent:
+    """Test the shared _maybe_binary_content helper used by both read_file variants."""
+
+    async def test_pdf_returns_binary_content(self, tmp_path: Path):
+        """A .pdf file is returned as BinaryContent(application/pdf)."""
+        (tmp_path / "report.pdf").write_bytes(PDF_DATA)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_binary_content(
+            backend, "report.pdf", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        )
+
+        assert isinstance(result, BinaryContent)
+        assert result.media_type == "application/pdf"
+        assert result.data == PDF_DATA
+        assert result.is_document
+
+    async def test_pdf_too_large_returns_error(self, tmp_path: Path):
+        """An oversized .pdf returns the size-limit error string."""
+        (tmp_path / "huge.pdf").write_bytes(PDF_DATA)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_binary_content(
+            backend, "huge.pdf", image_support=True, max_image_bytes=1
+        )
+
+        assert isinstance(result, str)
+        assert "too large" in result
+        assert "huge.pdf" in result
+
+    async def test_pdf_missing_returns_error(self):
+        """A missing/empty .pdf returns the not-found error string."""
+        backend = StateBackend()
+
+        result = await _maybe_binary_content(
+            backend, "missing.pdf", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        )
+
+        assert isinstance(result, str)
+        assert "not found or empty" in result
+
+    async def test_image_still_returns_binary_content(self, tmp_path: Path):
+        """Existing image behavior is unchanged."""
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (tmp_path / "test.png").write_bytes(png_data)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_binary_content(
+            backend, "test.png", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        )
+
+        assert isinstance(result, BinaryContent)
+        assert result.media_type == "image/png"
+        assert result.is_image
+
+    async def test_image_missing_error_message_unchanged(self):
+        """Image not-found error message is preserved verbatim."""
+        backend = StateBackend()
+
+        result = await _maybe_binary_content(
+            backend, "missing.png", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        )
+
+        assert result == "Error: Image file 'missing.png' not found or empty"
+
+    async def test_support_disabled_returns_none(self, tmp_path: Path):
+        """With image_support disabled, the helper always falls through to text."""
+        (tmp_path / "report.pdf").write_bytes(PDF_DATA)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_binary_content(
+            backend, "report.pdf", image_support=False, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        )
+
+        assert result is None
+
+    async def test_text_file_returns_none(self, tmp_path: Path):
+        """A non-binary extension falls through to the text path."""
+        (tmp_path / "notes.txt").write_text("hello")
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_binary_content(
+            backend, "notes.txt", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        )
+
+        assert result is None
+
+    async def test_no_extension_returns_none(self, tmp_path: Path):
+        """A file without an extension falls through to the text path."""
+        (tmp_path / "Makefile").write_text("all:\n")
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_binary_content(
+            backend, "Makefile", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        )
+
+        assert result is None
+
+
+def _make_ctx(deps: MockDeps) -> RunContext[ConsoleDeps]:
+    """Build a minimal RunContext for invoking a tool function directly."""
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.usage import RunUsage
+
+    return RunContext(deps=deps, model=TestModel(), usage=RunUsage())
+
+
+class TestReadFilePdfIntegration:
+    """End-to-end: invoke the real read_file tool for both edit_format variants."""
+
+    async def test_str_replace_read_file_pdf(self, tmp_path: Path):
+        """str_replace read_file returns BinaryContent for a PDF."""
+        (tmp_path / "report.pdf").write_bytes(PDF_DATA)
+        backend = LocalBackend(root_dir=tmp_path)
+        toolset = create_console_toolset(image_support=True)
+        read_file = toolset.tools["read_file"].function
+
+        result = await read_file(_make_ctx(MockDeps(backend=backend)), "report.pdf")
+
+        assert isinstance(result, BinaryContent)
+        assert result.media_type == "application/pdf"
+        assert result.data == PDF_DATA
+
+    async def test_hashline_read_file_pdf(self, tmp_path: Path):
+        """hashline read_file returns identical BinaryContent for a PDF."""
+        (tmp_path / "report.pdf").write_bytes(PDF_DATA)
+        backend = LocalBackend(root_dir=tmp_path)
+        toolset = create_console_toolset(image_support=True, edit_format="hashline")
+        read_file = toolset.tools["read_file"].function
+
+        result = await read_file(_make_ctx(MockDeps(backend=backend)), "report.pdf")
+
+        assert isinstance(result, BinaryContent)
+        assert result.media_type == "application/pdf"
+        assert result.data == PDF_DATA
+
+    async def test_str_replace_read_file_text_unaffected(self, tmp_path: Path):
+        """Text files still return text (str_replace) with image_support on."""
+        (tmp_path / "readme.txt").write_text("Hello, world!")
+        backend = LocalBackend(root_dir=tmp_path)
+        toolset = create_console_toolset(image_support=True)
+        read_file = toolset.tools["read_file"].function
+
+        result = await read_file(_make_ctx(MockDeps(backend=backend)), "readme.txt")
+
+        assert isinstance(result, str)
+        assert "Hello, world!" in result
+
+    async def test_hashline_read_file_text_unaffected(self, tmp_path: Path):
+        """Text files still return hashline text with image_support on."""
+        (tmp_path / "readme.txt").write_text("Hello, world!")
+        backend = LocalBackend(root_dir=tmp_path)
+        toolset = create_console_toolset(image_support=True, edit_format="hashline")
+        read_file = toolset.tools["read_file"].function
+
+        result = await read_file(_make_ctx(MockDeps(backend=backend)), "readme.txt")
+
+        assert isinstance(result, str)
+        assert "Hello, world!" in result

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -13,12 +13,15 @@ from pydantic_ai_backends import (
     get_console_system_prompt,
 )
 from pydantic_ai_backends.toolsets.console import (
+    DEFAULT_MAX_DOCUMENT_BYTES,
     DEFAULT_MAX_IMAGE_BYTES,
+    DOCUMENT_EXTENSIONS,
     DOCUMENT_MEDIA_TYPES,
     IMAGE_EXTENSIONS,
     IMAGE_MEDIA_TYPES,
     ConsoleDeps,
-    _maybe_binary_content,
+    _maybe_document_content,
+    _maybe_image_content,
 )
 
 # Minimal valid-ish PDF payload (header + EOF marker).
@@ -337,31 +340,68 @@ class TestConsoleToolsetAlias:
 class TestDocumentConstants:
     """Test document-related constants."""
 
+    def test_document_extensions(self):
+        """Test DOCUMENT_EXTENSIONS contains pdf."""
+        assert "pdf" in DOCUMENT_EXTENSIONS
+
     def test_document_media_types(self):
         """Test DOCUMENT_MEDIA_TYPES maps pdf to application/pdf."""
         assert DOCUMENT_MEDIA_TYPES["pdf"] == "application/pdf"
 
     def test_pdf_not_in_image_extensions(self):
-        """PDFs are documents, not images."""
+        """PDFs are documents, not images - the two sets stay disjoint."""
         assert "pdf" not in IMAGE_EXTENSIONS
+        assert IMAGE_EXTENSIONS.isdisjoint(DOCUMENT_EXTENSIONS)
 
-    def test_document_media_types_exported(self):
-        """Test DOCUMENT_MEDIA_TYPES is importable from package."""
-        from pydantic_ai_backends import DOCUMENT_MEDIA_TYPES as exported
+    def test_all_document_extensions_have_media_types(self):
+        """Every DOCUMENT_EXTENSION has a corresponding DOCUMENT_MEDIA_TYPE."""
+        for ext in DOCUMENT_EXTENSIONS:
+            assert ext in DOCUMENT_MEDIA_TYPES
 
-        assert exported == DOCUMENT_MEDIA_TYPES
+    def test_default_max_document_bytes(self):
+        """Test DEFAULT_MAX_DOCUMENT_BYTES is 50MB."""
+        assert DEFAULT_MAX_DOCUMENT_BYTES == 50 * 1024 * 1024
+
+    def test_document_constants_exported(self):
+        """Test document constants are importable from the package."""
+        from pydantic_ai_backends import DEFAULT_MAX_DOCUMENT_BYTES as max_exported
+        from pydantic_ai_backends import DOCUMENT_EXTENSIONS as ext_exported
+        from pydantic_ai_backends import DOCUMENT_MEDIA_TYPES as media_exported
+
+        assert ext_exported == DOCUMENT_EXTENSIONS
+        assert media_exported == DOCUMENT_MEDIA_TYPES
+        assert max_exported == DEFAULT_MAX_DOCUMENT_BYTES
 
 
-class TestMaybeBinaryContent:
-    """Test the shared _maybe_binary_content helper used by both read_file variants."""
+class TestCreateConsoleToolsetDocumentParams:
+    """Test create_console_toolset with document parameters."""
+
+    def test_create_toolset_with_document_support(self):
+        """Test creating toolset with document_support=True."""
+        toolset = create_console_toolset(document_support=True)
+        assert "read_file" in toolset.tools
+
+    def test_create_toolset_with_custom_max_document_bytes(self):
+        """Test creating toolset with custom max_document_bytes."""
+        toolset = create_console_toolset(document_support=True, max_document_bytes=1024)
+        assert "read_file" in toolset.tools
+
+    def test_create_toolset_default_no_document_support(self):
+        """Test that document_support defaults to False."""
+        toolset = create_console_toolset()
+        assert "read_file" in toolset.tools
+
+
+class TestMaybeDocumentContent:
+    """Test the _maybe_document_content helper (separate from image handling)."""
 
     async def test_pdf_returns_binary_content(self, tmp_path: Path):
         """A .pdf file is returned as BinaryContent(application/pdf)."""
         (tmp_path / "report.pdf").write_bytes(PDF_DATA)
         backend = LocalBackend(root_dir=tmp_path)
 
-        result = await _maybe_binary_content(
-            backend, "report.pdf", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        result = await _maybe_document_content(
+            backend, "report.pdf", max_document_bytes=DEFAULT_MAX_DOCUMENT_BYTES
         )
 
         assert isinstance(result, BinaryContent)
@@ -374,33 +414,69 @@ class TestMaybeBinaryContent:
         (tmp_path / "huge.pdf").write_bytes(PDF_DATA)
         backend = LocalBackend(root_dir=tmp_path)
 
-        result = await _maybe_binary_content(
-            backend, "huge.pdf", image_support=True, max_image_bytes=1
-        )
+        result = await _maybe_document_content(backend, "huge.pdf", max_document_bytes=1)
 
-        assert isinstance(result, str)
-        assert "too large" in result
-        assert "huge.pdf" in result
+        assert result == (
+            f"Error: Document 'huge.pdf' too large "
+            f"({len(PDF_DATA) / (1024 * 1024):.1f}MB, max 0.0MB)"
+        )
 
     async def test_pdf_missing_returns_error(self):
         """A missing/empty .pdf returns the not-found error string."""
         backend = StateBackend()
 
-        result = await _maybe_binary_content(
-            backend, "missing.pdf", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        result = await _maybe_document_content(
+            backend, "missing.pdf", max_document_bytes=DEFAULT_MAX_DOCUMENT_BYTES
         )
 
-        assert isinstance(result, str)
-        assert "not found or empty" in result
+        assert result == "Error: Document file 'missing.pdf' not found or empty"
 
-    async def test_image_still_returns_binary_content(self, tmp_path: Path):
+    async def test_image_returns_none(self, tmp_path: Path):
+        """An image is NOT a document - the document helper ignores it."""
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (tmp_path / "test.png").write_bytes(png_data)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_document_content(
+            backend, "test.png", max_document_bytes=DEFAULT_MAX_DOCUMENT_BYTES
+        )
+
+        assert result is None
+
+    async def test_text_file_returns_none(self, tmp_path: Path):
+        """A non-document extension falls through to the text path."""
+        (tmp_path / "notes.txt").write_text("hello")
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_document_content(
+            backend, "notes.txt", max_document_bytes=DEFAULT_MAX_DOCUMENT_BYTES
+        )
+
+        assert result is None
+
+    async def test_no_extension_returns_none(self, tmp_path: Path):
+        """A file without an extension falls through to the text path."""
+        (tmp_path / "Makefile").write_text("all:\n")
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_document_content(
+            backend, "Makefile", max_document_bytes=DEFAULT_MAX_DOCUMENT_BYTES
+        )
+
+        assert result is None
+
+
+class TestMaybeImageContent:
+    """Test the _maybe_image_content helper (separate from document handling)."""
+
+    async def test_image_returns_binary_content(self, tmp_path: Path):
         """Existing image behavior is unchanged."""
         png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
         (tmp_path / "test.png").write_bytes(png_data)
         backend = LocalBackend(root_dir=tmp_path)
 
-        result = await _maybe_binary_content(
-            backend, "test.png", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        result = await _maybe_image_content(
+            backend, "test.png", max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
         )
 
         assert isinstance(result, BinaryContent)
@@ -411,41 +487,31 @@ class TestMaybeBinaryContent:
         """Image not-found error message is preserved verbatim."""
         backend = StateBackend()
 
-        result = await _maybe_binary_content(
-            backend, "missing.png", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        result = await _maybe_image_content(
+            backend, "missing.png", max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
         )
 
         assert result == "Error: Image file 'missing.png' not found or empty"
 
-    async def test_support_disabled_returns_none(self, tmp_path: Path):
-        """With image_support disabled, the helper always falls through to text."""
+    async def test_image_too_large_message_unchanged(self, tmp_path: Path):
+        """Image size-limit error message is preserved verbatim."""
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (tmp_path / "test.png").write_bytes(png_data)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await _maybe_image_content(backend, "test.png", max_image_bytes=1)
+
+        assert result == (
+            f"Error: Image 'test.png' too large ({len(png_data) / (1024 * 1024):.1f}MB, max 0.0MB)"
+        )
+
+    async def test_pdf_returns_none(self, tmp_path: Path):
+        """A PDF is NOT an image - the image helper ignores it."""
         (tmp_path / "report.pdf").write_bytes(PDF_DATA)
         backend = LocalBackend(root_dir=tmp_path)
 
-        result = await _maybe_binary_content(
-            backend, "report.pdf", image_support=False, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
-        )
-
-        assert result is None
-
-    async def test_text_file_returns_none(self, tmp_path: Path):
-        """A non-binary extension falls through to the text path."""
-        (tmp_path / "notes.txt").write_text("hello")
-        backend = LocalBackend(root_dir=tmp_path)
-
-        result = await _maybe_binary_content(
-            backend, "notes.txt", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
-        )
-
-        assert result is None
-
-    async def test_no_extension_returns_none(self, tmp_path: Path):
-        """A file without an extension falls through to the text path."""
-        (tmp_path / "Makefile").write_text("all:\n")
-        backend = LocalBackend(root_dir=tmp_path)
-
-        result = await _maybe_binary_content(
-            backend, "Makefile", image_support=True, max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
+        result = await _maybe_image_content(
+            backend, "report.pdf", max_image_bytes=DEFAULT_MAX_IMAGE_BYTES
         )
 
         assert result is None
@@ -466,7 +532,7 @@ class TestReadFilePdfIntegration:
         """str_replace read_file returns BinaryContent for a PDF."""
         (tmp_path / "report.pdf").write_bytes(PDF_DATA)
         backend = LocalBackend(root_dir=tmp_path)
-        toolset = create_console_toolset(image_support=True)
+        toolset = create_console_toolset(document_support=True)
         read_file = toolset.tools["read_file"].function
 
         result = await read_file(_make_ctx(MockDeps(backend=backend)), "report.pdf")
@@ -479,7 +545,7 @@ class TestReadFilePdfIntegration:
         """hashline read_file returns identical BinaryContent for a PDF."""
         (tmp_path / "report.pdf").write_bytes(PDF_DATA)
         backend = LocalBackend(root_dir=tmp_path)
-        toolset = create_console_toolset(image_support=True, edit_format="hashline")
+        toolset = create_console_toolset(document_support=True, edit_format="hashline")
         read_file = toolset.tools["read_file"].function
 
         result = await read_file(_make_ctx(MockDeps(backend=backend)), "report.pdf")
@@ -488,11 +554,41 @@ class TestReadFilePdfIntegration:
         assert result.media_type == "application/pdf"
         assert result.data == PDF_DATA
 
+    async def test_pdf_ignored_without_document_support(self, tmp_path: Path):
+        """With document_support off, a PDF falls through to the text path."""
+        (tmp_path / "report.pdf").write_bytes(PDF_DATA)
+        backend = LocalBackend(root_dir=tmp_path)
+        # image_support on but document_support off: PDF must NOT become BinaryContent
+        toolset = create_console_toolset(image_support=True)
+        read_file = toolset.tools["read_file"].function
+
+        result = await read_file(_make_ctx(MockDeps(backend=backend)), "report.pdf")
+
+        assert not isinstance(result, BinaryContent)
+
+    async def test_image_and_document_support_together(self, tmp_path: Path):
+        """Both flags on: images and documents each resolve to BinaryContent."""
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (tmp_path / "test.png").write_bytes(png_data)
+        (tmp_path / "report.pdf").write_bytes(PDF_DATA)
+        backend = LocalBackend(root_dir=tmp_path)
+        toolset = create_console_toolset(image_support=True, document_support=True)
+        read_file = toolset.tools["read_file"].function
+        ctx = _make_ctx(MockDeps(backend=backend))
+
+        image = await read_file(ctx, "test.png")
+        document = await read_file(ctx, "report.pdf")
+
+        assert isinstance(image, BinaryContent)
+        assert image.media_type == "image/png"
+        assert isinstance(document, BinaryContent)
+        assert document.media_type == "application/pdf"
+
     async def test_str_replace_read_file_text_unaffected(self, tmp_path: Path):
-        """Text files still return text (str_replace) with image_support on."""
+        """Text files still return text (str_replace) with both flags on."""
         (tmp_path / "readme.txt").write_text("Hello, world!")
         backend = LocalBackend(root_dir=tmp_path)
-        toolset = create_console_toolset(image_support=True)
+        toolset = create_console_toolset(image_support=True, document_support=True)
         read_file = toolset.tools["read_file"].function
 
         result = await read_file(_make_ctx(MockDeps(backend=backend)), "readme.txt")
@@ -501,10 +597,12 @@ class TestReadFilePdfIntegration:
         assert "Hello, world!" in result
 
     async def test_hashline_read_file_text_unaffected(self, tmp_path: Path):
-        """Text files still return hashline text with image_support on."""
+        """Text files still return hashline text with both flags on."""
         (tmp_path / "readme.txt").write_text("Hello, world!")
         backend = LocalBackend(root_dir=tmp_path)
-        toolset = create_console_toolset(image_support=True, edit_format="hashline")
+        toolset = create_console_toolset(
+            image_support=True, document_support=True, edit_format="hashline"
+        )
         read_file = toolset.tools["read_file"].function
 
         result = await read_file(_make_ctx(MockDeps(backend=backend)), "readme.txt")


### PR DESCRIPTION
## Problem

With `image_support=True`, `create_console_toolset`'s `read_file` returns raster images (png/jpg/jpeg/gif/webp) as `pydantic_ai.BinaryContent` so multimodal models can see them. But **PDFs were not handled**: they fell through to the text path and were read via the `awk` command in `BaseSandbox.read`, which on a binary PDF emits an empty string (no newlines / NUL bytes). So an agent calling `read_file("report.pdf")` got `""` instead of usable content — even though pydantic-ai `BinaryContent` supports `application/pdf` for document understanding on capable models (OpenAI/Anthropic/Gemini).

## Root cause

In `src/pydantic_ai_backends/toolsets/console.py`:

- `IMAGE_EXTENSIONS` = `{"png","jpg","jpeg","gif","webp"}` — no `pdf`.
- `read_file` is defined **twice** — once per `edit_format` (`"hashline"` and `"str_replace"`). **Both** had the same image-only block: `if image_support: ext=...; if ext in IMAGE_EXTENSIONS: raw = read_bytes(...); ... return BinaryContent(...)`. Anything not an image (including PDFs) fell through to the text read and came back empty.

## Design decision (Option B — separate document support)

Images and **documents are distinct content kinds**. Treating PDFs as "just another image" under `image_support` would conflate two paths that we want to handle differently going forward — e.g. OCR/vision for images vs. native document understanding or library-based text extraction (PDF/DOCX) fallbacks. So this PR keeps them **cleanly separate**:

- New, independent **`document_support: bool = False`** flag with its own **`max_document_bytes`** limit. `image_support` / `max_image_bytes` are unchanged.
- New constants kept **disjoint** from the image ones: `DOCUMENT_EXTENSIONS = {"pdf"}`, `DOCUMENT_MEDIA_TYPES = {"pdf": "application/pdf"}`, `DEFAULT_MAX_DOCUMENT_BYTES`.
- Two clearly-named helpers, **`_maybe_image_content`** and **`_maybe_document_content`**, each owning extension detection + media-type resolution for its kind, sharing only a small low-level `_read_binary_within_limit` for the not-found/empty and size-limit guards. This removes the prior duplication between the two `read_file` variants while keeping the image and document seams independent.
- `read_file` (both `edit_format` variants) checks `image_support` then `document_support`.

(The earlier revision of this PR lumped PDFs under `image_support`; reworked per review to keep the cases separate so each can be handled properly.)

## Change summary

1. `DOCUMENT_EXTENSIONS`, `DOCUMENT_MEDIA_TYPES`, `DEFAULT_MAX_DOCUMENT_BYTES` constants (exported from the package, mirroring the `IMAGE_*` exports).
2. `document_support` + `max_document_bytes` params on `create_console_toolset` (default off → fully backward compatible).
3. `_maybe_image_content` / `_maybe_document_content` helpers + shared `_read_binary_within_limit`; both `read_file` variants wired to them.

## Tests

Added to `tests/test_console.py`:
- `_maybe_document_content`: PDF → `BinaryContent(application/pdf)`; oversize → exact size-limit error; missing/empty → exact not-found error; image/text/no-extension → `None`.
- `_maybe_image_content`: image → `BinaryContent`; missing + oversize error messages asserted **verbatim** (regression guard); PDF → `None`.
- Integration via the **real** `read_file` tool for **both** `edit_format` variants: PDF → `BinaryContent(application/pdf)`; PDF ignored when `document_support` is off (even with `image_support` on); image + document flags together; text files still return text.
- Document constant + export tests, and `document_support` toolset-construction tests.

## Acceptance criteria

- ✅ `read_file("x.pdf")` with `document_support=True` returns `BinaryContent(media_type="application/pdf")`, not `""`.
- ✅ Oversized PDFs return the size-limit error string; missing/empty return the not-found error string.
- ✅ Both `edit_format` variants behave identically for binary files.
- ✅ Existing image behavior unchanged (image error strings asserted verbatim; `image_support` semantics untouched).
- ✅ Image and document handling are cleanly separated and independently extensible.

## Checks

`uv run ruff format .`, `uv run ruff check .`, `uv run pyright`, `uv run mypy src/pydantic_ai_backends`, and `uv run coverage run -m pytest && uv run coverage report` all pass — **522 passed, 100.00% coverage**.

No version bump (CONTRIBUTING does not require it for feature PRs).

This unblocks multimodal PDF document reading for downstream agents (incl. pydantic-deep), with room to add OCR/extraction fallbacks per content kind later.

## Relationship to LiteParse (pydantic-deep `include_liteparse`)

`pydantic-deep` recently added [`LiteparseToolset`](https://vstorm-co.github.io/pydantic-deepagents/advanced/liteparse/) (`include_liteparse=True`), wrapping [run-llama/liteparse](https://github.com/run-llama/liteparse). These are **complementary, not duplicate** — they sit at different layers and solve PDFs differently:

| | `document_support` (this PR) | `LiteparseToolset` (pydantic-deep) |
| --- | --- | --- |
| Layer | `pydantic-ai-backend` (backend/toolset lib) | `pydantic-deep` agent runtime (depends on this lib; LiteParse even saves page screenshots **to the backend**) |
| Mechanism | `read_file("x.pdf")` returns `BinaryContent(application/pdf)`; the **model reads it natively** | dedicated `parse_document` / `screenshot_document` tools that shell out to the LiteParse Node CLI to **extract text/markdown + OCR** |
| Dependencies | none | Node.js ≥18 + npm CLI + `liteparse` extra |
| Best for | models with native PDF understanding; inline file reading | scanned/image-only PDFs, models without native PDF, structured text/bounding boxes, avoiding large binary uploads |

This PR is the lightweight, dependency-free native path at the backend layer; LiteParse is the heavier local extraction/OCR pipeline one layer up. Since pydantic-deep re-exports this library's API, both can be enabled together and the agent picks per document (cheap native `read_file` for clean PDFs, `parse_document` when OCR/structured extraction is needed). The `_maybe_document_content` seam introduced here is intentionally independent so such extraction/OCR fallbacks can be layered in without touching image handling.
