### PR TITLE
feat: run sandboxes as an unprivileged user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`SandboxdConfig.sandbox_uid`, which runs sandboxes as an unprivileged user.** A container runs as root unless told otherwise, and that is two problems: an escape starts from uid 0, and every file an agent writes into its bind-mounted workspace is owned by root *on the host*, so a `sandboxd` running unprivileged cannot clean up after its own sessions. Set the uid and built runtimes are built around it — a real account (a bare numeric id breaks everything calling `getpwuid`, `whoami` first), a home directory it owns (with `HOME` left at `/`, the first `pip install` fails on `Permission denied: '/.local'`), and a virtualenv it owns first on `PATH`. That last one is what makes it workable rather than merely safer: a non-root user cannot write to the interpreter's own `site-packages`, and `uv` — unlike pip — has no `--user` mode to fall back on, so without a virtualenv it fails with no way forward. Measured in that shape: `whoami`, `git commit`, `pip install`, `uv pip install` and running the installed tool all succeed, while `/etc` and the system `site-packages` are refused.
+
+  Off by default, because it changes filesystem ownership. It asks two things of the deployment: the service must be able to give each workspace to that uid — with the privilege to `chown`, or by running *as* it — and a service that can do neither is told so when the session opens rather than starting a sandbox whose first file write would fail. Ready-made runtimes stay as root, since an image nobody built for this has no such user and no virtualenv, so an agent inside one could install nothing.
+- **`RuntimeConfig.run_as_uid`**, the library-level form of the same thing for anyone building a `DockerSandbox` directly.
+
 ## [0.2.19] - 2026-08-01
 
 ### Changed

--- a/docs/concepts/remote.md
+++ b/docs/concepts/remote.md
@@ -182,6 +182,46 @@ that:
   untrusted code should not give them the network unless that is deliberate.
 - Bind it to a private network. It has no TLS and no rate limiting of its own.
 
+### Running sandboxes unprivileged
+
+A container runs as root unless told otherwise, and that is two problems: an
+escape starts from uid 0, and every file an agent writes into its bind-mounted
+workspace is owned by root **on the host**, so a `sandboxd` running
+unprivileged cannot clean up after its own sessions.
+
+`sandbox_uid` turns that off:
+
+```python
+SandboxdConfig(
+    token=token,
+    workspace_root="/var/lib/sandboxd",
+    sandbox_uid=1000,
+)
+```
+
+Built runtimes are then built around that user — a real account for it, a home
+directory, and a virtualenv it owns first on `PATH` — and their containers run
+as it, with each session's workspace given to it.
+
+The virtualenv is what makes this workable rather than merely safer. A non-root
+user cannot write to the interpreter's own `site-packages`, so without one an
+agent's first `pip install` fails; `uv`, which has no `--user` mode, fails with
+no way forward at all. Owning a virtualenv means both simply work, and console
+scripts land somewhere already on `PATH`. Measured in that shape: `whoami`,
+`git commit`, `pip install`, `uv pip install` and running the installed tool all
+succeed, while `/etc` and the system `site-packages` are refused.
+
+Two things it asks of the deployment:
+
+- **The service must be able to give each workspace to that uid.** Either run it
+  with the privilege to `chown`, or run it *as* that uid so the directories are
+  created owned by it. A service that can do neither is told so when the session
+  opens, rather than starting a sandbox whose first file write would fail with
+  an error nothing explains.
+- **Ready-made runtimes stay as root.** An image nobody built for this has no
+  such user and no virtualenv, so an agent inside one could install nothing. The
+  uid reaches runtimes built from a `base_image` and no others.
+
 ## Sessions that outlive a run
 
 By default, opening a session id that is already in use is a `409` — silently

--- a/docs/plans/coding-agent-runtime.md
+++ b/docs/plans/coding-agent-runtime.md
@@ -204,12 +204,36 @@ default.
 
 ## What is still open
 
