### PR TITLE
fix: report usable paths from a directory listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A listing no longer reports paths the sandbox cannot read back.** `ls_info` built each row's `path` from the *shell-quoted* directory, so listing `/my work` returned `'/my work'/notes.md` — a path that does not exist. A model handed that row and asking to read it got a failure it could not recover from, and the directory was effectively unreachable. Plain paths quote to themselves, which is why it went unnoticed. Affects every shell-derived sandbox: Docker, Daytona, Kubernetes and any third-party one.
+
 - **`is_async_backend` is importable from the package root**, alongside `ensure_async`. 0.2.17 announced it as public API and documented it, but only added it to `adapter.py` — so `from pydantic_ai_backends import is_async_backend` raised `ImportError` and the only way in was the submodule path.
 
 ## [0.2.17] - 2026-08-01

--- a/src/pydantic_ai_backends/backends/_shell.py
+++ b/src/pydantic_ai_backends/backends/_shell.py
@@ -41,7 +41,12 @@ def parse_ls(result: ExecuteResponse, path: str) -> list[FileInfo]:
     if result.exit_code != 0:
         return []
 
-    quoted_path = shlex.quote(path)
+    # The *unquoted* path: a listing's rows are handed to a model, which sends
+    # them back to `read` or `edit`, which quote for the shell themselves. Built
+    # from the quoted form, a directory with a space in it produced
+    # `'/my work'/notes.md` — a path that does not exist and cannot be recovered
+    # from. Plain paths quote to themselves, which is why it went unnoticed.
+    root = path.rstrip("/")
     entries: list[FileInfo] = []
     for line in result.output.strip().split("\n")[1:]:  # The first line is the total.
         parts = line.split()
@@ -55,7 +60,7 @@ def parse_ls(result: ExecuteResponse, path: str) -> list[FileInfo]:
         entries.append(
             FileInfo(
                 name=name,
-                path=f"{quoted_path.rstrip('/')}/{name}",
+                path=f"{root}/{name}",
                 is_dir=parts[0].startswith("d"),
                 size=int(parts[4]) if parts[4].isdigit() else None,
             )

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -96,6 +96,25 @@ drwxr-xr-x 2 root root 4096 Jan  1 00:00 src
     def test_a_failed_listing_is_empty(self):
         assert _shell.parse_ls(_failed(), "/w") == []
 
+    @pytest.mark.parametrize(
+        "root,expected",
+        [
+            ("/work", "/work/notes.md"),
+            ("/work/", "/work/notes.md"),
+            ("/", "/notes.md"),
+            # Built from the shell-quoted root this was `'/my work'/notes.md`,
+            # which the model then sent back to `read` and which does not exist.
+            ("/my work", "/my work/notes.md"),
+            ("/it's mine", "/it's mine/notes.md"),
+        ],
+    )
+    def test_the_reported_path_is_usable_not_shell_quoted(self, root: str, expected: str):
+        listing = "total 4\n-rw-r--r-- 1 root root 1 Jan  1 00:00 notes.md\n"
+
+        rows = _shell.parse_ls(_ok(listing), root)
+
+        assert rows[0]["path"] == expected
+
 
 class TestReadBytes:
     def test_content_is_returned(self):


### PR DESCRIPTION
A real bug I flagged during the review of main but deliberately preserved when extracting `_shell.py`, so as not to mix a behaviour change into a refactor. Closing it now.

`ls_info` built each row's `path` from the **shell-quoted** directory:

```python
rows = sandbox.ls_info("/my work")
rows[0]["path"]   # "'/my work'/notes.md"  — does not exist
```

A model is handed that row, asks to read it, and gets a failure it cannot recover from — the directory is effectively unreachable. Plain paths quote to themselves, which is why nobody hit it.

Affects every shell-derived sandbox: `DockerSandbox`, `DaytonaSandbox`, `KubernetesPodSandbox` and any third-party one, in both the sync and async base.

Regression test covers a plain root, a trailing slash, `/`, a space, and an apostrophe — the last two fail without the fix.

Under `[Unreleased]`, alongside the `is_async_backend` export fix from #70.