### PR TITLE
fix: add async backend adapter support

### DIFF
--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -46,10 +46,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 # Core exports - always available
+from pydantic_ai_backends.adapter import AsyncBackendAdapter, AsyncSandboxAdapter, ensure_async
 from pydantic_ai_backends.backends.composite import CompositeBackend
 from pydantic_ai_backends.backends.local import LocalBackend
 from pydantic_ai_backends.backends.state import StateBackend
-from pydantic_ai_backends.protocol import BackendProtocol, SandboxProtocol
+from pydantic_ai_backends.protocol import (
+    AsyncBackendProtocol,
+    AsyncSandboxProtocol,
+    BackendProtocol,
+    SandboxProtocol,
+)
 from pydantic_ai_backends.types import (
     EditResult,
     ExecuteResponse,
@@ -200,6 +206,12 @@ __all__ = [
     # Protocols
     "BackendProtocol",
     "SandboxProtocol",
+    "AsyncBackendProtocol",
+    "AsyncSandboxProtocol",
+    # Adapters
+    "AsyncBackendAdapter",
+    "AsyncSandboxAdapter",
+    "ensure_async",
     # Types
     "FileData",
     "FileInfo",

--- a/src/pydantic_ai_backends/adapter.py
+++ b/src/pydantic_ai_backends/adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -77,6 +78,13 @@ class AsyncSandboxAdapter(AsyncBackendAdapter):
 
     async def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
         sandbox = cast("SandboxProtocol", self._backend)
+        async_execute = getattr(sandbox, "async_execute", None)
+        if inspect.iscoroutinefunction(async_execute):
+            async_execute_fn = cast(
+                "Callable[[str, int | None], Awaitable[ExecuteResponse]]",
+                async_execute,
+            )
+            return await async_execute_fn(command, timeout)
         return await asyncio.to_thread(sandbox.execute, command, timeout)
 
 

--- a/src/pydantic_ai_backends/adapter.py
+++ b/src/pydantic_ai_backends/adapter.py
@@ -1,0 +1,95 @@
+"""Async adapters for sync backend implementations."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pydantic_ai_backends.protocol import (
+        AsyncBackendProtocol,
+        BackendProtocol,
+        SandboxProtocol,
+    )
+    from pydantic_ai_backends.types import (
+        EditResult,
+        ExecuteResponse,
+        FileInfo,
+        GrepMatch,
+        WriteResult,
+    )
+
+
+class AsyncBackendAdapter:
+    """Wrap a sync :class:`BackendProtocol` with async methods."""
+
+    def __init__(self, backend: BackendProtocol) -> None:
+        self._backend = backend
+
+    def unwrap(self) -> BackendProtocol:
+        """Return the wrapped sync backend."""
+        return self._backend
+
+    async def exists(self, path: str) -> bool:
+        return await asyncio.to_thread(self._backend.exists, path)
+
+    async def ls_info(self, path: str) -> list[FileInfo]:
+        return await asyncio.to_thread(self._backend.ls_info, path)
+
+    async def read_bytes(self, path: str) -> bytes:
+        reader = getattr(self._backend, "read_bytes", None)
+        if reader is None:
+            reader = self._backend._read_bytes  # type: ignore[attr-defined]
+        return await asyncio.to_thread(reader, path)
+
+    async def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+        return await asyncio.to_thread(self._backend.read, path, offset, limit)
+
+    async def write(self, path: str, content: str | bytes) -> WriteResult:
+        return await asyncio.to_thread(self._backend.write, path, content)
+
+    async def edit(
+        self, path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> EditResult:
+        return await asyncio.to_thread(
+            self._backend.edit, path, old_string, new_string, replace_all
+        )
+
+    async def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        return await asyncio.to_thread(self._backend.glob_info, pattern, path)
+
+    async def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        ignore_hidden: bool = True,
+    ) -> list[GrepMatch] | str:
+        return await asyncio.to_thread(self._backend.grep_raw, pattern, path, glob, ignore_hidden)
+
+
+class AsyncSandboxAdapter(AsyncBackendAdapter):
+    """Wrap a sync :class:`SandboxProtocol` with async sandbox methods."""
+
+    def __init__(self, backend: SandboxProtocol) -> None:
+        super().__init__(backend)
+
+    async def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+        sandbox = cast("SandboxProtocol", self._backend)
+        return await asyncio.to_thread(sandbox.execute, command, timeout)
+
+
+def _is_async_backend(backend: Any) -> bool:
+    return inspect.iscoroutinefunction(getattr(backend, "read_bytes", None))
+
+
+def ensure_async(backend: BackendProtocol | AsyncBackendProtocol) -> AsyncBackendProtocol:
+    """Return an async backend, wrapping sync backends when needed."""
+    if isinstance(backend, AsyncBackendAdapter):
+        return backend
+    if _is_async_backend(backend):
+        return cast("AsyncBackendProtocol", backend)
+    if hasattr(backend, "execute"):
+        return AsyncSandboxAdapter(cast("SandboxProtocol", backend))
+    return AsyncBackendAdapter(cast("BackendProtocol", backend))

--- a/src/pydantic_ai_backends/protocol.py
+++ b/src/pydantic_ai_backends/protocol.py
@@ -178,3 +178,35 @@ class SandboxProtocol(BackendProtocol, Protocol):
     def id(self) -> str:
         """Unique identifier for this sandbox instance."""
         ...
+
+
+@runtime_checkable
+class AsyncBackendProtocol(Protocol):
+    """Async protocol for file storage backends.
+
+    Sync backends can be adapted with :func:`pydantic_ai_backends.ensure_async`.
+    """
+
+    async def exists(self, path: str) -> bool: ...
+    async def ls_info(self, path: str) -> list[FileInfo]: ...
+    async def read_bytes(self, path: str) -> bytes: ...
+    async def read(self, path: str, offset: int = 0, limit: int = 2000) -> str: ...
+    async def write(self, path: str, content: str | bytes) -> WriteResult: ...
+    async def edit(
+        self, path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> EditResult: ...
+    async def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]: ...
+    async def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        ignore_hidden: bool = True,
+    ) -> list[GrepMatch] | str: ...
+
+
+@runtime_checkable
+class AsyncSandboxProtocol(AsyncBackendProtocol, Protocol):
+    """Async protocol for sandbox backends that support command execution."""
+
+    async def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse: ...

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, runtime_checkabl
 from pydantic_ai import BinaryContent, RunContext
 from pydantic_ai.toolsets import FunctionToolset
 
-from pydantic_ai_backends.protocol import BackendProtocol
+from pydantic_ai_backends.adapter import ensure_async
+from pydantic_ai_backends.protocol import AsyncBackendProtocol, BackendProtocol
 from pydantic_ai_backends.types import GrepMatch
 
 EditFormat = Literal["str_replace", "hashline"]
@@ -250,7 +251,7 @@ class ConsoleDeps(Protocol):
     """Protocol for dependencies that provide a backend."""
 
     @property
-    def backend(self) -> BackendProtocol:
+    def backend(self) -> BackendProtocol | AsyncBackendProtocol:
         """The backend for file operations."""
         ...
 
@@ -313,7 +314,7 @@ def _file_extension(path: str) -> str:
 
 
 async def _read_binary_within_limit(
-    backend: BackendProtocol,
+    backend: BackendProtocol | AsyncBackendProtocol,
     path: str,
     max_bytes: int,
     kind: str,
@@ -330,7 +331,7 @@ async def _read_binary_within_limit(
         The file bytes, or an error string when the file is missing/empty or
         exceeds ``max_bytes``.
     """
-    raw = await asyncio.to_thread(backend.read_bytes, path)
+    raw = await ensure_async(backend).read_bytes(path)
     if not raw:
         return f"Error: {kind} file '{path}' not found or empty"
     if len(raw) > max_bytes:
@@ -341,7 +342,7 @@ async def _read_binary_within_limit(
 
 
 async def _maybe_image_content(
-    backend: BackendProtocol,
+    backend: BackendProtocol | AsyncBackendProtocol,
     path: str,
     max_image_bytes: int,
 ) -> BinaryContent | str | None:
@@ -364,7 +365,7 @@ async def _maybe_image_content(
 
 
 async def _maybe_document_content(
-    backend: BackendProtocol,
+    backend: BackendProtocol | AsyncBackendProtocol,
     path: str,
     max_document_bytes: int,
 ) -> BinaryContent | str | None:
@@ -511,7 +512,8 @@ def create_console_toolset(  # noqa: C901
         Args:
             path: Directory path to list. Defaults to current directory.
         """
-        entries = await asyncio.to_thread(ctx.deps.backend.ls_info, path)
+        backend = ensure_async(ctx.deps.backend)
+        entries = await backend.ls_info(path)
 
         if not entries:
             return f"Directory '{path}' is empty or does not exist"
@@ -555,9 +557,10 @@ def create_console_toolset(  # noqa: C901
 
             from pydantic_ai_backends.hashline import format_hashline_output
 
-            if not await asyncio.to_thread(ctx.deps.backend.exists, path):
+            backend = ensure_async(ctx.deps.backend)
+            if not await backend.exists(path):
                 return f"Error: File '{path}' not found"
-            raw_bytes = await asyncio.to_thread(ctx.deps.backend.read_bytes, path)
+            raw_bytes = await backend.read_bytes(path)
             text = raw_bytes.decode("utf-8", errors="replace")
             return format_hashline_output(text, offset, limit)
 
@@ -585,7 +588,8 @@ def create_console_toolset(  # noqa: C901
                 document = await _maybe_document_content(ctx.deps.backend, path, max_document_bytes)
                 if document is not None:
                     return document
-            return await asyncio.to_thread(ctx.deps.backend.read, path, offset, limit)
+            backend = ensure_async(ctx.deps.backend)
+            return await backend.read(path, offset, limit)
 
     # --- write_file tool ---
     @toolset.tool(
@@ -603,7 +607,8 @@ def create_console_toolset(  # noqa: C901
             path: Path to the file to write.
             content: Complete content to write to the file.
         """
-        result = await asyncio.to_thread(ctx.deps.backend.write, path, content)
+        backend = ensure_async(ctx.deps.backend)
+        result = await backend.write(path, content)
 
         if result.error:
             return f"Error: {result.error}"
@@ -642,15 +647,16 @@ of replacing it.
             """
             from pydantic_ai_backends.hashline import apply_hashline_edit_with_summary
 
-            backend = ctx.deps.backend
-            per_path = _edit_locks.setdefault(backend, {})
+            raw_backend = ctx.deps.backend
+            backend = ensure_async(raw_backend)
+            per_path = _edit_locks.setdefault(raw_backend, {})
             if path not in per_path:
                 per_path[path] = asyncio.Lock()
             async with per_path[path]:
                 # Read current file content
-                if not await asyncio.to_thread(backend.exists, path):
+                if not await backend.exists(path):
                     return f"Error: File '{path}' not found"
-                raw_bytes = await asyncio.to_thread(backend.read_bytes, path)
+                raw_bytes = await backend.read_bytes(path)
 
                 text = raw_bytes.decode("utf-8", errors="replace")
 
@@ -669,7 +675,7 @@ of replacing it.
                     return f"Error: {error}"
 
                 # Write back
-                write_result = await asyncio.to_thread(backend.write, path, new_text)
+                write_result = await backend.write(path, new_text)
                 if write_result.error:
                     return f"Error: {write_result.error}"
 
@@ -698,9 +704,8 @@ including whitespace and indentation.
                 replace_all: If True, replace all occurrences. If False (default), \
 the old_string must appear exactly once in the file.
             """
-            result = await asyncio.to_thread(
-                ctx.deps.backend.edit, path, old_string, new_string, replace_all
-            )
+            backend = ensure_async(ctx.deps.backend)
+            result = await backend.edit(path, old_string, new_string, replace_all)
 
             if result.error:
                 return f"Error: {result.error}"
@@ -719,7 +724,8 @@ the old_string must appear exactly once in the file.
             pattern: Glob pattern to match.
             path: Base directory to search from. Defaults to current directory.
         """
-        entries = await asyncio.to_thread(ctx.deps.backend.glob_info, pattern, path)
+        backend = ensure_async(ctx.deps.backend)
+        entries = await backend.glob_info(pattern, path)
 
         if not entries:
             return f"No files matching '{pattern}' in {path}"
@@ -751,9 +757,8 @@ the old_string must appear exactly once in the file.
             output_mode: Output format — `"content"`, `"files_with_matches"`, or `"count"`.
             ignore_hidden: Whether to skip hidden files/directories.
         """
-        result = await asyncio.to_thread(
-            ctx.deps.backend.grep_raw, pattern, path, glob_pattern, ignore_hidden
-        )
+        backend = ensure_async(ctx.deps.backend)
+        result = await backend.grep_raw(pattern, path, glob_pattern, ignore_hidden)
 
         if isinstance(result, str):
             return result  # Error message
@@ -806,9 +811,10 @@ the old_string must appear exactly once in the file.
 for long-running builds or test suites.
             """
             backend = ctx.deps.backend
+            async_backend = ensure_async(backend)
 
             # Check if backend supports execute
-            if not hasattr(backend, "execute"):
+            if not hasattr(async_backend, "execute"):
                 return "Error: Backend does not support command execution"
 
             # Check if execute is enabled (for LocalBackend)
@@ -816,10 +822,7 @@ for long-running builds or test suites.
                 return "Error: Shell execution is disabled for this backend"
 
             try:
-                if hasattr(backend, "async_execute"):
-                    result = await backend.async_execute(command, timeout)  # pyright: ignore[reportAttributeAccessIssue]
-                else:
-                    result = await asyncio.to_thread(backend.execute, command, timeout)  # pyright: ignore[reportAttributeAccessIssue]
+                result = await async_backend.execute(command, timeout)  # pyright: ignore[reportAttributeAccessIssue]
             except RuntimeError as e:
                 return f"Error: {e}"
 

--- a/tests/test_async_adapter.py
+++ b/tests/test_async_adapter.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pydantic_ai_backends import (
+    AsyncBackendAdapter,
+    AsyncSandboxAdapter,
+    ExecuteResponse,
+    WriteResult,
+    ensure_async,
+)
+from pydantic_ai_backends.types import EditResult, FileInfo, GrepMatch
+
+
+class PublicReadBytesBackend:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    def exists(self, path: str) -> bool:
+        self.calls.append(("exists", (path,)))
+        return path == "/file.txt"
+
+    def ls_info(self, path: str) -> list[FileInfo]:
+        self.calls.append(("ls_info", (path,)))
+        return [FileInfo(name="file.txt", path="/file.txt", is_dir=False, size=4)]
+
+    def read_bytes(self, path: str) -> bytes:
+        self.calls.append(("read_bytes", (path,)))
+        return b"data"
+
+    def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+        self.calls.append(("read", (path, offset, limit)))
+        return "     1\tdata"
+
+    def write(self, path: str, content: str | bytes) -> WriteResult:
+        self.calls.append(("write", (path, content)))
+        return WriteResult(path=path)
+
+    def edit(
+        self,
+        path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        self.calls.append(("edit", (path, old_string, new_string, replace_all)))
+        return EditResult(path=path, occurrences=1)
+
+    def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        self.calls.append(("glob_info", (pattern, path)))
+        return [FileInfo(name="file.txt", path="/file.txt", is_dir=False, size=4)]
+
+    def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        ignore_hidden: bool = True,
+    ) -> list[GrepMatch] | str:
+        self.calls.append(("grep_raw", (pattern, path, glob, ignore_hidden)))
+        return [GrepMatch(path="/file.txt", line_number=1, line="data", match="data")]
+
+
+class PrivateReadBytesBackend(PublicReadBytesBackend):
+    read_bytes = None  # type: ignore[assignment]
+
+    def _read_bytes(self, path: str) -> bytes:
+        self.calls.append(("_read_bytes", (path,)))
+        return b"private"
+
+
+class SandboxBackend(PublicReadBytesBackend):
+    id = "sandbox"
+
+    def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+        self.calls.append(("execute", (command, timeout)))
+        return ExecuteResponse(output="ok", exit_code=0)
+
+
+class AsyncNativeBackend:
+    async def exists(self, path: str) -> bool:
+        return True
+
+    async def read_bytes(self, path: str) -> bytes:
+        return b"async"
+
+
+async def test_adapter_delegates_file_methods_to_sync_backend() -> None:
+    backend = PublicReadBytesBackend()
+    adapter = AsyncBackendAdapter(backend)
+
+    assert adapter.unwrap() is backend
+    assert await adapter.exists("/file.txt") is True
+    assert await adapter.ls_info("/") == [
+        FileInfo(name="file.txt", path="/file.txt", is_dir=False, size=4)
+    ]
+    assert await adapter.read_bytes("/file.txt") == b"data"
+    assert await adapter.read("/file.txt", 1, 2) == "     1\tdata"
+    assert await adapter.write("/new.txt", "new") == WriteResult(path="/new.txt")
+    assert await adapter.edit("/file.txt", "a", "b", True) == EditResult(
+        path="/file.txt", occurrences=1
+    )
+    assert await adapter.glob_info("*.txt", "/") == [
+        FileInfo(name="file.txt", path="/file.txt", is_dir=False, size=4)
+    ]
+    assert await adapter.grep_raw("data", "/", "*.txt", False) == [
+        GrepMatch(path="/file.txt", line_number=1, line="data", match="data")
+    ]
+
+    assert ("read_bytes", ("/file.txt",)) in backend.calls
+
+
+async def test_adapter_falls_back_to_private_read_bytes() -> None:
+    backend = PrivateReadBytesBackend()
+    adapter = AsyncBackendAdapter(backend)
+
+    assert await adapter.read_bytes("/file.txt") == b"private"
+    assert backend.calls == [("_read_bytes", ("/file.txt",))]
+
+
+async def test_ensure_async_is_idempotent_and_preserves_async_native_backend() -> None:
+    sync_backend = PublicReadBytesBackend()
+    adapter = ensure_async(sync_backend)
+
+    assert isinstance(adapter, AsyncBackendAdapter)
+    assert ensure_async(adapter) is adapter
+
+    async_backend = AsyncNativeBackend()
+    assert ensure_async(async_backend) is async_backend
+    assert await ensure_async(async_backend).read_bytes("/anything") == b"async"
+
+
+async def test_ensure_async_wraps_sandbox_backends_with_execute() -> None:
+    backend = SandboxBackend()
+    adapter = ensure_async(backend)
+
+    assert isinstance(adapter, AsyncSandboxAdapter)
+    assert await adapter.execute("echo ok", 5) == ExecuteResponse(output="ok", exit_code=0)
+    assert backend.calls[-1] == ("execute", ("echo ok", 5))

--- a/tests/test_async_adapter.py
+++ b/tests/test_async_adapter.py
@@ -75,6 +75,14 @@ class SandboxBackend(PublicReadBytesBackend):
         return ExecuteResponse(output="ok", exit_code=0)
 
 
+class AsyncExecuteSandboxBackend(SandboxBackend):
+    async def async_execute(
+        self, command: str, timeout: int | None = None
+    ) -> ExecuteResponse:
+        self.calls.append(("async_execute", (command, timeout)))
+        return ExecuteResponse(output="async ok", exit_code=0)
+
+
 class AsyncNativeBackend:
     async def exists(self, path: str) -> bool:
         return True
@@ -135,3 +143,15 @@ async def test_ensure_async_wraps_sandbox_backends_with_execute() -> None:
     assert isinstance(adapter, AsyncSandboxAdapter)
     assert await adapter.execute("echo ok", 5) == ExecuteResponse(output="ok", exit_code=0)
     assert backend.calls[-1] == ("execute", ("echo ok", 5))
+
+
+async def test_sandbox_adapter_prefers_async_execute_when_available() -> None:
+    backend = AsyncExecuteSandboxBackend()
+    adapter = ensure_async(backend)
+
+    assert isinstance(adapter, AsyncSandboxAdapter)
+    assert await adapter.execute("echo ok", 5) == ExecuteResponse(
+        output="async ok", exit_code=0
+    )
+    assert backend.calls[-1] == ("async_execute", ("echo ok", 5))
+    assert not any(call[0] == "execute" for call in backend.calls)

--- a/tests/test_async_adapter.py
+++ b/tests/test_async_adapter.py
@@ -76,9 +76,7 @@ class SandboxBackend(PublicReadBytesBackend):
 
 
 class AsyncExecuteSandboxBackend(SandboxBackend):
-    async def async_execute(
-        self, command: str, timeout: int | None = None
-    ) -> ExecuteResponse:
+    async def async_execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
         self.calls.append(("async_execute", (command, timeout)))
         return ExecuteResponse(output="async ok", exit_code=0)
 
@@ -150,8 +148,6 @@ async def test_sandbox_adapter_prefers_async_execute_when_available() -> None:
     adapter = ensure_async(backend)
 
     assert isinstance(adapter, AsyncSandboxAdapter)
-    assert await adapter.execute("echo ok", 5) == ExecuteResponse(
-        output="async ok", exit_code=0
-    )
+    assert await adapter.execute("echo ok", 5) == ExecuteResponse(output="async ok", exit_code=0)
     assert backend.calls[-1] == ("async_execute", ("echo ok", 5))
     assert not any(call[0] == "execute" for call in backend.calls)


### PR DESCRIPTION
## Summary

- add runtime-checkable async backend/sandbox protocols
- add ensure_async() adapters for sync backends, preferring public read_bytes() with _read_bytes fallback
- update console toolset backend calls to work with sync or async backends
- add regression coverage for public-only read_bytes wrappers


Closes #54 
Related: vstorm-co/pydantic-deepagents#142
Related: vstorm-co/pydantic-deepagents#129

## Test plan

- uv run ruff format .
- uv run ruff check .
- uv run pyright
- uv run mypy src/pydantic_ai_backends
- uv run pytest tests/test_async_adapter.py tests/test_console.py -q
- uv run pytest -q