### PR TITLE
fix: export `is_async_backend` from the package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`is_async_backend` is importable from the package root**, alongside `ensure_async`. 0.2.17 announced it as public API and documented it, but only added it to `adapter.py` — so `from pydantic_ai_backends import is_async_backend` raised `ImportError` and the only way in was the submodule path.
+
 ## [0.2.17] - 2026-08-01
 
 ### Added

--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -47,6 +47,7 @@ from pydantic_ai_backends.adapter import (
     AsyncBackgroundSandboxAdapter,
     AsyncSandboxAdapter,
     ensure_async,
+    is_async_backend,
 )
 from pydantic_ai_backends.backends.composite import AsyncCompositeBackend, CompositeBackend
 from pydantic_ai_backends.backends.local import LocalBackend
@@ -282,6 +283,7 @@ __all__ = [
     "create_console_toolset",
     "create_ruleset",
     "ensure_async",
+    "is_async_backend",
     "format_hashline_output",
     "get_console_system_prompt",
     "get_runtime",

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -54,3 +54,12 @@ class TestLazyLoading:
         with pytest.raises(AttributeError) as excinfo:
             _ = pydantic_ai_backends.NonExistentClass
         assert "NonExistentClass" in str(excinfo.value)
+
+
+def test_adapter_helpers_are_importable_from_the_root():
+    """0.2.17 documented `is_async_backend` but exported only its sibling."""
+    import pydantic_ai_backends as package
+
+    for name in ("ensure_async", "is_async_backend"):
+        assert name in package.__all__
+        assert getattr(package, name).__name__ == name


### PR DESCRIPTION
Caught smoke-testing the published 0.2.17 wheel from PyPI.

0.2.17 announces `is_async_backend` as public API in the changelog and links it from the backends guide, but it was only added to `adapter.py` — never to the package root's lazy-import map or `__all__`. So `from pydantic_ai_backends import is_async_backend` raises `ImportError`, while its sibling `ensure_async` is exported. Anyone following the changelog hits it immediately.

Fixed, with a test that pins both names at the root so the pair cannot drift again.

Not urgent — the function is reachable as `from pydantic_ai_backends.adapter import is_async_backend`, which is what the docs actually link and what the test suite already used. Whether this warrants a 0.2.18 or should ride along with the next release is your call; it is under `[Unreleased]` either way.