### PR TITLE
fix: enforce permission rules on read_bytes, grep, ls, glob and execute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Permission rules are now enforced on every content-returning path of `LocalBackend`** (closes [#62](https://github.com/vstorm-co/pydantic-ai-backend/issues/62)) (`src/pydantic_ai_backends/backends/local.py`). Previously only `read`/`write`/`edit` and the execute command-pattern check consulted the ruleset, so a `deny` rule like `**/restricted/**` could be bypassed:
+  - `read_bytes` now applies the same "read" rules as `read` (a denied path returns `b""`) — this also closes the leak through the console toolset's `read_file` on images/documents, which reads via `read_bytes`.
+  - `grep_raw` no longer returns matches from files denied for "grep" **or "read"** (grep leaks content, so read denies must apply), and an explicit "grep" deny on the search path errors the search.
+  - `ls_info` / `glob_info` hide entries and matches with an explicit "ls" / "glob" deny. Listings can't prompt, so "ask" is treated as visible — a ruleset whose global default is "ask" keeps listing as before.
+  - `execute` / `async_execute` / `execute_background` gain a best-effort path guard: path-looking tokens in the command are resolved against the backend root and denied when they hit a "read"/"write" deny rule, catching the straightforward `cat restricted/secret.txt` bypass. Documented explicitly as defense-in-depth, not a security boundary — use `DockerSandbox` (or an execute default of "deny"/"ask") for enforced isolation. The permissions docs gained a section spelling out these semantics.
+
 ## [0.2.15] - 2026-06-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.16] - 2026-07-18
 
 ### Fixed
 

--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -372,6 +372,49 @@ backend = LocalBackend(
 # 2. Does the permission ruleset allow this operation?
 ```
 
+### How each operation applies the rules
+
+- **`read` / `read_bytes`** — full "read" semantics: `deny` blocks, `ask`
+  follows the callback / `ask_fallback`. `read_bytes` returns `b""` on a
+  denied path (its documented "empty bytes on failure" contract).
+- **`write` / `edit`** — full "write" / "edit" semantics.
+- **`ls_info` / `glob_info`** — hide entries (and whole listings) with an
+  explicit `deny` rule for the "ls" / "glob" operation. Because a listing
+  can't prompt for approval, `ask` is treated as visible here — only `deny`
+  hides.
+- **`grep_raw`** — an explicit "grep" `deny` on the search path errors the
+  search; individual files denied for "grep" **or for "read"** never
+  contribute matches, so read-protected content can't leak through search
+  results.
+- **`execute`** — see below.
+
+### Shell execution and permission rules
+
+Execute rules pattern-match the **command string**, not file paths — a rule
+like `PermissionRule(pattern="rm *", action="deny")` blocks `rm` commands,
+but a read deny on `**/restricted/**` says nothing about `cat restricted/x`.
+
+As defense-in-depth, `LocalBackend` also resolves path-looking tokens in the
+command and denies it when one hits a "read" or "write" deny rule, so the
+straightforward bypass (`cat restricted/secret.txt`) is caught.
+
+**This guard is a speed bump, not a security boundary.** A shell can always
+reach a file in ways command-string inspection cannot see (subshells,
+`python -c`, encodings, …). If you need enforced path isolation *and* shell
+access, run commands in a sandboxed backend such as `DockerSandbox` (mount
+only what the agent may touch), or set the execute default to `"deny"` or
+`"ask"`:
+
+```python
+ruleset = PermissionRuleset(
+    read=OperationPermissions(
+        default="allow",
+        rules=[PermissionRule(pattern="**/restricted/**", action="deny")],
+    ),
+    execute=OperationPermissions(default="deny"),  # shell can't bypass file rules
+)
+```
+
 ## Integration with Console Toolset
 
 Pass permissions to the toolset:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.15"
+version = "0.2.16"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import os
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -264,6 +265,84 @@ class LocalBackend:
         # ask_fallback == "error"
         raise PermissionAskError(operation, target, "Approval required but no callback")
 
+    def _is_denied_sync(self, operation: PermissionOperation, target: str) -> bool:
+        """True when the ruleset explicitly resolves to "deny" for this target.
+
+        Used by listing/search operations (`ls`, `glob`, `grep`) where a sync
+        "ask" cannot be answered: those operations only hide explicitly denied
+        targets and treat "ask" as visible, so a ruleset whose global default
+        is "ask" doesn't blank out every listing.
+        """
+        if self._permission_checker is None:
+            return False
+        return self._permission_checker.check_sync(operation, target) == "deny"
+
+    def _grep_file_hidden(self, path: str) -> bool:
+        """True when a file must not contribute grep matches.
+
+        A file is hidden from grep when it is explicitly denied for "grep",
+        or denied for "read" — grep returns file content, so a read deny
+        must also stop content from leaking through search results.
+        """
+        return self._is_denied_sync("grep", path) or self._is_denied_sync("read", path)
+
+    def _command_path_targets(self, command: str) -> set[str]:
+        """Best-effort extraction of filesystem paths referenced by a command.
+
+        Tokenizes the command, expands `~`, and resolves each token (and the
+        value side of `--flag=value` tokens) against the backend root — the
+        cwd commands actually run in. Non-path tokens resolve to harmless
+        paths that simply won't match any deny rule.
+        """
+        try:
+            tokens = shlex.split(command, posix=True)
+        except ValueError:
+            # Unbalanced quotes etc. — fall back to whitespace splitting so a
+            # malformed command can't dodge the guard entirely.
+            tokens = [token.strip("\"'") for token in command.split()]
+
+        candidates: set[str] = set()
+        for token in tokens:
+            candidates.add(token)
+            if "=" in token:
+                candidates.add(token.split("=", 1)[1])
+
+        targets: set[str] = set()
+        for candidate in candidates:
+            if not candidate:
+                continue
+            expanded = os.path.expanduser(candidate)
+            p = Path(expanded)
+            resolved = p.resolve() if p.is_absolute() else (self._root / expanded).resolve()
+            targets.add(str(resolved))
+        return targets
+
+    def _check_execute_permission_sync(self, command: str) -> str | None:
+        """Check a command against execute rules plus a best-effort path guard.
+
+        After the command-pattern check, path-looking tokens in the command are
+        resolved and denied when one hits a "read" or "write" deny rule, so the
+        straightforward bypass (`cat restricted/secret.txt`) is caught. This is
+        defense-in-depth, not a security boundary — a shell can always reach a
+        file in ways command-string inspection cannot see. For enforced
+        isolation use a sandboxed backend (e.g. `DockerSandbox`).
+        """
+        perm_error = self._check_permission_sync("execute", command)
+        if perm_error:
+            return perm_error
+        if self._permission_checker is None:
+            return None
+
+        guarded_ops: tuple[PermissionOperation, ...] = ("read", "write")
+        for target in sorted(self._command_path_targets(command)):
+            for op in guarded_ops:
+                if self._is_denied_sync(op, target):
+                    return (
+                        f"Permission denied: command references '{target}', "
+                        f"which is denied for {op}"
+                    )
+        return None
+
     def _validate_path(self, path: str) -> Path:
         """Validate and resolve path within allowed directories.
 
@@ -324,10 +403,17 @@ class LocalBackend:
             return False
 
     def ls_info(self, path: str) -> list[FileInfo]:
-        """List files and directories at the given path."""
+        """List files and directories at the given path.
+
+        Entries (and the path itself) with an explicit "ls" deny rule are
+        omitted; "ask" is treated as visible (listings can't prompt).
+        """
         try:
             full_path = self._validate_path(path)
         except PermissionError:  # pragma: no cover
+            return []
+
+        if self._is_denied_sync("ls", str(full_path)):
             return []
 
         if not full_path.exists():  # pragma: no cover
@@ -349,6 +435,8 @@ class LocalBackend:
                 try:
                     # Validate each entry is within allowed dirs
                     self._validate_path(str(entry))
+                    if self._is_denied_sync("ls", str(entry)):
+                        continue
                     results.append(
                         FileInfo(
                             name=entry.name,
@@ -364,11 +452,20 @@ class LocalBackend:
 
         return sorted(results, key=lambda x: (not x["is_dir"], x["name"]))
 
-    def read_bytes(self, path: str) -> bytes:  # pragma: no cover
-        """Read raw bytes from a file."""
+    def read_bytes(self, path: str) -> bytes:
+        """Read raw bytes from a file.
+
+        Applies the same "read" permission rules as `read` — a denied path
+        returns `b""`, matching the documented "empty bytes on failure"
+        contract (an "ask" that can't be answered follows `ask_fallback`,
+        exactly like `read`).
+        """
         try:
             full_path = self._validate_path(path)
         except PermissionError:
+            return b""
+
+        if self._check_permission_sync("read", str(full_path)) is not None:
             return b""
 
         if not full_path.exists() or not full_path.is_file():
@@ -376,7 +473,7 @@ class LocalBackend:
 
         try:
             return full_path.read_bytes()
-        except (PermissionError, OSError):
+        except (PermissionError, OSError):  # pragma: no cover
             return b""
 
     def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
@@ -519,10 +616,17 @@ class LocalBackend:
             return EditResult(error=str(e))
 
     def glob_info(self, pattern: str, path: str = ".") -> list[FileInfo]:
-        """Find files matching a glob pattern."""
+        """Find files matching a glob pattern.
+
+        Matches (and the base path itself) with an explicit "glob" deny rule
+        are omitted; "ask" is treated as visible (listings can't prompt).
+        """
         try:
             base_path = self._validate_path(path)
         except PermissionError:  # pragma: no cover
+            return []
+
+        if self._is_denied_sync("glob", str(base_path)):
             return []
 
         if not base_path.exists():  # pragma: no cover
@@ -539,6 +643,8 @@ class LocalBackend:
                 if match.is_file():
                     try:
                         self._validate_path(str(match))
+                        if self._is_denied_sync("glob", str(match)):
+                            continue
                         stat = match.stat()
                         collected.append(
                             (
@@ -570,6 +676,10 @@ class LocalBackend:
         """Search for pattern in files.
 
         Uses ripgrep if available, falls back to Python regex.
+
+        Files denied for "grep" — or for "read", since matches leak file
+        content — never contribute results; an explicit "grep" deny on the
+        search path errors the whole search.
         """
         search_path = path or str(self._root)
 
@@ -577,6 +687,9 @@ class LocalBackend:
             validated_path = self._validate_path(search_path)
         except PermissionError as e:  # pragma: no cover
             return str(e)
+
+        if self._is_denied_sync("grep", str(validated_path)):
+            return f"Error: Permission denied for grep on '{search_path}'"
 
         # Try ripgrep first when searching directories for better performance
         use_ripgrep = shutil.which("rg") is not None and not validated_path.is_file()
@@ -632,6 +745,8 @@ class LocalBackend:
                     base_path = search_path.parent if search_path.is_file() else search_path
                     full_path = (base_path / file_path).resolve()
                     self._validate_path(str(full_path))
+                    if self._grep_file_hidden(str(full_path)):
+                        continue
                     results.append(
                         GrepMatch(
                             path=str(full_path),
@@ -682,6 +797,9 @@ class LocalBackend:
             except PermissionError:
                 continue
 
+            if self._grep_file_hidden(str(file_path)):
+                continue
+
             try:
                 with open(file_path, encoding="utf-8", errors="replace") as f:
                     for i, line in enumerate(f):
@@ -718,7 +836,7 @@ class LocalBackend:
             )
 
         # Check permissions
-        perm_error = self._check_permission_sync("execute", command)
+        perm_error = self._check_execute_permission_sync(command)
         if perm_error:
             return ExecuteResponse(
                 output=f"Error: {perm_error}",
@@ -776,7 +894,7 @@ class LocalBackend:
                 "Initialize with enable_execute=True to enable."
             )
 
-        perm_error = self._check_permission_sync("execute", command)
+        perm_error = self._check_execute_permission_sync(command)
         if perm_error:
             return ExecuteResponse(output=f"Error: {perm_error}", exit_code=1, truncated=False)
 
@@ -868,7 +986,7 @@ class LocalBackend:
                 "Shell execution is disabled for this backend. "
                 "Initialize with enable_execute=True to enable."
             )
-        perm_error = self._check_permission_sync("execute", command)
+        perm_error = self._check_execute_permission_sync(command)
         if perm_error:
             raise PermissionError(perm_error)
 

--- a/tests/test_local_backend_permissions.py
+++ b/tests/test_local_backend_permissions.py
@@ -280,6 +280,313 @@ class TestLocalBackendExecutePermissions:
         assert "Block rm commands" in result.output
 
 
+class TestLocalBackendReadBytesPermissions:
+    """`read_bytes` must honor the same "read" rules as `read` (issue #62)."""
+
+    def test_read_bytes_without_permissions(self, tmp_path: Path):
+        """No ruleset — read_bytes returns content."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        (tmp_path / "data.bin").write_bytes(b"\x00\x01payload")
+
+        assert backend.read_bytes("data.bin") == b"\x00\x01payload"
+
+    def test_read_bytes_allowed(self, tmp_path: Path):
+        ruleset = PermissionRuleset(read=OperationPermissions(default="allow"))
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        (tmp_path / "data.bin").write_bytes(b"payload")
+
+        assert backend.read_bytes("data.bin") == b"payload"
+
+    def test_read_bytes_denied_by_rule(self, tmp_path: Path):
+        """A read deny rule must block the raw-bytes path too."""
+        ruleset = PermissionRuleset(
+            read=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted/**", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        secret = tmp_path / "restricted" / "secret.txt"
+        secret.parent.mkdir()
+        secret.write_text("SECRET=123")
+
+        assert backend.read_bytes("restricted/secret.txt") == b""
+
+    def test_read_bytes_default_deny(self, tmp_path: Path):
+        ruleset = PermissionRuleset(read=OperationPermissions(default="deny"))
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        (tmp_path / "data.bin").write_bytes(b"payload")
+
+        assert backend.read_bytes("data.bin") == b""
+
+    def test_read_bytes_ask_with_deny_fallback(self, tmp_path: Path):
+        ruleset = PermissionRuleset(read=OperationPermissions(default="ask"))
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset, ask_fallback="deny")
+
+        (tmp_path / "data.bin").write_bytes(b"payload")
+
+        assert backend.read_bytes("data.bin") == b""
+
+    def test_read_bytes_ask_with_error_fallback(self, tmp_path: Path):
+        ruleset = PermissionRuleset(read=OperationPermissions(default="ask"))
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset, ask_fallback="error")
+
+        (tmp_path / "data.bin").write_bytes(b"payload")
+
+        with pytest.raises(PermissionAskError):
+            backend.read_bytes("data.bin")
+
+    def test_read_bytes_outside_allowed_directories(self, tmp_path: Path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        backend = LocalBackend(allowed_directories=[str(project_dir)])
+
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"payload")
+
+        assert backend.read_bytes(str(outside)) == b""
+
+    def test_read_bytes_missing_file(self, tmp_path: Path):
+        backend = LocalBackend(root_dir=tmp_path)
+
+        assert backend.read_bytes("missing.bin") == b""
+
+    def test_read_bytes_directory(self, tmp_path: Path):
+        backend = LocalBackend(root_dir=tmp_path)
+
+        (tmp_path / "subdir").mkdir()
+
+        assert backend.read_bytes("subdir") == b""
+
+
+class TestLocalBackendListingPermissions:
+    """`ls`, `glob`, and `grep` honor explicit deny rules (issue #62)."""
+
+    def _restricted_tree(self, tmp_path: Path) -> None:
+        (tmp_path / "app.py").write_text("print('SECRET_MARKER ok')\n")
+        restricted = tmp_path / "restricted"
+        restricted.mkdir()
+        (restricted / "secret.txt").write_text("SECRET_MARKER hidden\n")
+
+    def test_ls_denied_path_returns_empty(self, tmp_path: Path):
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(
+            ls=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted*", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        assert backend.ls_info("restricted") == []
+
+    def test_ls_hides_denied_entries(self, tmp_path: Path):
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(
+            ls=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted*", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        names = [info["name"] for info in backend.ls_info(".")]
+
+        assert "app.py" in names
+        assert "restricted" not in names
+
+    def test_ls_global_ask_default_still_lists(self, tmp_path: Path):
+        """A global default of "ask" must not blank out listings (compat)."""
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(read=OperationPermissions(default="allow"))
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        names = [info["name"] for info in backend.ls_info(".")]
+
+        assert "app.py" in names
+
+    def test_glob_denied_base_returns_empty(self, tmp_path: Path):
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(
+            glob=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted*", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        assert backend.glob_info("**/*.txt", "restricted") == []
+
+    def test_glob_hides_denied_matches(self, tmp_path: Path):
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(
+            glob=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted/**", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        paths = [info["path"] for info in backend.glob_info("**/*")]
+
+        assert any(p.endswith("app.py") for p in paths)
+        assert not any("secret.txt" in p for p in paths)
+
+    def test_grep_denied_search_path_errors(self, tmp_path: Path):
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(
+            grep=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted*", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        result = backend.grep_raw("SECRET_MARKER", "restricted")
+
+        assert isinstance(result, str)
+        assert "Permission denied" in result
+
+    def test_grep_read_deny_hides_content(self, tmp_path: Path):
+        """Grep must not leak lines from files the agent may not read."""
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(
+            read=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted/**", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        result = backend.grep_raw("SECRET_MARKER")
+
+        assert isinstance(result, list)
+        assert any(m["path"].endswith("app.py") for m in result)
+        assert not any("secret.txt" in m["path"] for m in result)
+
+    def test_grep_grep_deny_hides_file(self, tmp_path: Path):
+        self._restricted_tree(tmp_path)
+        ruleset = PermissionRuleset(
+            grep=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted/**", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        result = backend.grep_raw("SECRET_MARKER")
+
+        assert isinstance(result, list)
+        assert not any("secret.txt" in m["path"] for m in result)
+
+
+class TestLocalBackendExecutePathGuard:
+    """Best-effort guard: commands referencing read/write-denied paths (issue #62)."""
+
+    def _backend(self, tmp_path: Path) -> LocalBackend:
+        secret = tmp_path / "restricted" / "secret.txt"
+        secret.parent.mkdir(exist_ok=True)
+        secret.write_text("SECRET=123")
+        ruleset = PermissionRuleset(
+            read=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/restricted/**", action="deny")],
+            ),
+            execute=OperationPermissions(default="allow"),
+        )
+        return LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+    def test_execute_denies_relative_path_to_denied_file(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+
+        result = backend.execute("cat restricted/secret.txt")
+
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+        assert "SECRET" not in result.output
+
+    def test_execute_denies_absolute_path_to_denied_file(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+
+        result = backend.execute(f"cat {tmp_path / 'restricted' / 'secret.txt'}")
+
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+        assert "SECRET" not in result.output
+
+    def test_execute_denies_flag_value_path(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+
+        result = backend.execute("some-tool --empty= --input=restricted/secret.txt")
+
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+
+    def test_execute_guard_survives_unbalanced_quotes(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+
+        result = backend.execute("cat 'restricted/secret.txt")
+
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+
+    def test_execute_denies_write_denied_path(self, tmp_path: Path):
+        ruleset = PermissionRuleset(
+            write=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="**/protected/**", action="deny")],
+            ),
+            execute=OperationPermissions(default="allow"),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        result = backend.execute("touch protected/new.txt")
+
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+
+    def test_execute_allows_unrelated_command(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+
+        result = backend.execute("echo hello ./allowed/path.txt")
+
+        assert result.exit_code == 0
+        assert "hello" in result.output
+
+    def test_execute_rule_check_still_wins(self, tmp_path: Path):
+        """The command-pattern check runs before the path guard."""
+        ruleset = PermissionRuleset(
+            execute=OperationPermissions(
+                default="allow",
+                rules=[PermissionRule(pattern="rm *", action="deny")],
+            ),
+        )
+        backend = LocalBackend(root_dir=tmp_path, permissions=ruleset)
+
+        result = backend.execute("rm file.txt")
+
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+
+    async def test_async_execute_uses_path_guard(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+
+        result = await backend.async_execute("cat restricted/secret.txt")
+
+        assert result.exit_code == 1
+        assert "Permission denied" in result.output
+
+    def test_execute_background_uses_path_guard(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+
+        with pytest.raises(PermissionError, match="Permission denied"):
+            backend.execute_background("cat restricted/secret.txt")
+
+
 class TestLocalBackendPermissionsWithAllowedDirectories:
     """Tests for permissions combined with allowed_directories."""
 


### PR DESCRIPTION
Issue: https://github.com/vstorm-co/pydantic-ai-backend/issues/62