### PR TITLE
chore: release 0.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-08-01
+
 ### Added
 
 - **`KubernetesPodSandbox` and `DaytonaSandbox` are covered.** The last two class-level `# pragma: no cover`; no blanket one remains in the package. 30 tests cover the pod-exec path, both readiness outcomes and the polling in between, liveness, config loading, the `mode="http"` listing failures and the `mode="api"` fallbacks to the shell — plus Daytona's readiness probe and failure handlers. The two exec bugs above are what the pass found.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.17"
+version = "0.2.18"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
A bug-fix release. Four things shipped broken in 0.2.17, all found by reviewing main afterwards rather than reported:

| | |
|---|---|
| #70 | `is_async_backend` was announced as public API and documented, but `from pydantic_ai_backends import is_async_backend` raised `ImportError` |
| #71 | `ls_info` reported shell-quoted paths, so a directory with a space in its name was unreachable — the model got a path it could not read back |
| #72 | `glob_info` aborted its whole walk on one unreadable entry, returning a silently short listing. Four matching files with one bad entry returned **one** |
| #74 | A Kubernetes exec reported an unknown status as **success**, so every truncated command looked like it passed — and leaked a websocket per failed command |

Plus #73 and the coverage halves of #72 and #74: **no blanket `# pragma: no cover` remains in the package.** Removing them is what found three of the four bugs above. What was hidden: `LocalBackend`'s entire permission boundary, every console tool's rendering, and both remote sandbox classes.

Verified before tagging: 1329 tests, 100% branch coverage — with and without `rg` on PATH, after #72 showed coverage here could depend on what the machine has installed. pyright and mypy strict clean, `mkdocs build --strict` passes, and the built wheel installs into a clean environment where I checked the three fixes above by hand and confirmed `/healthz` and `/ui` still serve.