### PR TITLE
chore: release 0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17] - 2026-08-01
+
 ### Added
 
 - **`AsyncBaseSandbox`** — the shell-derived file operations, for a sandbox that is natively asynchronous. `BaseSandbox` gives a subclass every operation for the price of implementing `execute` and `edit`, but only synchronously, so an author reaching a sandbox over asyncssh or an async HTTP SDK got nothing from it and hand-wrote all eight: `ls -la` and its parsing, `awk` for a numbered read, `find -path` for a glob, `grep -rn`, a heredoc write. That is a reimplementation of a class we already ship, and one that drifts from ours the moment either changes. Both bases now derive their operations from one internal module, so a subclass implements `execute` and `edit` — as coroutines — and nothing else.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.16"
+version = "0.2.17"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Closes the `[Unreleased]` section and bumps to 0.2.17.

Everything since 0.2.16, in three merged PRs:

- **#66** — the remote sandbox service, operator dashboard and library-wide refactor.
- **#67** — `AsyncBaseSandbox`, `is_async_backend`, and the toolset no longer letting a backend's exception end the agent's run.
- **#68** — the review that followed: `AsyncBaseSandbox` did not actually work with `SessionManager`, a sandbox found dead was dropped without being stopped, the exception guard covered one tool of thirteen, and that guard would have swallowed pydantic-ai's control-flow exceptions.

Verified before tagging: 1214 tests, 100% branch coverage, pyright and mypy strict clean, `mkdocs build --strict` passes, and the built wheel installs into a clean environment and serves `/healthz` and `/ui` — the dashboard is a data file, so its absence from the wheel would only have shown up after publishing.