-- **Running as a non-root user.** `_run_kwargs` sets no `user`, so every sandbox
-  runs as uid 0. Two things follow: an escape starts from root rather than from
-  nobody, and every file the agent writes into the bind-mounted workspace is
-  owned by root *on the host*, so a `sandboxd` running unprivileged cannot clean
-  up after its own sessions. `no-new-privileges` does not help — it stops a
-  process gaining privileges it lacks, and this one already has them.
+- ~~**Running as a non-root user.**~~ Shipped as `SandboxdConfig.sandbox_uid`
+  and `RuntimeConfig.run_as_uid`. The measurements changed the design twice on
+  the way, and both corrections are worth keeping:
+
+  - **`getpwuid` was not the problem.** The note below guessed git would break
+    on a uid with no `/etc/passwd` entry. It does not — git works fine. What
+    breaks is `pip`, on `Permission denied: '/.local'`, because `HOME` defaults
+    to `/`.
+  - **`uv` was the real obstacle**, and it is not fixable with a writable home.
+    `uv` has no `--user` mode: `--system` hits permission denied on the
+    interpreter's `site-packages`, and without it there is simply no
+    environment. A virtualenv the sandbox user owns is the only design that
+    works, which is why option (1) below was not the one taken.
+  - **The container's environment overrides its image's**, so the
+    `UV_SYSTEM_PYTHON=0` the image asks for was being clobbered by the sandbox
+    default. It is dropped for an unprivileged runtime instead.
+
+  Validated on true Linux filesystem semantics rather than through a macOS bind
+  mount: `whoami`, `git commit`, `pip install`, `uv pip install` and running the
+  installed console script all succeed, while `/etc` and the system
+  `site-packages` are refused.
+
+  Original reasoning, kept because the options were the argument:
+
+  `_run_kwargs` set no `user`, so every sandbox ran as uid 0. Two things
+  followed: an escape starts from root rather than from nobody, and every file
+  the agent writes into the bind-mounted workspace is owned by root *on the
+  host*, so a `sandboxd` running unprivileged cannot clean up after its own
+  sessions. `no-new-privileges` does not help — it stops a process gaining
+  privileges it lacks, and this one already has them.
 
   It is not a one-line fix, because adding `user="1000:1000"` breaks the happy
   path immediately: `_session_volumes` creates

