### PR TITLE
chore: release 0.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.19] - 2026-08-01
+
 ### Changed
 
 - **`SandboxdConfig.default_runtime` defaults to the first entry in `runtimes`** rather than to the literal alias `"python"`. The old default meant every custom allowlist had to contain a key named `python` or the config refused to construct, which is a coupling nothing asked for. The shipped allowlist lists `coding` first, so that is what a default service now hands out; naming an alias explicitly still wins, and naming one that is not allowed is still refused.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.18"
+version = "0.2.19"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump and changelog heading for 0.2.19.

Ships the hibernate tier (sessions are evicted by giving up their sandbox rather than their identity, with `max_open_sessions` bounding what exists against `max_sessions` bounding what is resident), the `coding` runtime, and the two bugs found building it — orphaned processes accumulating as zombies until a session could not fork, and git refusing to work in a bind-mounted workspace.

Full detail in [#76](https://github.com/vstorm-co/pydantic-ai-backend/pull/76).