### PR TITLE
feat(backends): add AsyncCompositeBackend for async path routing

### DIFF
--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING
 
 # Core exports - always available
 from pydantic_ai_backends.adapter import AsyncBackendAdapter, AsyncSandboxAdapter, ensure_async
-from pydantic_ai_backends.backends.composite import CompositeBackend
+from pydantic_ai_backends.backends.composite import AsyncCompositeBackend, CompositeBackend
 from pydantic_ai_backends.backends.local import LocalBackend
 from pydantic_ai_backends.backends.state import StateBackend
 from pydantic_ai_backends.protocol import (
@@ -224,6 +224,7 @@ __all__ = [
     "StateBackend",
     "LocalBackend",
     "CompositeBackend",
+    "AsyncCompositeBackend",
     # Hashline editing
     "line_hash",
     "format_hashline_output",

--- a/src/pydantic_ai_backends/backends/composite.py
+++ b/src/pydantic_ai_backends/backends/composite.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from pydantic_ai_backends.protocol import BackendProtocol
+from pydantic_ai_backends.adapter import ensure_async
+from pydantic_ai_backends.protocol import AsyncBackendProtocol, BackendProtocol
 from pydantic_ai_backends.types import EditResult, FileInfo, GrepMatch, WriteResult
 
 
@@ -64,11 +65,7 @@ class CompositeBackend:
     @staticmethod
     def _normalize_path(path: str) -> str:
         """Normalize path to consistent format."""
-        if not path.startswith("/"):
-            path = "/" + path
-        if len(path) > 1 and path.endswith("/"):
-            path = path.rstrip("/")
-        return path
+        return _normalize_path(path)
 
     def _get_backend(self, path: str) -> BackendProtocol:
         """Get the appropriate backend for a path."""
@@ -182,3 +179,135 @@ class CompositeBackend:
             return all_results
 
         return self._get_backend(path).grep_raw(pattern, path, glob, ignore_hidden)
+
+
+def _normalize_path(path: str) -> str:
+    """Normalize path to consistent format."""
+    if not path.startswith("/"):
+        path = "/" + path
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    return path
+
+
+class AsyncCompositeBackend:
+    """Async backend that routes operations to different backends by path prefix.
+
+    Accepts both sync and async sub-backends; sync backends are wrapped
+    via :func:`~pydantic_ai_backends.ensure_async` internally.
+
+    Example:
+        ```python
+        from pydantic_ai_backends import AsyncCompositeBackend, StateBackend
+
+        backend = AsyncCompositeBackend(
+            default=StateBackend(),
+            routes={"/scratch/": StateBackend()},
+        )
+        await backend.write("/scratch/tmp.txt", "data")
+        content = await backend.read("/scratch/tmp.txt")
+        ```
+    """
+
+    def __init__(
+        self,
+        default: BackendProtocol | AsyncBackendProtocol,
+        routes: dict[str, BackendProtocol | AsyncBackendProtocol] | None = None,
+    ):
+        self._default = ensure_async(default)
+        raw_routes = routes or {}
+        self._routes = {k: ensure_async(v) for k, v in raw_routes.items()}
+        self._sorted_prefixes = sorted(self._routes.keys(), key=len, reverse=True)
+
+    def _get_backend(self, path: str) -> AsyncBackendProtocol:
+        normalized = _normalize_path(path)
+        for prefix in self._sorted_prefixes:
+            normalized_prefix = _normalize_path(prefix)
+            if normalized == normalized_prefix or normalized.startswith(normalized_prefix + "/"):
+                return self._routes[prefix]
+        return self._default
+
+    async def exists(self, path: str) -> bool:
+        return await self._get_backend(path).exists(path)
+
+    async def ls_info(self, path: str) -> list[FileInfo]:
+        normalized = _normalize_path(path)
+
+        if normalized == "/":
+            all_entries: dict[str, FileInfo] = {}
+
+            for entry in await self._default.ls_info(normalized):
+                all_entries[entry["path"]] = entry
+
+            for prefix in self._routes:
+                parts = prefix.strip("/").split("/")
+                if parts[0]:
+                    dir_name = parts[0]
+                    dir_path = "/" + dir_name
+                    if dir_path not in all_entries:
+                        all_entries[dir_path] = FileInfo(
+                            name=dir_name,
+                            path=dir_path,
+                            is_dir=True,
+                            size=None,
+                        )
+
+            return sorted(all_entries.values(), key=lambda x: (not x["is_dir"], x["name"]))
+
+        backend = self._get_backend(normalized)
+        return await backend.ls_info(normalized)
+
+    async def read_bytes(self, path: str) -> bytes:
+        return await self._get_backend(path).read_bytes(path)
+
+    async def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+        return await self._get_backend(path).read(path, offset, limit)
+
+    async def write(self, path: str, content: str | bytes) -> WriteResult:
+        return await self._get_backend(path).write(path, content)
+
+    async def edit(
+        self, path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> EditResult:
+        return await self._get_backend(path).edit(path, old_string, new_string, replace_all)
+
+    async def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        if path == "/" or path == "":
+            all_results: list[FileInfo] = []
+
+            all_results.extend(await self._default.glob_info(pattern, path))
+
+            for prefix, backend in self._routes.items():
+                results = await backend.glob_info(pattern, prefix)
+                all_results.extend(results)
+
+            return sorted(all_results, key=lambda x: x["path"])
+
+        return await self._get_backend(path).glob_info(pattern, path)
+
+    async def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        ignore_hidden: bool = True,
+    ) -> list[GrepMatch] | str:
+        if path is None or path == "/" or path == "":
+            all_results: list[GrepMatch] = []
+
+            result = await self._default.grep_raw(pattern, path, glob, ignore_hidden)
+            if isinstance(result, list):
+                all_results.extend(result)
+            else:
+                return result
+
+            for prefix, backend in self._routes.items():
+                result = await backend.grep_raw(pattern, prefix, glob, ignore_hidden)
+                if isinstance(result, list):
+                    all_results.extend(result)
+                else:
+                    return result
+
+            return all_results
+
+        return await self._get_backend(path).grep_raw(pattern, path, glob, ignore_hidden)

--- a/tests/test_async_adapter.py
+++ b/tests/test_async_adapter.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from pydantic_ai_backends import (
     AsyncBackendAdapter,
+    AsyncCompositeBackend,
     AsyncSandboxAdapter,
     ExecuteResponse,
+    StateBackend,
     WriteResult,
     ensure_async,
 )
@@ -151,3 +153,210 @@ async def test_sandbox_adapter_prefers_async_execute_when_available() -> None:
     assert await adapter.execute("echo ok", 5) == ExecuteResponse(output="async ok", exit_code=0)
     assert backend.calls[-1] == ("async_execute", ("echo ok", 5))
     assert not any(call[0] == "execute" for call in backend.calls)
+
+
+# --- AsyncCompositeBackend tests ---
+
+
+async def test_async_composite_mixed_sync_async_routing() -> None:
+    sync_backend = StateBackend()
+    async_backend = ensure_async(StateBackend())
+
+    composite = AsyncCompositeBackend(
+        default=sync_backend,
+        routes={"/scratch/": async_backend},
+    )
+
+    await composite.write("/default.txt", "default data")
+    await composite.write("/scratch/temp.txt", "scratch data")
+
+    assert await composite.read("/default.txt") == "     1\tdefault data"
+    assert await composite.read("/scratch/temp.txt") == "     1\tscratch data"
+
+
+async def test_async_composite_read_write_edit_routing() -> None:
+    default = StateBackend()
+    routed = StateBackend()
+    composite = AsyncCompositeBackend(default=default, routes={"/data/": routed})
+
+    await composite.write("/data/file.txt", "hello world")
+    assert await composite.exists("/data/file.txt") is True
+    assert await composite.exists("/data/missing.txt") is False
+
+    result = await composite.edit("/data/file.txt", "hello", "goodbye")
+    assert result.path == "/data/file.txt"
+
+    content = await composite.read("/data/file.txt")
+    assert "goodbye world" in content
+
+    raw = await composite.read_bytes("/data/file.txt")
+    assert raw == b"goodbye world"
+
+
+async def test_async_composite_ls_info_root_aggregation() -> None:
+    default = StateBackend()
+    scratch = StateBackend()
+
+    default.write("/readme.txt", "hi")
+    scratch.write("/scratch/tmp.txt", "tmp")
+
+    composite = AsyncCompositeBackend(default=default, routes={"/scratch/": scratch})
+    entries = await composite.ls_info("/")
+
+    paths = [e["path"] for e in entries]
+    assert "/scratch" in paths
+    assert "/readme.txt" in paths
+
+
+async def test_async_composite_glob_info_root_aggregation() -> None:
+    default = StateBackend()
+    routed = StateBackend()
+
+    default.write("/a.txt", "a")
+    routed.write("/data/b.txt", "b")
+
+    composite = AsyncCompositeBackend(default=default, routes={"/data/": routed})
+    results = await composite.glob_info("**/*.txt")
+
+    paths = [r["path"] for r in results]
+    assert "/a.txt" in paths
+    assert "/data/b.txt" in paths
+
+
+async def test_async_composite_grep_raw_aggregation() -> None:
+    default = StateBackend()
+    routed = StateBackend()
+
+    default.write("/a.py", "foo = 1")
+    routed.write("/lib/b.py", "foo = 2")
+
+    composite = AsyncCompositeBackend(default=default, routes={"/lib/": routed})
+    results = await composite.grep_raw("foo")
+
+    assert isinstance(results, list)
+    paths = [r["path"] for r in results]
+    assert "/a.py" in paths
+    assert "/lib/b.py" in paths
+
+
+async def test_async_composite_grep_raw_error_propagation() -> None:
+    backend = PublicReadBytesBackend()
+
+    class ErrorGrepBackend(PublicReadBytesBackend):
+        def grep_raw(
+            self,
+            pattern: str,
+            path: str | None = None,
+            glob: str | None = None,
+            ignore_hidden: bool = True,
+        ) -> list[GrepMatch] | str:
+            return "regex error: invalid pattern"
+
+    composite = AsyncCompositeBackend(default=ErrorGrepBackend(), routes={"/ok/": backend})
+    result = await composite.grep_raw("(invalid")
+    assert isinstance(result, str)
+    assert "error" in result
+
+
+async def test_async_composite_grep_raw_routed_error_propagation() -> None:
+    class ErrorGrepBackend(PublicReadBytesBackend):
+        def grep_raw(
+            self,
+            pattern: str,
+            path: str | None = None,
+            glob: str | None = None,
+            ignore_hidden: bool = True,
+        ) -> list[GrepMatch] | str:
+            return "regex error: invalid pattern"
+
+    composite = AsyncCompositeBackend(
+        default=PublicReadBytesBackend(), routes={"/err/": ErrorGrepBackend()}
+    )
+    result = await composite.grep_raw("(invalid")
+    assert isinstance(result, str)
+    assert "error" in result
+
+
+async def test_async_composite_exists_routing() -> None:
+    default = StateBackend()
+    routed = StateBackend()
+
+    default.write("/a.txt", "a")
+    routed.write("/mount/b.txt", "b")
+
+    composite = AsyncCompositeBackend(default=default, routes={"/mount/": routed})
+    assert await composite.exists("/a.txt") is True
+    assert await composite.exists("/mount/b.txt") is True
+    assert await composite.exists("/mount/missing.txt") is False
+    assert await composite.exists("/missing.txt") is False
+
+
+async def test_async_composite_path_normalization() -> None:
+    default = StateBackend()
+    routed = StateBackend()
+
+    composite = AsyncCompositeBackend(default=default, routes={"/data/": routed})
+
+    await composite.write("/data/file.txt", "content")
+    # Path without leading slash should still route correctly
+    assert await composite.exists("data/file.txt") is True
+
+
+async def test_async_composite_glob_info_routed_path() -> None:
+    routed = StateBackend()
+    routed.write("/data/file.txt", "content")
+
+    composite = AsyncCompositeBackend(default=StateBackend(), routes={"/data/": routed})
+    results = await composite.glob_info("*.txt", "/data/")
+    paths = [r["path"] for r in results]
+    assert "/data/file.txt" in paths
+
+
+async def test_async_composite_grep_raw_specific_path() -> None:
+    routed = StateBackend()
+    routed.write("/lib/code.py", "target = 42")
+
+    composite = AsyncCompositeBackend(default=StateBackend(), routes={"/lib/": routed})
+    results = await composite.grep_raw("target", "/lib/")
+    assert isinstance(results, list)
+    assert any(r["path"] == "/lib/code.py" for r in results)
+
+
+async def test_async_composite_ls_info_routed_path() -> None:
+    routed = StateBackend()
+    routed.write("/data/file.txt", "content")
+
+    composite = AsyncCompositeBackend(default=StateBackend(), routes={"/data/": routed})
+    entries = await composite.ls_info("/data/")
+    paths = [e["path"] for e in entries]
+    assert "/data/file.txt" in paths
+
+
+async def test_async_composite_ls_info_root_empty_prefix() -> None:
+    composite = AsyncCompositeBackend(default=StateBackend(), routes={"/": StateBackend()})
+    entries = await composite.ls_info("/")
+    assert isinstance(entries, list)
+
+
+async def test_async_composite_ls_info_root_duplicate_dir() -> None:
+    default = StateBackend()
+    default.write("/data/existing.txt", "x")
+
+    composite = AsyncCompositeBackend(default=default, routes={"/data/": StateBackend()})
+    entries = await composite.ls_info("/")
+    dir_entries = [e for e in entries if e["path"] == "/data"]
+    assert len(dir_entries) == 1
+
+
+async def test_ensure_async_on_composite_backend() -> None:
+    from pydantic_ai_backends import CompositeBackend
+
+    sync_composite = CompositeBackend(
+        default=StateBackend(),
+        routes={"/tmp/": StateBackend()},
+    )
+    sync_composite.write("/tmp/file.txt", "data")
+
+    async_adapter = ensure_async(sync_composite)
+    content = await async_adapter.read("/tmp/file.txt")
+    assert "data" in content


### PR DESCRIPTION
## Changes

### Summary

Add `AsyncCompositeBackend` — an async counterpart to `CompositeBackend` that routes file operations across mixed sync/async sub-backends by path prefix, wrapping sync backends via `ensure_async()` internally.

### Business Context

PR #55 added async backend support (`AsyncBackendProtocol`, `AsyncBackendAdapter`, `ensure_async`), but `CompositeBackend` had no async counterpart. Users who need async routing across mixed sync/async backends now have a first-class option.

### Changes

- **`backends/composite.py`**: Added `AsyncCompositeBackend` class mirroring `CompositeBackend`'s routing logic with `async def` methods and `AsyncBackendProtocol` internals. Constructor accepts `BackendProtocol | AsyncBackendProtocol` for both `default` and `routes`. Extracted `_normalize_path` to a shared module-level function to avoid duplication.
- **`__init__.py`**: Exported `AsyncCompositeBackend` via direct import and `__all__`.
- **`tests/test_async_adapter.py`**: Added 15 tests covering mixed sync/async routing, read/write/edit, `ls_info` root aggregation (including edge cases), `glob_info`/`grep_raw` aggregation, error propagation, `exists` routing, path normalization, and `ensure_async` on sync `CompositeBackend`.

### Verification

```bash
uv run pytest tests/test_async_adapter.py -v        # 20 tests pass (15 new)
uv run coverage run -m pytest && uv run coverage report  # 100% coverage
uv run ruff check . && uv run ruff format --check .      # Clean
uv run pyright && uv run mypy src/pydantic_ai_backends   # 0 errors
```

### Linked Issues

Extends #55 (async backend adapter support)