--- a/src/pydantic_ai_backends/backends/docker/_image.py
+++ b/src/pydantic_ai_backends/backends/docker/_image.py
@@ -51,6 +51,21 @@ cargo names — and rejects whitespace and shell metacharacters."""
 ENV_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 """The POSIX portable character set for environment variable names."""
 
+VENV_PATH = "/opt/venv"
+"""Where an unprivileged runtime's virtualenv lives.
+
+Outside both the workspace — which is a bind mount, and would carry the
+environment into the user's own files — and the interpreter's own tree, which
+the sandbox user must not be able to write to.
+"""
+
+SANDBOX_USER = "agent"
+"""Login name given to the uid a `run_as_uid` runtime runs as.
+
+A numeric uid with no `/etc/passwd` entry works for the kernel and confuses
+everything that calls `getpwuid`, `whoami` included.
+"""
+
 SHELL_METACHARACTERS = frozenset(";&|`$()<>\n\r")
 """Characters that would let an interpolated value start its own command."""
 
@@ -256,6 +271,9 @@ def build_dockerfile(runtime: RuntimeConfig, *, cache_mounts: bool = False) -> s
     if runtime.packages:
         lines.extend(install_instructions(runtime, cache_mounts=cache_mounts))
 
+    if runtime.run_as_uid is not None:
+        lines.extend(unprivileged_instructions(runtime.run_as_uid))
+
     for key, value in runtime.env_vars.items():
         lines.append(env_instruction(key, value))
 
@@ -263,6 +281,43 @@ def build_dockerfile(runtime: RuntimeConfig, *, cache_mounts: bool = False) -> s
     lines.append(f"WORKDIR {shlex.quote(runtime.work_dir)}")
 
     return "\n".join(lines)
+
+
+def unprivileged_instructions(uid: int) -> list[str]:
+    """Instructions preparing an image to be run by an unprivileged user.
+
+    Three things, and each is load-bearing:
+
+    - **A real account** for `uid`, because a bare numeric id works for the
+      kernel and breaks everything that calls `getpwuid` — `whoami` first.
+    - **A home directory it owns**, since with `HOME` left at `/` an agent's
+      first `pip install` fails on `Permission denied: '/.local'`.
+    - **A virtualenv it owns**, first on `PATH`. Without one a non-root user
+      cannot install anything: pip falls back to a user-site directory whose
+      console scripts are not on `PATH`, and `uv` — which has no `--user` mode —
+      fails outright. Created with `--system-site-packages`, so a runtime's own
+      `packages`, installed system-wide above, stay importable.
+
+    `UV_SYSTEM_PYTHON` is switched off here rather than left to the sandbox's
+    default: on it, uv aims at the interpreter the user cannot write to and
+    ignores the virtualenv entirely.
+
+    Raises:
+        ValueError: If the uid is not one a user may hold. Root defeats the
+            purpose, and the value lands in a shell command.
+    """
+    if uid <= 0:
+        raise ValueError(f"run_as_uid must be a positive uid, not {uid}")
+
+    return [
+        f"RUN useradd --uid {uid} --create-home --shell /bin/bash {SANDBOX_USER} "
+        f"&& python -m venv --system-site-packages {VENV_PATH} "
+        f"&& chown -R {uid}:{uid} {VENV_PATH}",
+        f"ENV VIRTUAL_ENV={VENV_PATH} "
+        f"HOME=/home/{SANDBOX_USER} "
+        f"UV_SYSTEM_PYTHON=0 "
+        f"PATH={VENV_PATH}/bin:$PATH",
+    ]
 
 
 def install_instructions(runtime: RuntimeConfig, *, cache_mounts: bool = False) -> list[str]:

--- a/src/pydantic_ai_backends/backends/docker/sandbox.py
+++ b/src/pydantic_ai_backends/backends/docker/sandbox.py
@@ -337,6 +337,23 @@ class DockerSandbox(BaseSandbox):
         # Dead or being removed: a fresh container is the only way forward.
         return None
 
+    def _environment(self) -> dict[str, str]:
+        """What the container starts with: the sandbox defaults, then the runtime's.
+
+        `UV_SYSTEM_PYTHON` is dropped for a runtime that runs unprivileged. A
+        container's environment overrides its image's, so leaving it set would
+        clobber the `0` the image asks for and send uv at the interpreter the
+        sandbox user cannot write to — which fails with `Permission denied` and
+        no way forward, the virtualenv built for exactly this being ignored.
+        """
+        env = dict(SANDBOX_ENV)
+        if self._runtime is None:
+            return env
+        if self._runtime.run_as_uid is not None:
+            del env["UV_SYSTEM_PYTHON"]
+        env.update(self._runtime.env_vars)
+        return env
+
     def _run_kwargs(self) -> dict[str, Any]:
         """Arguments for `containers.run`, including limits and hardening."""
         kwargs: dict[str, Any] = {
@@ -351,7 +368,7 @@ class DockerSandbox(BaseSandbox):
             "init": True,
             "working_dir": self._work_dir,
             "auto_remove": self._auto_remove,
-            "environment": {**SANDBOX_ENV, **(self._runtime.env_vars if self._runtime else {})},
+            "environment": self._environment(),
             "volumes": {
                 host: {"bind": container, "mode": "rw"} for host, container in self._volumes.items()
             }
@@ -363,6 +380,10 @@ class DockerSandbox(BaseSandbox):
         }
         if self._container_name is not None:
             kwargs["name"] = self._container_name
+        if self._runtime is not None and self._runtime.run_as_uid is not None:
+            # Both halves of the pair, because a process writing into a
+            # bind-mounted workspace is checked on its gid as well.
+            kwargs["user"] = f"{self._runtime.run_as_uid}:{self._runtime.run_as_uid}"
         if self._network_mode is not None:
             kwargs["network_mode"] = self._network_mode
         if self._pids_limit is not None:

--- a/src/pydantic_ai_backends/remote/server.py
+++ b/src/pydantic_ai_backends/remote/server.py
@@ -438,6 +438,28 @@ class SandboxdConfig:
             `node_modules` — while leaving its workspace untouched, so the files
             survive and only the rebuildable part goes. `None` keeps them.
             Only meaningful with `persist_containers`.
+        sandbox_uid: Run every built runtime's sandbox as this unprivileged
+            user instead of root, and give each session's workspace to it.
+            `None` — the default — keeps the current behaviour, where a sandbox
+            runs as root.
+
+            Worth turning on. A container escape starts from whoever the
+            container runs as, and every file an agent writes into its
+            bind-mounted workspace is owned by that user on the host — as root,
+            a `sandboxd` running unprivileged cannot clean up after its own
+            sessions. The image is built around the uid: a real account, a home
+            directory, and a virtualenv it owns first on `PATH`, without which
+            an agent's `pip install` fails and `uv` — having no `--user` mode —
+            fails with no way forward.
+
+            Two things it asks of the deployment. The service must be able to
+            `chown` each session's workspace to this uid, which means either
+            running with the privilege or running *as* that uid so the
+            directories are created owned by it; a service that can do neither
+            is told so when the session opens rather than handing an agent a
+            workspace it cannot write to. And ready-made runtimes are left as
+            root, since an image nobody built for this has no such user and no
+            virtualenv, so an agent inside one could install nothing.
         max_read_bytes: Largest single file a client may read out of a sandbox.
         execute_timeout: Hard ceiling applied to every command, so one client
             cannot occupy a worker indefinitely.
@@ -476,6 +498,7 @@ class SandboxdConfig:
     cleanup_interval: int = 300
     workspace_ttl: int | None = None
     container_ttl: int | None = None
+    sandbox_uid: int | None = None
     max_read_bytes: int = 8 * 1024 * 1024
     execute_timeout: int = 300
     max_workers: int = 32
@@ -615,11 +638,17 @@ def _default_builder(config: SandboxdConfig) -> SandboxBuilder:
         from pydantic_ai_backends.backends.docker.sandbox import DockerSandbox
 
         built = runtime.resolved_runtime()
+        # A ready-made image was not built around the sandbox user and has no
+        # virtualenv it owns, so running it unprivileged would leave an agent
+        # unable to install anything. Only built runtimes take the uid.
+        overrides: dict[str, Any] = {"work_dir": config.work_dir}
+        if config.sandbox_uid is not None:
+            overrides["run_as_uid"] = config.sandbox_uid
         return DockerSandbox(
             # One work directory service-wide: it is where the workspace volume
             # is mounted and what the archive endpoints read, so a runtime's own
             # `work_dir` is overridden rather than allowed to disagree.
-            runtime=built.model_copy(update={"work_dir": config.work_dir}) if built else None,
+            runtime=built.model_copy(update=overrides) if built else None,
             image=runtime.image or "",
             session_id=session_id,
             work_dir=config.work_dir,
@@ -659,10 +688,39 @@ def _session_volumes(config: SandboxdConfig, session_id: str) -> dict[str, str] 
         return None
     workspace = workspace_root_for(session_dir.parent, session_id)
     workspace.mkdir(parents=True, exist_ok=True)
+    if config.sandbox_uid is not None:
+        _hand_workspace_to(workspace, config.sandbox_uid)
     # The sweep reads this mtime as "when the session was last opened", and
     # mkdir on an existing directory does not touch it.
     os.utime(session_dir)
     return {str(workspace.resolve()): config.work_dir}
+
+
+def _hand_workspace_to(workspace: Path, uid: int) -> None:
+    """Give one session's workspace to the user its sandbox will run as.
+
+    A sandbox running unprivileged writes into this directory as `uid`, so the
+    directory has to belong to `uid` — otherwise the agent's very first file
+    write fails, which is a worse outcome than the privilege this is buying back.
+
+    Raises:
+        RuntimeError: When the service cannot change the ownership, naming what
+            it would have to be able to do. Starting the sandbox anyway would
+            hand an agent a workspace it cannot write to, and the cause would
+            surface much later as an unexplained permission error inside a
+            container.
+    """
+    try:
+        # Owner only. The container writes as this uid, so the owner bits are
+        # what decide; setting the group as well would additionally require the
+        # service to be a member of a group it may well not have.
+        os.chown(workspace, uid, -1)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Cannot give {workspace} to uid {uid} for an unprivileged sandbox: {exc}. "
+            "Either run sandboxd with the privilege to chown, or run it as that uid "
+            "so the directory is created owned by it, or unset sandbox_uid."
+        ) from exc
 
 
 def sweep_containers(config: SandboxdConfig, client: Any, now: float) -> list[str]:
@@ -1278,6 +1336,7 @@ class _Service:
             execute_timeout=config.execute_timeout,
             max_read_bytes=config.max_read_bytes,
             persist_containers=config.persist_containers,
+            sandbox_uid=config.sandbox_uid,
             workspace_ttl=config.workspace_ttl,
             container_ttl=config.container_ttl,
             tmpfs_size=config.tmpfs_size,

--- a/src/pydantic_ai_backends/remote/wire.py
+++ b/src/pydantic_ai_backends/remote/wire.py
@@ -348,6 +348,8 @@ class ServicePolicy(BaseModel):
     execute_timeout: int = 0
     max_read_bytes: int = 0
     persist_containers: bool = False
+    sandbox_uid: int | None = None
+    """Uid built runtimes run as, or `None` when sandboxes run as root."""
     """Whether a stopped sandbox keeps its filesystem for the next attach."""
     workspace_ttl: int | None = None
     """Seconds an unused workspace is kept before it is swept, or `None`."""

--- a/src/pydantic_ai_backends/types.py
+++ b/src/pydantic_ai_backends/types.py
@@ -168,3 +168,27 @@ class RuntimeConfig(BaseModel):
 
     cache_image: bool = True
     """Whether to cache the built image locally."""
+
+    run_as_uid: int | None = None
+    """Build the image around an unprivileged user, and run containers as them.
+
+    `None` — the default — runs as root, which is what a container does unless
+    told otherwise. Naming a uid instead adds three things to the generated
+    image: a real user with that id (so `whoami` and anything else calling
+    `getpwuid` works), a home directory it owns, and a virtualenv at
+    :data:`VENV_PATH` it owns, put first on `PATH`.
+
+    The virtualenv is the part that makes this workable rather than merely
+    safer. A non-root user cannot write to the interpreter's own
+    `site-packages`, so without one an agent's first `pip install` fails — and
+    `uv`, unlike pip, has no `--user` mode to fall back on, so it fails with no
+    way forward at all. Owning a virtualenv means both simply work, and console
+    scripts land somewhere already on `PATH`.
+
+    Only meaningful with `base_image`: a ready-made `image` was not built with
+    this user, so running it unprivileged would leave an agent unable to install
+    anything system-wide.
+
+    The uid has to match whoever owns the workspace mounted into the container,
+    which is why it is a number rather than a name.
+    """

--- a/tests/test_docker_image.py
+++ b/tests/test_docker_image.py
@@ -442,3 +442,66 @@ class TestPruningSupersededImages:
         build_image(_Client(images), runtime)
 
         assert images.removed == [stale]
+
+
+class TestUnprivilegedRuntimes:
+    """What `run_as_uid` adds to a generated image, and why each part is there."""
+
+    def _runtime(self, **kwargs):
+        from pydantic_ai_backends.types import RuntimeConfig
+
+        return RuntimeConfig(name="nr", base_image="python:3.12-slim", **kwargs)
+
+    def test_nothing_is_added_without_a_uid(self):
+        from pydantic_ai_backends.backends.docker._image import build_dockerfile
+
+        assert "useradd" not in build_dockerfile(self._runtime())
+
+    def test_the_uid_gets_a_real_account(self):
+        """A bare numeric id works for the kernel and breaks `getpwuid`."""
+        from pydantic_ai_backends.backends.docker._image import SANDBOX_USER, build_dockerfile
+
+        dockerfile = build_dockerfile(self._runtime(run_as_uid=1000))
+
+        assert f"useradd --uid 1000 --create-home --shell /bin/bash {SANDBOX_USER}" in dockerfile
+
+    def test_it_owns_a_virtualenv_that_comes_first_on_path(self):
+        """Without one, pip installs somewhere off `PATH` and uv cannot install at all."""
+        from pydantic_ai_backends.backends.docker._image import VENV_PATH, build_dockerfile
+
+        dockerfile = build_dockerfile(self._runtime(run_as_uid=1000))
+
+        assert f"python -m venv --system-site-packages {VENV_PATH}" in dockerfile
+        assert f"chown -R 1000:1000 {VENV_PATH}" in dockerfile
+        assert f"PATH={VENV_PATH}/bin:$PATH" in dockerfile
+
+    def test_the_venv_keeps_the_runtimes_own_packages_importable(self):
+        """They were installed system-wide, before the user existed."""
+        from pydantic_ai_backends.backends.docker._image import build_dockerfile
+
+        dockerfile = build_dockerfile(self._runtime(packages=["six"], run_as_uid=1000))
+        install = dockerfile.index("pip install")
+        venv = dockerfile.index("python -m venv")
+
+        assert install < venv
+        assert "--system-site-packages" in dockerfile
+
+    def test_uv_is_pointed_at_the_venv_rather_than_the_interpreter(self):
+        from pydantic_ai_backends.backends.docker._image import build_dockerfile
+
+        assert "UV_SYSTEM_PYTHON=0" in build_dockerfile(self._runtime(run_as_uid=1000))
+
+    def test_a_runtimes_own_env_still_wins(self):
+        from pydantic_ai_backends.backends.docker._image import build_dockerfile
+
+        dockerfile = build_dockerfile(self._runtime(run_as_uid=1000, env_vars={"HOME": "/tmp"}))
+
+        assert dockerfile.index("HOME=/home/agent") < dockerfile.index("ENV HOME=/tmp")
+
+    @pytest.mark.parametrize("uid", [0, -1])
+    def test_a_uid_that_is_not_one_is_refused(self, uid: int):
+        """Root defeats the purpose, and the value lands in a shell command."""
+        from pydantic_ai_backends.backends.docker._image import unprivileged_instructions
+
+        with pytest.raises(ValueError, match="positive uid"):
+            unprivileged_instructions(uid)

--- a/tests/test_docker_sandbox.py
+++ b/tests/test_docker_sandbox.py
@@ -525,39 +525,40 @@ class TestSharedDockerClient:
         assert len(calls) == 1
 
 
+@pytest.fixture
+def fake_client(monkeypatch):
+    """Install fake `docker` modules and a client that records `containers.run`."""
+    import pydantic_ai_backends.backends.docker.sandbox as sandbox_mod
+
+    fake_errors = types.ModuleType("docker.errors")
+    fake_errors.NotFound = type("NotFound", (Exception,), {})
+    fake_errors.ImageNotFound = type("ImageNotFound", (Exception,), {})
+    fake_docker = types.ModuleType("docker")
+    fake_docker.errors = fake_errors
+    monkeypatch.setitem(sys.modules, "docker", fake_docker)
+    monkeypatch.setitem(sys.modules, "docker.errors", fake_errors)
+
+    class Containers:
+        def __init__(self):
+            self.image = None
+            self.kwargs = None
+
+        def run(self, image, **kwargs):
+            self.image = image
+            self.kwargs = kwargs
+            return _FakeContainer()
+
+    class Client:
+        def __init__(self):
+            self.containers = Containers()
+
+    client = Client()
+    monkeypatch.setattr(sandbox_mod, "docker_client", lambda: client)
+    return client
+
+
 class TestDockerSandboxResourceLimits:
     """Tests that limits and hardening reach `containers.run` (no daemon needed)."""
-
-    @pytest.fixture
-    def fake_client(self, monkeypatch):
-        """Install fake `docker` modules and a recording client."""
-        import pydantic_ai_backends.backends.docker.sandbox as sandbox_mod
-
-        fake_errors = types.ModuleType("docker.errors")
-        fake_errors.NotFound = type("NotFound", (Exception,), {})
-        fake_errors.ImageNotFound = type("ImageNotFound", (Exception,), {})
-        fake_docker = types.ModuleType("docker")
-        fake_docker.errors = fake_errors
-        monkeypatch.setitem(sys.modules, "docker", fake_docker)
-        monkeypatch.setitem(sys.modules, "docker.errors", fake_errors)
-
-        class Containers:
-            def __init__(self):
-                self.image = None
-                self.kwargs = None
-
-            def run(self, image, **kwargs):
-                self.image = image
-                self.kwargs = kwargs
-                return _FakeContainer()
-
-        class Client:
-            def __init__(self):
-                self.containers = Containers()
-
-        client = Client()
-        monkeypatch.setattr(sandbox_mod, "docker_client", lambda: client)
-        return client
 
     def test_defaults_bound_processes_and_block_escalation(self, fake_client):
         """A default sandbox still caps PIDs and denies setuid escalation."""
@@ -1463,3 +1464,45 @@ class TestOciRuntimePassthrough:
         assert kwargs["runtime"] == "kata"
         assert kwargs["mem_limit"] == "1g"
         assert kwargs["network_mode"] == "none"
+
+
+class TestUnprivilegedContainers:
+    """A runtime that names a uid is run as it, and told so consistently."""
+
+    def _runtime(self, **kwargs):
+        from pydantic_ai_backends.types import RuntimeConfig
+
+        return RuntimeConfig(name="nr", image="img", **kwargs)
+
+    def test_a_root_runtime_names_no_user(self, fake_client):
+        _sandbox(runtime=self._runtime())._ensure_container()
+
+        assert "user" not in fake_client.containers.kwargs
+
+    def test_the_container_runs_as_the_uid_and_its_group(self, fake_client):
+        """The gid matters too: a bind-mounted workspace is checked on both."""
+        _sandbox(runtime=self._runtime(run_as_uid=1000))._ensure_container()
+
+        assert fake_client.containers.kwargs["user"] == "1000:1000"
+
+    def test_uv_is_not_aimed_at_the_interpreter_the_user_cannot_write_to(self, fake_client):
+        """A container's environment overrides its image's, so this has to go.
+
+        Measured: left set, uv ignores the virtualenv the image built and fails
+        with `Permission denied` on the system `site-packages`.
+        """
+        _sandbox(runtime=self._runtime(run_as_uid=1000))._ensure_container()
+
+        assert "UV_SYSTEM_PYTHON" not in fake_client.containers.kwargs["environment"]
+
+    def test_a_root_runtime_keeps_it(self, fake_client):
+        _sandbox(runtime=self._runtime())._ensure_container()
+
+        assert fake_client.containers.kwargs["environment"]["UV_SYSTEM_PYTHON"] == "1"
+
+    def test_a_sandbox_without_a_runtime_still_gets_the_defaults(self, fake_client):
+        _sandbox()._ensure_container()
+        env = fake_client.containers.kwargs["environment"]
+
+        assert env["UV_SYSTEM_PYTHON"] == "1"
+        assert "user" not in fake_client.containers.kwargs

--- a/tests/test_remote_sandbox.py
+++ b/tests/test_remote_sandbox.py
@@ -2090,7 +2090,10 @@ class TestPerRuntimeCeilings:
         assert config.limits_for(config.resolve_runtime("online")[1])["network_mode"] == "bridge"
 
     def test_the_builder_applies_the_runtime_ceilings(self):
-        from pydantic_ai_backends.remote.server import SandboxRuntime, _default_builder
+        from pydantic_ai_backends.remote.server import (
+            SandboxRuntime,
+            _default_builder,
+        )
 
         config = self._config(mem_limit="512m", cpus=1.0)
 
@@ -2105,7 +2108,10 @@ class TestPerRuntimeCeilings:
 
     def test_the_builder_forces_the_service_work_dir_on_a_built_runtime(self):
         """The volume mount, the archive and a client's paths must agree on one."""
