### PR TITLE
fix(backends): normalize line endings in LocalBackend write/edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`LocalBackend.write()` / `edit()` no longer double carriage returns on Windows** ([#51](https://github.com/vstorm-co/pydantic-ai-backend/issues/51)) (`src/pydantic_ai_backends/backends/local.py`). `Path.write_text()` opens in text mode, where only `\n` is translated to `os.linesep` on write while existing `\r` is left untouched — so content already containing `\r\n` (commonly emitted by LLMs) became `\r\r\n` on Windows, leaving files with blank lines between every line of code. Content is now normalized before writing so text mode re-adds clean, platform-native line endings.
+
 ## [0.2.12] - 2026-06-12
 
 ### Added

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -39,6 +39,17 @@ AskFallback = Literal["deny", "error"]
 MAX_EXECUTE_OUTPUT = 100_000
 
 
+def _normalize_newlines(content: str) -> str:
+    """Collapse carriage returns so text-mode writes don't double them.
+
+    ``Path.write_text`` opens in text mode, where only ``\\n`` is translated to
+    ``os.linesep`` on write while existing ``\\r`` is left untouched. Content
+    that already contains ``\\r\\n`` would become ``\\r\\r\\n`` on Windows.
+    Stripping ``\\r`` lets text mode re-add clean platform-native endings.
+    """
+    return content.replace("\r", "")
+
+
 class LocalBackend:
     """Local filesystem backend with optional shell execution.
 
@@ -366,7 +377,7 @@ class LocalBackend:
             if isinstance(content, bytes):  # pragma: no cover
                 full_path.write_bytes(content)
             else:
-                full_path.write_text(content, encoding="utf-8")
+                full_path.write_text(_normalize_newlines(content), encoding="utf-8")
 
             return WriteResult(path=str(full_path))
         except PermissionError:  # pragma: no cover
@@ -415,7 +426,7 @@ class LocalBackend:
             new_content = content.replace(old_string, new_string, 1)
 
         try:
-            full_path.write_text(new_content, encoding="utf-8")
+            full_path.write_text(_normalize_newlines(new_content), encoding="utf-8")
             return EditResult(path=str(full_path), occurrences=occurrences if replace_all else 1)
         except PermissionError:  # pragma: no cover
             return EditResult(error=f"Permission denied for '{path}'")

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -114,6 +114,34 @@ class TestLocalBackendFileOps:
         assert result.error is not None
         assert "not found" in result.error
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "line1\nline2\nline3\n",
+            "line1\r\nline2\r\nline3\r\n",
+            "line1\r\r\nline2\r\r\nline3\r\r\n",
+        ],
+    )
+    def test_write_does_not_double_carriage_returns(self, tmp_path: Path, content: str):
+        """Write must not accumulate \\r from text-mode translation (issue #51)."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        backend.write("file.py", content)
+        written = (tmp_path / "file.py").read_bytes()
+
+        assert b"\r\r" not in written
+        assert written.replace(b"\r\n", b"\n") == b"line1\nline2\nline3\n"
+
+    def test_edit_does_not_double_carriage_returns(self, tmp_path: Path):
+        """Edit must normalize line endings like write (issue #51)."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        backend.write("file.py", "alpha\nbeta\n")
+        backend.edit("file.py", "beta", "beta\r\ngamma")
+        written = (tmp_path / "file.py").read_bytes()
+
+        assert b"\r\r" not in written
+
     def test_ls_info(self, tmp_path: Path):
         """Test listing directory contents."""
         backend = LocalBackend(root_dir=tmp_path)


### PR DESCRIPTION
## Summary

Fixes #51 — `LocalBackend.write()` (and `edit()`) doubled carriage returns on Windows, leaving agent-written files with blank lines between every line of code.

## Root cause

`Path.write_text()` opens the file in **text mode** (`newline=None`), where only `\n` is translated to `os.linesep` on write — existing `\r` is left untouched. When the LLM sends content that already contains `\r\n` (very common), the `\r` survives and the `\n` becomes `\r\n`, producing `\r\r\n`. `\r\r\n` input becomes `\r\r\r\n`, and so on.

This is Windows-only (`os.linesep == "\n"` on Unix) and does not affect `StateBackend` or `DockerSandbox`, exactly as the reporter described.

## Fix

Normalize content by stripping `\r` before `write_text()` in both `write()` and `edit()`. Text mode then re-adds clean, platform-native line endings (`\r\n` on Windows, `\n` on Unix) regardless of the incoming line endings. No platform branch, so the logic is fully covered by tests on Linux CI.

## Tests

- Parametrized `write()` test across `\n`, `\r\n`, and `\r\r\n` inputs asserting no `\r\r` in the written bytes and a normalized result.
- `edit()` regression test.
- Full suite: 562 passed; `local.py` at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)