-        from pydantic_ai_backends.remote.server import SandboxRuntime, _default_builder
+        from pydantic_ai_backends.remote.server import (
+            SandboxRuntime,
+            _default_builder,
+        )
 
         config = SandboxdConfig(
             token="t",
@@ -2220,7 +2226,10 @@ class TestTmpfsAndCpuShares:
 
     def test_every_sandbox_gets_an_in_memory_tmp_by_default(self):
         """Scratch writes otherwise land in the overlay and grow the disk."""
-        from pydantic_ai_backends.remote.server import SandboxRuntime, _default_builder
+        from pydantic_ai_backends.remote.server import (
+            SandboxRuntime,
+            _default_builder,
+        )
 
         config = SandboxdConfig(token="t")
         sandbox = _default_builder(config)("s1", SandboxRuntime(image="python:3.12-slim"))
@@ -2228,7 +2237,10 @@ class TestTmpfsAndCpuShares:
         assert sandbox._tmpfs == {"/tmp": "size=64m"}
 
     def test_tmpfs_can_be_turned_off(self):
-        from pydantic_ai_backends.remote.server import SandboxRuntime, _default_builder
+        from pydantic_ai_backends.remote.server import (
+            SandboxRuntime,
+            _default_builder,
+        )
 
         config = SandboxdConfig(token="t", tmpfs_size=None)
         sandbox = _default_builder(config)("s1", SandboxRuntime(image="python:3.12-slim"))
@@ -3701,3 +3713,87 @@ class TestAsyncSandboxThroughTheService:
 
         assert again.status_code == 200, again.text
         assert again.json()["session"]["alive"] is True
+
+
+class TestUnprivilegedSandboxes:
+    """`sandbox_uid` is what turns a root sandbox into an unprivileged one."""
+
+    def test_it_is_off_unless_an_operator_asks(self):
+        """It changes filesystem ownership, so it is not a silent default."""
+        assert SandboxdConfig(token="t").sandbox_uid is None
+
+    def test_a_built_runtime_is_handed_the_uid(self, tmp_path):
+        from pydantic_ai_backends.remote.server import (
+            SandboxRuntime,
+            _as_runtime,
+            _default_builder,
+        )
+
+        config = SandboxdConfig(
+            token="t",
+            runtimes={"built": SandboxRuntime(runtime="python-analytics")},
+            workspace_root=str(tmp_path),
+            sandbox_uid=os.getuid(),
+        )
+        sandbox = _default_builder(config)("s1", _as_runtime(config.runtimes["built"]))
+
+        assert sandbox._runtime.run_as_uid == os.getuid()
+
+    def test_a_ready_made_image_is_left_as_root(self, tmp_path):
+        """Nobody built it around the user, so it has no venv the agent owns —
+        an agent inside one could install nothing at all."""
+        from pydantic_ai_backends.remote.server import (
+            SandboxRuntime,
+            _as_runtime,
+            _default_builder,
+        )
+
+        config = SandboxdConfig(
+            token="t",
+            runtimes={"ready": SandboxRuntime(image="python:3.12-slim")},
+            workspace_root=str(tmp_path),
+            sandbox_uid=os.getuid(),
+        )
+        sandbox = _default_builder(config)("s1", _as_runtime(config.runtimes["ready"]))
+
+        assert sandbox._runtime is None
+
+    def test_the_workspace_is_given_to_the_user_that_will_write_it(self, tmp_path):
+        config = SandboxdConfig(token="t", workspace_root=str(tmp_path), sandbox_uid=os.getuid())
+
+        volumes = _session_volumes(config, "s1")
+
+        assert volumes is not None
+        assert Path(next(iter(volumes))).stat().st_uid == os.getuid()
+
+    def test_a_service_that_cannot_chown_is_told_so_at_once(self, tmp_path, monkeypatch):
+        """Rather than starting a sandbox whose first file write would fail."""
+        from pydantic_ai_backends.remote import server as server_mod
+
+        def refuse(*args: Any, **kwargs: Any) -> None:
+            raise PermissionError("not permitted")
+
+        monkeypatch.setattr(server_mod.os, "chown", refuse)
+        config = SandboxdConfig(token="t", workspace_root=str(tmp_path), sandbox_uid=4242)
+
+        with pytest.raises(RuntimeError, match="run sandboxd with the privilege to chown"):
+            _session_volumes(config, "s1")
+
+    def test_nothing_is_chowned_when_it_is_off(self, tmp_path, monkeypatch):
+        from pydantic_ai_backends.remote import server as server_mod
+
+        def refuse(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError("chown must not be reached")
+
+        monkeypatch.setattr(server_mod.os, "chown", refuse)
+
+        assert _session_volumes(SandboxdConfig(token="t", workspace_root=str(tmp_path)), "s1")
+
+    def test_it_is_visible_in_the_policy(self, tmp_path):
+        harness = Harness(workspace_root=str(tmp_path), sandbox_uid=os.getuid())
+        with harness.client() as client:
+            policy = wire.ServicePolicy.model_validate(
+                client.get("/policy", headers=_service_headers()).json()
+            )
+
+        assert policy.sandbox_uid == os.getuid()


### PR DESCRIPTION
A container runs as root unless told otherwise, and that is two problems: an escape starts from uid 0, and every file an agent writes into its bind-mounted workspace is owned by root **on the host**, so a `sandboxd` running unprivileged cannot clean up after its own sessions. `no-new-privileges` does not help — it stops a process gaining privileges it lacks, and this one already has them.

```python
SandboxdConfig(token=token, workspace_root="/var/lib/sandboxd", sandbox_uid=1000)
```

Built runtimes are then built around that user — a real account for the uid, a home directory it owns, and a virtualenv it owns first on `PATH` — and their containers run as it, with each session's workspace given to it. `RuntimeConfig.run_as_uid` is the same thing for anyone building a `DockerSandbox` directly.

## The virtualenv is the load-bearing part

It took three corrections to get here, and each one came from a measurement rather than from reasoning:

| guess | what actually happens |
|---|---|
| git breaks on a uid with no `/etc/passwd` entry (`getpwuid`) | it does not — git works fine |
| a writable `HOME` is enough | it fixes pip (`Permission denied: '/.local'`) and nothing else |
| the image's `ENV UV_SYSTEM_PYTHON=0` settles uv | a container's environment **overrides** its image's, so the sandbox default clobbered it |

The real obstacle is **`uv` has no `--user` mode**. `--system` hits permission denied on the interpreter's own `site-packages`, and without it there is no environment at all — so unlike pip it has nothing to fall back on. A virtualenv the sandbox user owns is the only shape that works, and it fixes console scripts at the same time: they land in `/opt/venv/bin`, already on `PATH`, instead of a user-site directory that is not.

It is created with `--system-site-packages`, so a runtime's own declared `packages` — installed system-wide before the user exists — stay importable.

## Validated on real Linux semantics

Not through a macOS bind mount, whose uid mapping is not the one production sees. In the shape the service runs — workspace owned by the sandbox uid, the real `SANDBOX_ENV`, `init` on, `--user 1000:1000`:

```
whoami:   agent  uid=1000:1000  HOME=/home/agent
git:      8620cba t2
pip:      /opt/venv/lib/python3.12/site-packages/attrs/__init__.py
uv:       /opt/venv/bin/ruff -> ruff 0.16.1
sitepkgs: denied, as intended
/etc:     denied, as intended
```

One thing worth recording for whoever hits it next: a Docker **named volume** is re-initialised from the image whenever it is mounted empty, which silently reverts a `chown`. Bind mounts — what `sandboxd` actually uses — are never treated that way. An early failure here was that, not the design.

## What it asks of the deployment

Both explicit rather than silent:

- **The service must be able to give each workspace to that uid** — either the privilege to `chown`, or running *as* that uid so the directories are created owned by it. A service that can do neither gets a `RuntimeError` naming both options when the session opens, rather than a sandbox whose first file write fails with an error nothing explains.
- **Ready-made runtimes stay as root.** An image nobody built for this has no such user and no virtualenv, so an agent inside one could install nothing. The uid reaches runtimes built from a `base_image` and no others.

The `chown` sets the owner only, not the group: the container writes as this uid so the owner bits are what decide, and setting the group would additionally require the service to belong to a group it may not have.

## Compatibility

Off by default — `sandbox_uid=None` and `run_as_uid=None` keep every existing deployment running as root. Nothing changes unless an operator opts in.

## Verification

`1381 passed`, 100% coverage, `ruff`, `pyright` and `mypy` clean.
