### PR TITLE
fix: close the ten findings from the codebase audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,13 +77,26 @@ before upgrading is deferred.
   and exposed as `RemoteSandbox.server_timeout`, falling back to the local
   timeout when the service will not say.
 
-- **`BaseSandbox.write` accepts `bytes`.** The protocol types `content` as
-  `str | bytes`; both base classes narrowed it to `str` and the heredoc
-  interpolated bytes as their Python repr, writing the 17 characters
-  `b'\x89PNG\r\n'` into the file with no error. Content now travels
-  base64-encoded, which also fixes the trailing newline a heredoc could not avoid
-  adding — `write(path, "x\n")` produced `"x\n\n"`. **Requires `base64` in the
-  sandbox image** (GNU coreutils and BusyBox both provide it).
+- **Shell-derived `write` and `read_bytes` carry binary intact.** The protocol
+  types `content` as `str | bytes`; both base classes narrowed it to `str`, and
+  the heredoc interpolated bytes as their Python repr — writing the 17 characters
+  `b'\x89PNG\r\n'` into the file with no error. `read_bytes` was lossy in the
+  other direction: `cat` returns its output through an exec stream a sandbox
+  decodes with `errors="replace"`, so every byte that is not UTF-8 came back as
+  U+FFFD. Both now travel base64-encoded, so a file written through one and read
+  through the other is byte-identical — which is what the console toolset's
+  `image_support` needs on a shell-derived sandbox. The write side also stops
+  appending the trailing newline a heredoc could not avoid: `write(path, "x\n")`
+  produced `"x\n\n"`.
+
+  Two consequences. **The sandbox image needs `base64`** (GNU coreutils and
+  BusyBox both provide it, alongside the `cat` this replaces). And a `read_bytes`
+  whose output is truncated by the execute ceiling now returns `b""` rather than
+  a prefix: base64 cut short decodes to bytes that are not the file's, and the
+  caller cannot tell a wrong answer from a right one.
+
+  Verified byte-for-byte over all 256 byte values against real `python:3.12-slim`,
+  `node:20-slim` and `alpine:3.20` containers, which CI does not cover.
 
 - **`LocalBackend.edit` returns its failure instead of raising.** It read the
   file as strict UTF-8 and caught only `PermissionError` and `OSError`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,114 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.21] - 2026-08-01
+
+A full audit of the codebase, and the ten findings it produced. Nothing here is a
+new feature; several are behaviour changes, and the security one is worth reading
+before upgrading is deferred.
+
+### Security
+
+- **A denied `execute` now removes every shell tool, not just `execute`.**
+  `create_console_toolset(permissions=...)` promises that an operation defaulting
+  to `"deny"` drops its tools entirely, and `_denied_tools` listed only
+  `execute` — so `run_in_background`, which runs an arbitrary command, stayed
+  registered. With the shipped `READONLY_RULESET`, whose docstring reads "nothing
+  may change or run", the model was still handed a working shell.
+  `ConsoleCapability` was worse: the background tools were absent from
+  `TOOL_OPERATIONS`, and an unmapped name is both kept by `prepare_tools` and
+  waved through `before_tool_execute` unchecked, so no permission check ran on
+  them at all — via the example in the capability's own module docstring. All
+  five tools now live and die with the `execute` operation, the capability passes
+  its ruleset to the toolset as well as filtering per request, and a test asserts
+  the tool/operation map covers every registered tool so the next tool cannot
+  repeat this.
+
+- **`grep_raw` no longer interpolates the pattern into a shell command
+  unquoted.** Every other value in `_shell` goes through `shlex.quote`; the grep
+  pattern and glob were wrapped in literal single quotes, which one of their own
+  closed. A search for `don't` produced an unterminated command and a crafted
+  pattern ran whatever followed it, on `DockerSandbox`, `DaytonaSandbox`,
+  `KubernetesPodSandbox(mode="api")` and any third-party `BaseSandbox` subclass.
+  Both are quoted now, and the pattern is passed with `-e` so one starting with
+  `-` is a pattern rather than an option.
+
+### Fixed
+
+- **`path="."` no longer returns nothing on the virtual-path backends.**
+  `normalize_path` prefixed a slash without resolving the segment, so `"."` — the
+  console toolset's default for `ls` and `glob` — became `"/."`, a directory no
+  file is ever stored under. `StateBackend` and `CompositeBackend` therefore
+  answered every default listing, glob and grep with nothing at all, and an agent
+  was told its workspace was empty with no error anywhere. `"/"`, `""`, `"."` and
+  `"./"` now all mean the root, and the composite's fan-out recognises them.
+
+- **`SessionManager.release` takes the session's lock.** It mutated `_sessions`
+  and `_locks` with no lock at all, so a release landing inside a concurrent
+  `get_or_create` deleted the entry that call was about to delete — a `KeyError`
+  out of a public coroutine — and deleted the lock it was holding, after which
+  the next caller interned a fresh one and two tasks created a sandbox for one
+  session. Locks are now reference-counted while in use rather than pruned on
+  `Lock.locked()`, which reads False between a holder releasing and the woken
+  waiter resuming.
+
+- **The service's command ceiling applies to every operation.**
+  `SandboxdConfig.execute_timeout` is documented as "a hard ceiling applied to
+  every command, so one client cannot occupy a worker indefinitely" and was
+  applied to `/exec` alone. `ls`, `glob`, `grep`, `read` and `write` reach the
+  sandbox's shell too, and `BaseSandbox` passed a timeout for `exists` and
+  nothing else — so one slow search pinned a worker thread that nothing could
+  reclaim, and `max_workers` of them wedged the service. The derived operations
+  now carry `FILE_OP_TIMEOUT` (30s) or `SEARCH_TIMEOUT` (120s), and every
+  sandboxd operation route is bounded by the ceiling, answering `504` past it.
+
+- **`RemoteSandbox` waits as long as the service will run a command.**
+  `TRANSPORT_SLACK_SECONDS` exists so the transport never gives up first, but the
+  client's default (60s) and the service's ceiling (300s) were set independently.
+  Anything in between was reported to the agent as `sandbox service unavailable`
+  while the command was in fact still running — and typically retried, starting a
+  second one. The ceiling is now read from `GET /policy` when the session opens
+  and exposed as `RemoteSandbox.server_timeout`, falling back to the local
+  timeout when the service will not say.
+
+- **`BaseSandbox.write` accepts `bytes`.** The protocol types `content` as
+  `str | bytes`; both base classes narrowed it to `str` and the heredoc
+  interpolated bytes as their Python repr, writing the 17 characters
+  `b'\x89PNG\r\n'` into the file with no error. Content now travels
+  base64-encoded, which also fixes the trailing newline a heredoc could not avoid
+  adding — `write(path, "x\n")` produced `"x\n\n"`. **Requires `base64` in the
+  sandbox image** (GNU coreutils and BusyBox both provide it).
+
+- **`LocalBackend.edit` returns its failure instead of raising.** It read the
+  file as strict UTF-8 and caught only `PermissionError` and `OSError`;
+  `UnicodeDecodeError` subclasses `ValueError`, so a file that is not text raised
+  straight out of a backend the protocol promises never raises. It is now refused
+  with an error, and the file is left untouched — decoding with replacement would
+  substitute U+FFFD and write it back.
+
+- **`edit_file` serializes on the same lock `hashline_edit` uses.** Both are a
+  read, a replace and a write; only one was locked, so two concurrent edits to a
+  path lost one of them. The staleness check moved inside the lock too — checked
+  outside, it was answered before the other edit's write.
+
+- **`LocalBackend.ls_info` survives an entry that vanishes mid-listing.**
+  `glob_info` was hardened against exactly this and its sibling was not, so a
+  file removed between `iterdir` and `stat` raised out of the whole listing and
+  took the directory's other rows with it.
+
+- **`ConsoleCapability` accepts `ask_callback` and `ask_fallback`.** It exposed
+  `permissions` but built its checker with the defaults, so every operation
+  resolving to `"ask"` raised `PermissionAskError` with no way to answer it —
+  which made `DEFAULT_RULESET` and `STRICT_RULESET` unusable through the
+  capability. It also gained `include_background`.
+
+- **Smaller ones.** `StateBackend` reported a size one byte short per line and
+  silently corrupted non-UTF-8 writes (`write`/`read_bytes` now round-trip byte
+  for byte via `surrogateescape`); `sandboxd`'s `/events` raised `KeyError` — a
+  500 — where its sibling `describe` correctly 404s on the same race; a malformed
+  glob in a permission rule raised `re.error` out of the permission check and is
+  now inert; and a docstring in `ServicePolicy` sat under the wrong field.
+
 ## [0.2.20] - 2026-08-01
 
 ### Added

--- a/docs/concepts/capability.md
+++ b/docs/concepts/capability.md
@@ -53,24 +53,53 @@ agent = Agent(
 
 ## How Permissions Work
 
-1. **`prepare_tools`** — hides tools for denied operations. With `READONLY_RULESET`,
-   the model never sees `write_file`, `edit_file`, or `execute`.
+1. **The toolset drops denied tools** — the ruleset is passed straight through to
+   `create_console_toolset`, so a denied operation's tools are never registered.
 
-2. **`before_tool_execute`** — checks per-path permissions before each tool call.
+2. **`prepare_tools`** — hides them again from each request's tool definitions.
+   With `READONLY_RULESET`, the model never sees `write_file`, `edit_file`,
+   `execute`, or any of the background shell tools.
+
+3. **`before_tool_execute`** — checks per-path permissions before each tool call.
    If a specific path is denied (e.g., `.env` files), the call is blocked even if
    the operation is generally allowed.
+
+A denied `execute` removes **every** shell tool — `execute`, `run_in_background`,
+`read_output`, `kill_shell` and `list_shells` — because they are one operation
+reached different ways. Leaving the background ones behind meant a read-only
+agent could still run arbitrary commands.
+
+### Answering an "ask"
+
+An operation resolving to `"ask"` needs somebody to ask. Give the capability an
+`ask_callback`, or set `ask_fallback="deny"` to refuse instead:
+
+```python
+async def approve(operation: str, target: str, reason: str) -> bool:
+    return await my_ui.confirm(f"Allow {operation} on {target}?")
+
+
+capability = ConsoleCapability(permissions=DEFAULT_RULESET, ask_callback=approve)
+```
+
+Without either, an "ask" raises `PermissionAskError` — which is what you want in
+a batch job and not what you want in an interactive one. Every shipped preset
+except `PERMISSIVE_RULESET` has at least one operation defaulting to `"ask"`.
 
 ## Constructor Parameters
 
 [`ConsoleCapability`][pydantic_ai_backends.ConsoleCapability] is a dataclass with
-four fields:
+these fields:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `backend` | `BackendProtocol \| AsyncBackendProtocol \| None` | `None` | Backend the tools operate on. When `None`, each call reads `ctx.deps.backend`. See [Where the Backend Comes From](#where-the-backend-comes-from). |
 | `include_execute` | `bool` | `True` | Whether to register the `execute` shell tool. |
+| `include_background` | `bool` | `True` | Whether to register the background-shell tools (`run_in_background`, `read_output`, `kill_shell`, `list_shells`). |
 | `edit_format` | `"str_replace" \| "hashline"` | `"str_replace"` | File-editing format. `"hashline"` registers `hashline_edit` instead of `edit_file` and changes the injected instructions. See [Hashline Edit Format](console-toolset.md#hashline-edit-format). |
 | `permissions` | `PermissionRuleset \| None` | `None` | Ruleset controlling which operations are allowed, asked, or denied. When `None`, all tools are exposed and no permission checks run. |
+| `ask_callback` | `AskCallback \| None` | `None` | Async `(operation, target, reason) -> bool` answering an operation that resolves to `"ask"`. |
+| `ask_fallback` | `"deny" \| "error"` | `"error"` | What an unanswerable `"ask"` does when there is no callback. |
 
 ```python
 from pydantic_ai_backends import ConsoleCapability

--- a/docs/concepts/console-toolset.md
+++ b/docs/concepts/console-toolset.md
@@ -118,6 +118,21 @@ toolset = create_console_toolset(permissions=custom)
 
 When `permissions` is provided, it overrides the legacy `require_write_approval` and `require_execute_approval` flags.
 
+An operation whose default is `"deny"` has its tools removed outright. For
+`execute` that means **all five** shell tools — `execute`, `run_in_background`,
+`read_output`, `kill_shell` and `list_shells` — since they are the same operation
+reached different ways.
+
+Note what this does and does not do. The ruleset decides which tools *exist* and
+which need approval; it does not filter individual paths. Per-path enforcement is
+the backend's job, so pass the ruleset to the backend as well when you want it:
+
+```python
+ruleset = READONLY_RULESET
+toolset = create_console_toolset(permissions=ruleset)
+backend = LocalBackend(root_dir="/workspace", permissions=ruleset)
+```
+
 See [Permissions](permissions.md) for full documentation.
 
 ## Image Support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.20"
+version = "0.2.21"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/_paths.py
+++ b/src/pydantic_ai_backends/_paths.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 
 def normalize_path(path: str) -> str:
-    """Return `path` as an absolute POSIX path without a trailing slash."""
-    if not path.startswith("/"):
-        path = "/" + path
-    if len(path) > 1 and path.endswith("/"):
-        path = path.rstrip("/")
-    return path
+    """Return `path` as an absolute POSIX path without a trailing slash.
+
+    `.` segments are dropped, so the three ways a caller spells a backend's root
+    — `"/"`, `""` and `"."` — all arrive as `"/"`. That matters because the
+    console toolset's `ls` and `glob` default to `"."`: prefixing a slash without
+    resolving it produced `"/."`, a directory no file is ever stored under, so a
+    virtual-path backend answered every default listing with nothing at all.
+
+    `..` is *not* resolved here — :func:`unsafe_path_reason` rejects it outright,
+    and resolving it in this function would quietly turn a path the caller should
+    have been told about into a valid one.
+    """
+    segments = [segment for segment in path.split("/") if segment and segment != "."]
+    return "/" + "/".join(segments) if segments else "/"
 
 
 def unsafe_path_reason(path: str) -> str | None:

--- a/src/pydantic_ai_backends/backends/_shell.py
+++ b/src/pydantic_ai_backends/backends/_shell.py
@@ -12,8 +12,8 @@ The names are public inside this private module so call sites read as prose:
 
 from __future__ import annotations
 
+import base64
 import shlex
-import uuid
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
@@ -107,21 +107,23 @@ def parse_read(result: ExecuteResponse) -> str:
     return result.output
 
 
-def write_command(path: str, content: str) -> str:
-    """Write a file with `cat` and a quoted heredoc.
+def write_command(path: str, content: str | bytes) -> str:
+    """Write a file, carrying the content base64-encoded.
 
-    The delimiter is quoted (`<< 'DELIM'`) so the shell expands nothing inside
-    the body and the content lands verbatim. Pre-escaping backslashes or `$` here
-    would corrupt it instead. The delimiter is random so it cannot collide with a
-    line of the content.
+    Base64 rather than the quoted heredoc this used to be, for two reasons the
+    heredoc could not fix. It cannot carry arbitrary bytes: `content` is typed
+    `str | bytes` by the protocol, and interpolating `bytes` into the body wrote
+    the Python repr — `b'\\x89PNG\\r\\n'` — into the file with no error. And a
+    heredoc's terminator must start a line, so writing `"x\\n"` produced `"x\\n\\n"`;
+    `LocalBackend` and `StateBackend` both store exactly what they are given.
+
+    The payload needs no quoting of its own, base64 being `[A-Za-z0-9+/=]`.
+    Requires `base64` in the image, which GNU coreutils and BusyBox both provide.
     """
-    delimiter = f"EOF_{uuid.uuid4().hex[:8]}"
+    raw = content if isinstance(content, bytes) else content.encode("utf-8")
+    payload = base64.b64encode(raw).decode("ascii")
     quoted_path = shlex.quote(path)
-    return (
-        f"mkdir -p $(dirname {quoted_path}) && cat > {quoted_path} << '{delimiter}'\n"
-        f"{content}\n"
-        f"{delimiter}"
-    )
+    return f"mkdir -p $(dirname {quoted_path}) && printf %s {payload} | base64 -d > {quoted_path}"
 
 
 def parse_write(result: ExecuteResponse, path: str) -> WriteResult:
@@ -161,13 +163,23 @@ def grep_command(
     glob: str | None = None,
     ignore_hidden: bool = True,
 ) -> str:
-    """Search file contents with `grep`."""
+    """Search file contents with `grep`.
+
+    The pattern and the glob are quoted like every other value here. Wrapping
+    them in literal single quotes instead let one of their own close the quoting:
+    a search for `don't` produced an unterminated command, and a crafted pattern
+    ran whatever followed it. `-e` for the same reason a pattern is quoted — a
+    pattern starting with `-` is a pattern, not an option.
+    """
     options = ["-rn"]
     if ignore_hidden:
-        options.extend(["--exclude='.*'", "--exclude-dir='.*'"])
+        # Quoted, or the shell expands `.*` against the working directory before
+        # grep ever sees it.
+        hidden = shlex.quote(".*")
+        options.extend([f"--exclude={hidden}", f"--exclude-dir={hidden}"])
     if glob:
-        options.append(f"--include='{glob}'")
-    return f"grep {' '.join(options)} '{pattern}' {shlex.quote(path or '.')}"
+        options.append(f"--include={shlex.quote(glob)}")
+    return f"grep {' '.join(options)} -e {shlex.quote(pattern)} {shlex.quote(path or '.')}"
 
 
 def parse_grep(result: ExecuteResponse) -> list[GrepMatch] | str:

--- a/src/pydantic_ai_backends/backends/_shell.py
+++ b/src/pydantic_ai_backends/backends/_shell.py
@@ -13,6 +13,7 @@ The names are public inside this private module so call sites read as prose:
 from __future__ import annotations
 
 import base64
+import binascii
 import shlex
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
@@ -70,19 +71,36 @@ def parse_ls(result: ExecuteResponse, path: str) -> list[FileInfo]:
 
 
 def read_bytes_command(path: str) -> str:
-    """Read a whole file."""
-    return f"cat {shlex.quote(path)}"
+    """Read a whole file, base64-encoded so arbitrary bytes survive the trip.
+
+    A plain `cat` could not carry them. Command output crosses back as text — a
+    sandbox decodes its exec stream with `errors="replace"` — so every byte that
+    is not UTF-8 arrived as U+FFFD. A PNG written by `write_command` and read
+    back came out a different file, silently and with no error, which is exactly
+    what the toolset's `image_support` does on a shell-derived sandbox.
+
+    Requires `base64` in the image, as `write_command` already does.
+    """
+    return f"base64 {shlex.quote(path)}"
 
 
 def parse_read_bytes(result: ExecuteResponse) -> bytes:
-    """Content of a `cat`, or `b""` on any failure.
+    """Content of a base64 read, or `b""` on any failure.
 
     An error message encoded into the payload would leave the caller unable to
     tell it from real file content, so failure is empty rather than described.
+    A *truncated* payload is a failure too: base64 cut short decodes to bytes
+    that are not the file's, and a wrong answer is worse here than no answer,
+    since the caller cannot tell one from the other. `read` returns a partial
+    slice for the oversized case; this returns nothing.
     """
-    if result.exit_code != 0:
+    if result.exit_code != 0 or result.truncated:
         return b""
-    return result.output.encode("utf-8", errors="replace")
+    try:
+        # `validate=False` (the default) discards the newlines `base64` wraps at.
+        return base64.b64decode(result.output)
+    except (binascii.Error, ValueError):
+        return b""
 
 
 def read_command(path: str, offset: int, limit: int) -> str:

--- a/src/pydantic_ai_backends/backends/base.py
+++ b/src/pydantic_ai_backends/backends/base.py
@@ -31,6 +31,25 @@ from pydantic_ai_backends.types import (
 LS_FIELD_COUNT = _shell.LS_FIELD_COUNT
 """Re-exported from `_shell`, where the parsing that uses it lives."""
 
+FILE_OP_TIMEOUT = 30
+"""Ceiling on the shell commands `ls`, `read`, `read_bytes` and `write` derive from.
+
+Every operation here runs a command, and a command with no timeout is one
+nothing can reclaim: `DockerSandbox.execute` only wraps the `timeout` utility
+around a command it was given a limit for, and `exec_run` has no deadline of its
+own. A single uncapped operation therefore pins a worker thread for good, which
+is how a handful of requests wedged a whole sandbox service. A listing or a read
+that has not answered in thirty seconds is not going to.
+"""
+
+SEARCH_TIMEOUT = 120
+"""Ceiling on `glob_info` and `grep_raw`, which walk a tree rather than one file.
+
+Separate from :data:`FILE_OP_TIMEOUT` because a legitimate `grep` over a large
+repository is slow in a way a `ls` never is, and capping both at the same number
+would mean choosing between a useless search and an unbounded listing.
+"""
+
 
 class _SandboxIdentity:
     """The identity and idle bookkeeping both base sandboxes share.
@@ -116,23 +135,28 @@ class BaseSandbox(_SandboxIdentity, ABC):
 
     def ls_info(self, path: str) -> list[FileInfo]:
         """List one directory using `ls -la`."""
-        return _shell.parse_ls(self.execute(_shell.ls_command(path)), path)
+        command = _shell.ls_command(path)
+        return _shell.parse_ls(self.execute(command, timeout=FILE_OP_TIMEOUT), path)
 
     def read_bytes(self, path: str) -> bytes:
         """Read a whole file with `cat`, or `b""` on any failure."""
-        return _shell.parse_read_bytes(self.execute(_shell.read_bytes_command(path)))
+        command = _shell.read_bytes_command(path)
+        return _shell.parse_read_bytes(self.execute(command, timeout=FILE_OP_TIMEOUT))
 
     def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
         """Read a slice of a file, numbered by its real line positions."""
-        return _shell.parse_read(self.execute(_shell.read_command(path, offset, limit)))
+        command = _shell.read_command(path, offset, limit)
+        return _shell.parse_read(self.execute(command, timeout=FILE_OP_TIMEOUT))
 
-    def write(self, path: str, content: str) -> WriteResult:
-        """Write a file with `cat` and a quoted heredoc."""
-        return _shell.parse_write(self.execute(_shell.write_command(path, content)), path)
+    def write(self, path: str, content: str | bytes) -> WriteResult:
+        """Write a file, carrying the content base64-encoded."""
+        command = _shell.write_command(path, content)
+        return _shell.parse_write(self.execute(command, timeout=FILE_OP_TIMEOUT), path)
 
     def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
         """Match files with `find`."""
-        return _shell.parse_glob(self.execute(_shell.glob_command(pattern, path)))
+        command = _shell.glob_command(pattern, path)
+        return _shell.parse_glob(self.execute(command, timeout=SEARCH_TIMEOUT))
 
     def grep_raw(
         self,
@@ -143,7 +167,7 @@ class BaseSandbox(_SandboxIdentity, ABC):
     ) -> list[GrepMatch] | str:
         """Search file contents with `grep`."""
         command = _shell.grep_command(pattern, path, glob, ignore_hidden)
-        return _shell.parse_grep(self.execute(command))
+        return _shell.parse_grep(self.execute(command, timeout=SEARCH_TIMEOUT))
 
 
 class AsyncBaseSandbox(_SandboxIdentity, ABC):
@@ -240,24 +264,28 @@ class AsyncBaseSandbox(_SandboxIdentity, ABC):
 
     async def ls_info(self, path: str) -> list[FileInfo]:
         """List one directory using `ls -la`."""
-        return _shell.parse_ls(await self.execute(_shell.ls_command(path)), path)
+        result = await self.execute(_shell.ls_command(path), timeout=FILE_OP_TIMEOUT)
+        return _shell.parse_ls(result, path)
 
     async def read_bytes(self, path: str) -> bytes:
         """Read a whole file with `cat`, or `b""` on any failure."""
-        return _shell.parse_read_bytes(await self.execute(_shell.read_bytes_command(path)))
+        command = _shell.read_bytes_command(path)
+        return _shell.parse_read_bytes(await self.execute(command, timeout=FILE_OP_TIMEOUT))
 
     async def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
         """Read a slice of a file, numbered by its real line positions."""
-        return _shell.parse_read(await self.execute(_shell.read_command(path, offset, limit)))
+        command = _shell.read_command(path, offset, limit)
+        return _shell.parse_read(await self.execute(command, timeout=FILE_OP_TIMEOUT))
 
-    async def write(self, path: str, content: str) -> WriteResult:
-        """Write a file with `cat` and a quoted heredoc."""
-        result = await self.execute(_shell.write_command(path, content))
+    async def write(self, path: str, content: str | bytes) -> WriteResult:
+        """Write a file, carrying the content base64-encoded."""
+        result = await self.execute(_shell.write_command(path, content), timeout=FILE_OP_TIMEOUT)
         return _shell.parse_write(result, path)
 
     async def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
         """Match files with `find`."""
-        return _shell.parse_glob(await self.execute(_shell.glob_command(pattern, path)))
+        command = _shell.glob_command(pattern, path)
+        return _shell.parse_glob(await self.execute(command, timeout=SEARCH_TIMEOUT))
 
     async def grep_raw(
         self,
@@ -268,4 +296,4 @@ class AsyncBaseSandbox(_SandboxIdentity, ABC):
     ) -> list[GrepMatch] | str:
         """Search file contents with `grep`."""
         command = _shell.grep_command(pattern, path, glob, ignore_hidden)
-        return _shell.parse_grep(await self.execute(command))
+        return _shell.parse_grep(await self.execute(command, timeout=SEARCH_TIMEOUT))

--- a/src/pydantic_ai_backends/backends/composite.py
+++ b/src/pydantic_ai_backends/backends/composite.py
@@ -12,7 +12,17 @@ from pydantic_ai_backends.types import EditResult, FileInfo, GrepMatch, WriteRes
 BackendT = TypeVar("BackendT")
 
 ROOT_PATHS = ("/", "")
-"""Paths that mean "everywhere", and so fan out to every backend."""
+"""Paths that mean "everywhere", and so fan out to every backend.
+
+Kept for callers that import it. Use :func:`is_root_path`, which recognises the
+other spellings — `"."` is what the console toolset's `glob` sends by default,
+and compared against this tuple it routed to one backend instead of fanning out.
+"""
+
+
+def is_root_path(path: str) -> bool:
+    """Whether `path` means "everywhere" and so fans out to every backend."""
+    return normalize_path(path) == "/"
 
 
 class PrefixRouter(Generic[BackendT]):
@@ -125,10 +135,10 @@ class CompositeBackend:
 
     def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
         """Match files, searching every backend when starting from the root."""
-        if path not in ROOT_PATHS:
+        if not is_root_path(path):
             return self._router.for_path(path).glob_info(pattern, path)
 
-        results = list(self._router.default.glob_info(pattern, path))
+        results = list(self._router.default.glob_info(pattern, "/"))
         for prefix, backend in self._router.routes.items():
             results.extend(backend.glob_info(pattern, prefix))
         return sorted(results, key=lambda x: x["path"])
@@ -145,7 +155,7 @@ class CompositeBackend:
         An error from any backend is returned as-is rather than dropped, so a
         failed search is never mistaken for no matches.
         """
-        if path is not None and path not in ROOT_PATHS:
+        if path is not None and not is_root_path(path):
             return self._router.for_path(path).grep_raw(pattern, path, glob, ignore_hidden)
 
         matches: list[GrepMatch] = []
@@ -227,10 +237,10 @@ class AsyncCompositeBackend:
 
     async def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
         """Match files, searching every backend when starting from the root."""
-        if path not in ROOT_PATHS:
+        if not is_root_path(path):
             return await self._router.for_path(path).glob_info(pattern, path)
 
-        results = list(await self._router.default.glob_info(pattern, path))
+        results = list(await self._router.default.glob_info(pattern, "/"))
         for prefix, backend in self._router.routes.items():
             results.extend(await backend.glob_info(pattern, prefix))
         return sorted(results, key=lambda x: x["path"])
@@ -243,7 +253,7 @@ class AsyncCompositeBackend:
         ignore_hidden: bool = True,
     ) -> list[GrepMatch] | str:
         """Search, covering every backend when no specific path is given."""
-        if path is not None and path not in ROOT_PATHS:
+        if path is not None and not is_root_path(path):
             return await self._router.for_path(path).grep_raw(pattern, path, glob, ignore_hidden)
 
         matches: list[GrepMatch] = []

--- a/src/pydantic_ai_backends/backends/docker/session.py
+++ b/src/pydantic_ai_backends/backends/docker/session.py
@@ -31,10 +31,13 @@ import inspect
 import logging
 import time
 from collections.abc import Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from concurrent.futures import Executor
 
     from pydantic_ai_backends.types import RuntimeConfig
@@ -50,6 +53,14 @@ LEGACY_ACTIVITY_ATTR = "_last_activity"
 LEGACY_IDLE_TIMEOUT_ATTR = "_idle_timeout"
 """Attributes read as a fallback: custom factory sandboxes were documented
 against these before `BaseSandbox` exposed `last_activity` and `touch`."""
+
+
+@dataclass
+class _SessionLock:
+    """One session id's lock, plus how many tasks are holding or awaiting it."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    users: int = 0
 
 
 class SessionLimitExceeded(RuntimeError):
@@ -130,10 +141,11 @@ class SessionManager:
         self._max_sessions = max_sessions
         self._on_release = on_release
         self.executor = executor
-        # Per-session locks serialize concurrent get_or_create calls for the
-        # same id, so two awaits cannot each create and start a sandbox — one of
-        # which would be overwritten in the dict and leaked.
-        self._locks: dict[str, asyncio.Lock] = {}
+        # Per-session locks serialize every lifecycle change for one id —
+        # `get_or_create` and `release` both — so two awaits cannot each create
+        # and start a sandbox (one of which would be overwritten in the dict and
+        # leaked), and a release cannot land in the middle of a creation.
+        self._locks: dict[str, _SessionLock] = {}
 
     @property
     def sessions(self) -> dict[str, Any]:
@@ -160,8 +172,7 @@ class SessionManager:
             SessionLimitExceeded: If `max_sessions` is reached and `session_id`
                 is not an existing live session.
         """
-        lock = self._locks.setdefault(session_id, asyncio.Lock())
-        async with lock:
+        async with self._session_lock(session_id):
             existing = self._sessions.get(session_id)
             if existing is not None:
                 if await alive_of(existing):
@@ -172,7 +183,11 @@ class SessionManager:
                 # reference alone leaks those until garbage collection, which for
                 # an `httpx.Client` means a warning and an unclosed socket. It is
                 # already dead, so a failing stop is expected and ignored.
-                del self._sessions[session_id]
+                #
+                # `pop`, not `del`: `release` holds the same lock now, but a
+                # caller reaching into `_sessions` directly must not turn a
+                # missing key into a KeyError out of a public coroutine.
+                self._sessions.pop(session_id, None)
                 with contextlib.suppress(Exception):
                     await self._lifecycle(existing.stop)
 
@@ -236,14 +251,45 @@ class SessionManager:
             volumes=volumes,
         )
 
-    async def release(self, session_id: str) -> bool:
-        """Stop a session's sandbox. Returns whether the session existed."""
-        if session_id not in self._sessions:
-            return False
+    @asynccontextmanager
+    async def _session_lock(self, session_id: str) -> AsyncIterator[None]:
+        """Hold the lock serializing every lifecycle change for one session id.
 
-        sandbox = self._sessions.pop(session_id)
-        self._locks.pop(session_id, None)
-        await self._lifecycle(sandbox.stop)
+        Interned rather than created per call, so `get_or_create` and `release`
+        contend on the same object — and reference-counted while entered, so
+        :meth:`_prune_locks` cannot drop one out from under a task. Counting
+        rather than asking `Lock.locked()`: between a holder releasing and the
+        woken waiter resuming, a lock reads as unlocked while a task is very much
+        still queued on it, and interning a fresh one for the next caller is how
+        two of them end up creating a sandbox for the same session at once.
+        """
+        entry = self._locks.setdefault(session_id, _SessionLock())
+        entry.users += 1
+        try:
+            async with entry.lock:
+                yield
+        finally:
+            entry.users -= 1
+
+    async def release(self, session_id: str) -> bool:
+        """Stop a session's sandbox. Returns whether the session existed.
+
+        Takes the session's lock, so a release cannot land in the middle of a
+        `get_or_create` for the same id. Without it the two interleaved: the
+        release removed the entry `get_or_create` was about to delete (a
+        `KeyError` out of a public coroutine) and removed the lock it was
+        holding, after which a third caller interned a new lock and created a
+        second sandbox for one session — the leak the lock is meant to prevent.
+        """
+        async with self._session_lock(session_id):
+            sandbox = self._sessions.pop(session_id, None)
+            if sandbox is None:
+                return False
+            await self._lifecycle(sandbox.stop)
+
+        self._prune_locks()
+        # Outside the lock: `on_release` belongs to the caller, and one that
+        # opens or releases a session from it would otherwise deadlock.
         if self._on_release is not None:
             self._on_release(session_id)
         return True
@@ -294,13 +340,14 @@ class SessionManager:
 
         `get_or_create` interns a lock before it knows whether the sandbox can
         be created, so every rejected or failed creation would otherwise leave
-        an entry behind for good. Held locks are left alone — a waiter is
-        relying on that exact object for mutual exclusion.
+        an entry behind for good. A lock any task is inside — holding it, or
+        queued for it — is left alone: that entry is what mutual exclusion for
+        the id currently is, and replacing it means two tasks proceed at once.
         """
         stale = [
             session_id
-            for session_id, lock in self._locks.items()
-            if session_id not in self._sessions and not lock.locked()
+            for session_id, entry in self._locks.items()
+            if session_id not in self._sessions and entry.users == 0
         ]
         for session_id in stale:
             del self._locks[session_id]

--- a/src/pydantic_ai_backends/backends/kubernetes.py
+++ b/src/pydantic_ai_backends/backends/kubernetes.py
@@ -417,11 +417,12 @@ class KubernetesPodSandbox(BaseSandbox):
             return [_to_file_info(row) for row in r.json()]
         return super().glob_info(pattern, path)
 
-    def write(self, path: str, content: str) -> WriteResult:
+    def write(self, path: str, content: str | bytes) -> WriteResult:
         self.touch()
         if self._mode == "http":
             try:
-                payload = base64.b64encode(content.encode("utf-8")).decode("ascii")
+                raw = content if isinstance(content, bytes) else content.encode("utf-8")
+                payload = base64.b64encode(raw).decode("ascii")
                 r = self._http.post("/write", json={"path": path, "content_b64": payload})
                 r.raise_for_status()
             except Exception as exc:

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -256,11 +256,20 @@ class LocalBackend:
             for entry in full_path.iterdir():
                 try:
                     self._resolve(str(entry))
+                    if self._is_denied("ls", str(entry)):
+                        continue
+                    info = _entry_info(entry)
                 except PermissionError:
                     continue
-                if not self._is_denied("ls", str(entry)):
-                    results.append(_entry_info(entry))
-        except PermissionError:
+                except OSError:
+                    # Per entry, not per listing, matching `glob_info`: a file
+                    # that vanished or cannot be stat'd between `iterdir` and
+                    # `_entry_info` used to abort the whole loop and take the
+                    # directory's other rows with it.
+                    continue
+                results.append(info)
+        except (PermissionError, OSError):
+            # The walk itself failed, so there is nothing left to collect.
             return []
 
         return sorted(results, key=lambda x: (not x["is_dir"], x["name"]))
@@ -360,6 +369,12 @@ class LocalBackend:
 
         try:
             content = full_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Refused rather than decoded with replacement characters: writing the
+            # result back would substitute every undecodable byte for U+FFFD and
+            # destroy the file. `read` can afford `errors="replace"` because it
+            # only displays the content; `edit` stores it again.
+            return EditResult(error=f"'{path}' is not valid UTF-8 text and cannot be edited")
         except PermissionError:
             return EditResult(error=f"Permission denied for '{path}'")
         except OSError as e:

--- a/src/pydantic_ai_backends/backends/state.py
+++ b/src/pydantic_ai_backends/backends/state.py
@@ -89,7 +89,7 @@ class StateBackend:
         stored = self._files.get(normalize_path(path))
         if stored is None:
             return b""
-        return "\n".join(stored["content"]).encode("utf-8", errors="replace")
+        return _encode("\n".join(stored["content"]))
 
     def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
         """Read a slice of a file with line numbers."""
@@ -120,7 +120,7 @@ class StateBackend:
 
         path = normalize_path(path)
         if isinstance(content, bytes):
-            content = content.decode("utf-8", errors="replace")
+            content = _decode(content)
 
         now = _timestamp()
         existing = self._files.get(path)
@@ -227,10 +227,38 @@ def _timestamp() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+BYTES_ERRORS = "surrogateescape"
+"""How bytes cross into the `str` lines this backend stores, and back.
+
+Files here are lines of text, so binary content has to survive a `str` round
+trip. `errors="replace"` did not: every byte that is not UTF-8 became U+FFFD, so
+a PNG written through `write` came back from `read_bytes` as different bytes,
+with a `WriteResult` reporting success. `surrogateescape` maps those bytes to
+lone surrogates and maps them back unchanged, which makes the round trip exact.
+
+The cost is that `read` and `grep` show a surrogate where the undecodable byte
+was — no worse than the replacement character they showed before, and only for
+content that was never text.
+"""
+
+
+def _decode(data: bytes) -> str:
+    """Bytes as the `str` this backend stores, reversibly."""
+    return data.decode("utf-8", errors=BYTES_ERRORS)
+
+
+def _encode(text: str) -> bytes:
+    """Stored text back as the bytes it was written from."""
+    return text.encode("utf-8", errors=BYTES_ERRORS)
+
+
 def _file_entry(name: str, path: str, data: FileData) -> FileInfo:
     return FileInfo(
         name=name,
         path=path,
         is_dir=False,
-        size=sum(len(line) for line in data["content"]),
+        # The separators count: content is stored split on "\n" and rejoined on
+        # the way out, so summing the lines alone reported one byte less per line
+        # than `read_bytes` returns.
+        size=len(_encode("\n".join(data["content"]))),
     )

--- a/src/pydantic_ai_backends/capability.py
+++ b/src/pydantic_ai_backends/capability.py
@@ -27,7 +27,11 @@ from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset
 
-from pydantic_ai_backends.permissions.checker import PermissionChecker
+from pydantic_ai_backends.permissions.checker import (
+    AskCallback,
+    AskFallback,
+    PermissionChecker,
+)
 from pydantic_ai_backends.permissions.types import (
     PermissionOperation,
     PermissionRuleset,
@@ -48,8 +52,16 @@ TOOL_OPERATIONS: dict[str, PermissionOperation] = {
     "glob": "glob",
     "grep": "grep",
     "execute": "execute",
+    # The background shells are the "execute" operation reached a different way.
+    # Left out of this map they were governed by nothing at all: an unmapped name
+    # is both kept by `prepare_tools` and waved through `before_tool_execute`, so
+    # a ruleset denying execution still handed the model `run_in_background`.
+    # `tests/test_capability.py` asserts this map covers every registered tool.
+    "run_in_background": "execute",
+    "read_output": "execute",
+    "kill_shell": "execute",
+    "list_shells": "execute",
 }
-
 """Console tool name -> the permission operation that governs it."""
 
 PATH_OPERATIONS: set[PermissionOperation] = {"read", "write", "edit"}
@@ -71,9 +83,11 @@ class ConsoleCapability(AbstractCapability[Any]):
     grep, execute) with dynamic instructions and per-tool permission control.
 
     When a permission ruleset is provided:
-    - Tools for denied operations are hidden from the model entirely
+    - Tools for denied operations are dropped from the toolset entirely, and
+      hidden again from each request's tool definitions
     - Per-path/command permissions are checked before each tool execution
-    - "ask" permissions can trigger an approval callback
+    - "ask" permissions go to `ask_callback`, and are refused or raised per
+      `ask_fallback` when there is none
 
     Example:
         ```python
@@ -107,11 +121,31 @@ class ConsoleCapability(AbstractCapability[Any]):
     include_execute: bool = True
     """Whether to include the execute tool."""
 
+    include_background: bool = True
+    """Whether to include the background-shell tools.
+
+    Separate from `include_execute` because a backend may support commands
+    without supporting long-lived ones — and because an agent that should not
+    start a process it cannot see finish wants these off while keeping `execute`.
+    """
+
     edit_format: EditFormat = "str_replace"
     """Edit format: 'str_replace' or 'hashline'."""
 
     permissions: PermissionRuleset | None = None
     """Permission ruleset for controlling tool access."""
+
+    ask_callback: AskCallback | None = None
+    """Async approval callback for operations the ruleset resolves to "ask".
+
+    Without one an "ask" cannot be answered, and `ask_fallback` decides what
+    happens instead. Every shipped preset except `PERMISSIVE_RULESET` has at
+    least one operation defaulting to "ask", so a ruleset supplied without this
+    or `ask_fallback="deny"` refuses those operations by raising.
+    """
+
+    ask_fallback: AskFallback = "error"
+    """What an unanswerable "ask" does — `"deny"` refuses it, `"error"` raises."""
 
     _toolset: AbstractToolset[Any] | None = field(default=None, init=False, repr=False)
     _checker: PermissionChecker | None = field(default=None, init=False, repr=False)
@@ -121,10 +155,19 @@ class ConsoleCapability(AbstractCapability[Any]):
         self._toolset = create_console_toolset(
             backend=self.backend,
             include_execute=self.include_execute,
+            include_background=self.include_background,
             edit_format=self.edit_format,
+            # Passed through as well as being enforced in `prepare_tools`: the
+            # toolset drops a denied operation's tools outright, so they are gone
+            # rather than merely hidden from one request's tool definitions.
+            permissions=self.permissions,
         )
         if self.permissions is not None:
-            self._checker = PermissionChecker(ruleset=self.permissions)
+            self._checker = PermissionChecker(
+                ruleset=self.permissions,
+                ask_callback=self.ask_callback,
+                ask_fallback=self.ask_fallback,
+            )
 
     @classmethod
     def get_serialization_name(cls) -> str:

--- a/src/pydantic_ai_backends/permissions/checker.py
+++ b/src/pydantic_ai_backends/permissions/checker.py
@@ -26,6 +26,9 @@ PATTERN_CACHE_SIZE = 512
 """Compiled patterns kept around. Every check walks a ruleset's rules, so
 recompiling them per call showed up in profiles of read-heavy agent runs."""
 
+MATCHES_NOTHING = re.compile(r"(?!)")
+"""What an unrenderable glob compiles to, so a bad rule is inert, not an error."""
+
 
 class PermissionAskError(Exception):
     """Raised when an operation needs approval and `ask_fallback="error"`.
@@ -89,6 +92,12 @@ def glob_to_regex(pattern: str) -> re.Pattern[str]:
 
     Supports `*` (anything but `/`), `**` (anything, including `/`), `?` (one
     character but `/`) and `[seq]` character classes with `!` or `^` negation.
+
+    A pattern whose character class is malformed beyond rescue — `[\\]`, whose
+    only `]` is escaped — renders to a regex `re` rejects. It compiles to a
+    pattern matching nothing, so the rule is inert and the operation's own
+    default decides. The alternative was `re.error` escaping the permission
+    check, which every caller here is promised will only ever return an action.
     """
     parts: list[str] = []
     index = 0
@@ -113,7 +122,10 @@ def glob_to_regex(pattern: str) -> re.Pattern[str]:
             parts.append(re.escape(pattern[index]))
             index += 1
 
-    return re.compile("^" + "".join(parts) + "$")
+    try:
+        return re.compile("^" + "".join(parts) + "$")
+    except re.error:
+        return MATCHES_NOTHING
 
 
 def _character_class(pattern: str, start: int) -> tuple[str, int]:

--- a/src/pydantic_ai_backends/remote/client.py
+++ b/src/pydantic_ai_backends/remote/client.py
@@ -35,7 +35,10 @@ TRANSPORT_SLACK_SECONDS = 10.0
 gives up before the command it is waiting for."""
 
 DEFAULT_TIMEOUT_SECONDS = 60.0
-"""Request timeout for operations that carry no timeout of their own."""
+"""Request timeout for operations that carry no timeout of their own.
+
+Only the floor. A command with no explicit timeout runs under the *service's*
+ceiling, which is larger — see :attr:`RemoteSandbox.server_timeout`."""
 
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
@@ -130,6 +133,9 @@ class RemoteSandbox(BaseSandbox):
             session_id=self._id, runtime=runtime, tenant=tenant, reuse=reuse
         )
         self._timeout = timeout
+        # Learned from the service when the session opens. Until then the local
+        # default stands, which is the right answer for a service we cannot ask.
+        self._server_timeout = timeout
         self._started = False
         # Operations run on a thread pool, so two of them can arrive at an
         # unopened session at once; without this both would POST /sessions and
@@ -166,6 +172,14 @@ class RemoteSandbox(BaseSandbox):
 
         Opens the session first if this is the first operation.
 
+        Args:
+            url: Operation path.
+            payload: JSON body.
+            timeout: Transport timeout. `None` waits out the service's own
+                ceiling plus slack, because every operation here runs a shell
+                command on the far side and giving up first reports a running
+                command as an unreachable service.
+
         Returns:
             The `httpx.Response`, or `None` when the request could not be made
             or the service answered with an error status.
@@ -179,7 +193,11 @@ class RemoteSandbox(BaseSandbox):
                 url,
                 json=payload,
                 headers={wire.TOKEN_HEADER: self._session_token},
-                timeout=timeout if timeout is not None else self._timeout,
+                timeout=(
+                    timeout
+                    if timeout is not None
+                    else self._server_timeout + TRANSPORT_SLACK_SECONDS
+                ),
             )
         except Exception:
             return None
@@ -255,6 +273,36 @@ class RemoteSandbox(BaseSandbox):
         self._id = created.session.session_id
         self._session_token = created.token
         self._started = True
+        self._server_timeout = self._fetch_server_timeout()
+
+    @property
+    def server_timeout(self) -> float:
+        """How long the service lets an operation run, once the session is open.
+
+        Read from `GET /policy` when the session opens, falling back to this
+        sandbox's own `timeout` when the service will not say. It exists because
+        the two numbers are one contract and were set independently: the client
+        gave up after 60s while the service happily ran a command for its default
+        300s, so anything in between was reported to the agent as "sandbox
+        service unavailable" while it was in fact still running — and typically
+        retried, starting a second one.
+        """
+        return self._server_timeout
+
+    def _fetch_server_timeout(self) -> float:
+        """The service's own operation ceiling, or this sandbox's default."""
+        try:
+            response = self._http.get(
+                "/policy",
+                headers={wire.TOKEN_HEADER: self._service_token},
+                timeout=self._timeout,
+            )
+        except Exception:
+            return self._timeout
+        policy = _parse(response if response.status_code < 400 else None, wire.ServicePolicy)
+        if policy is None or policy.execute_timeout <= 0:
+            return self._timeout
+        return float(policy.execute_timeout)
 
     def is_alive(self) -> bool:
         """Whether the remote session exists and its sandbox is running."""
@@ -317,11 +365,16 @@ class RemoteSandbox(BaseSandbox):
                 self._http.close()
 
     def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
-        """Run a command in the remote sandbox."""
+        """Run a command in the remote sandbox.
+
+        Without an explicit `timeout` the command runs under the service's
+        ceiling, and the transport waits that long plus slack — the two are one
+        contract, and the client giving up first turned a slow-but-successful
+        command into a reported outage.
+        """
         body = wire.ExecRequest(command=command, timeout_seconds=timeout)
-        transport_timeout = (
-            timeout + TRANSPORT_SLACK_SECONDS if timeout is not None else self._timeout
-        )
+        effective = float(timeout) if timeout is not None else self._server_timeout
+        transport_timeout = effective + TRANSPORT_SLACK_SECONDS
         response = self._post(self._url("exec"), body.model_dump(mode="json"), transport_timeout)
         parsed = _parse(response, wire.ExecResponse)
         if parsed is None:

--- a/src/pydantic_ai_backends/remote/server.py
+++ b/src/pydantic_ai_backends/remote/server.py
@@ -52,13 +52,13 @@ import stat
 import time
 import uuid
 from collections import Counter, deque
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar, cast
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi import Path as PathParam
@@ -89,6 +89,8 @@ if TYPE_CHECKING:
     from pydantic_ai_backends.protocol import AsyncSandboxProtocol
 
 _logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
 
 SandboxBuilder = Callable[[str, "SandboxRuntime"], Any]
 """Builds a sandbox for the service: `(session_id, runtime) -> sandbox`."""
@@ -1307,8 +1309,16 @@ class _Service:
                 record.next_seq += 1
 
     def events(self, session_id: str, after: int) -> wire.SessionEvents:
-        """Activity entries newer than `after`, for incremental polling."""
-        record = self._sessions[session_id]
+        """Activity entries newer than `after`, for incremental polling.
+
+        Raises:
+            HTTPException: 404 when the session was reaped between the
+                authorization check and this call, matching :meth:`describe` —
+                a subscript here turned that race into a 500.
+        """
+        record = self._sessions.get(session_id)
+        if record is None:
+            raise HTTPException(status_code=404, detail=f"No such session: {session_id}")
         return wire.SessionEvents(
             events=[event for event in record.events if event.seq > after],
             latest_seq=record.next_seq - 1,
@@ -1762,6 +1772,33 @@ class _Service:
             return self.config.execute_timeout
         return min(requested, self.config.execute_timeout)
 
+    async def bounded(self, operation: Awaitable[_T]) -> _T:
+        """Await one sandbox operation under the service's command ceiling.
+
+        `execute_timeout` is documented as applying to every command, and it was
+        applied to `/exec` alone. Everything else — `ls`, `glob`, `grep`, `read`,
+        `write` — reaches the sandbox's shell too, and an uncapped one of those
+        occupies a worker thread that nothing reclaims: a grep over a large tree
+        is enough, and `max_workers` of them wedge the service. Enforced here
+        rather than per backend so the promise is kept in the one place that
+        makes it.
+
+        The thread running the call cannot be interrupted, so this bounds how
+        long a *client* waits rather than how long the command runs. The
+        backend's own per-operation timeouts bound the command; this is what
+        stops the request from outliving them.
+
+        Raises:
+            HTTPException: 504 when the operation outlasts the ceiling.
+        """
+        try:
+            return await asyncio.wait_for(operation, timeout=self.config.execute_timeout)
+        except (asyncio.TimeoutError, TimeoutError) as exc:
+            raise HTTPException(
+                status_code=504,
+                detail=f"Operation exceeded the {self.config.execute_timeout}s service ceiling",
+            ) from exc
+
 
 def _service_of(request: Request) -> _Service:
     """Pull the service off application state."""
@@ -1920,8 +1957,13 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """Run a shell command, capped by the service's `execute_timeout`."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "exec", body.command) as outcome:
-            result = await service.adapter(sandbox).execute(
-                body.command, service.command_timeout(body.timeout_seconds)
+            # Both: the clamped timeout kills the command inside the sandbox,
+            # and `bounded` stops a backend that ignores it from holding the
+            # request — and its worker — for ever.
+            result = await service.bounded(
+                service.adapter(sandbox).execute(
+                    body.command, service.command_timeout(body.timeout_seconds)
+                )
             )
             outcome.ok = result.exit_code == 0
             outcome.detail = f"exit {result.exit_code}"
@@ -1934,7 +1976,9 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """Read a slice of a text file."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "read", body.path) as outcome:
-            content = await service.adapter(sandbox).read(body.path, body.offset, body.limit)
+            content = await service.bounded(
+                service.adapter(sandbox).read(body.path, body.offset, body.limit)
+            )
             outcome.ok = not content.startswith(("Error:", "[Error"))
             outcome.detail = f"{len(content)} chars"
         return wire.ReadResponse(content=content)
@@ -1946,7 +1990,7 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """Read a whole file as base64."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "read_bytes", body.path) as outcome:
-            raw = await service.adapter(sandbox).read_bytes(body.path)
+            raw = await service.bounded(service.adapter(sandbox).read_bytes(body.path))
             outcome.ok = bool(raw)
             outcome.detail = f"{len(raw)} bytes"
         return wire.ReadBytesResponse(content_b64=base64.b64encode(raw).decode("ascii"))
@@ -1965,7 +2009,7 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
 
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "write", body.path) as outcome:
-            result = await service.adapter(sandbox).write(body.path, raw)
+            result = await service.bounded(service.adapter(sandbox).write(body.path, raw))
             outcome.ok = result.error is None
             outcome.detail = result.error or f"{len(raw)} bytes"
         return wire.WriteResponse(path=result.path, error=result.error)
@@ -1975,8 +2019,10 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """Replace a string inside a file."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "edit", body.path) as outcome:
-            result = await service.adapter(sandbox).edit(
-                body.path, body.old_string, body.new_string, body.replace_all
+            result = await service.bounded(
+                service.adapter(sandbox).edit(
+                    body.path, body.old_string, body.new_string, body.replace_all
+                )
             )
             outcome.ok = result.error is None
             outcome.detail = result.error or f"{result.occurrences} replaced"
@@ -1991,7 +2037,7 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """Test whether a path is a regular file."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "exists", body.path) as outcome:
-            found = await service.adapter(sandbox).exists(body.path)
+            found = await service.bounded(service.adapter(sandbox).exists(body.path))
             outcome.ok = True
             outcome.detail = "found" if found else "missing"
         return wire.ExistsResponse(exists=found)
@@ -2001,7 +2047,7 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """List one directory."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "ls", body.path) as outcome:
-            rows = await service.adapter(sandbox).ls_info(body.path)
+            rows = await service.bounded(service.adapter(sandbox).ls_info(body.path))
             outcome.ok = True
             outcome.detail = f"{len(rows)} entries"
         return [wire.FileEntry(**row) for row in rows]
@@ -2013,7 +2059,9 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """Match files by glob pattern."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "glob", f"{body.pattern} in {body.path}") as outcome:
-            rows = await service.adapter(sandbox).glob_info(body.pattern, body.path)
+            rows = await service.bounded(
+                service.adapter(sandbox).glob_info(body.pattern, body.path)
+            )
             outcome.ok = True
             outcome.detail = f"{len(rows)} matches"
         return [wire.FileEntry(**row) for row in rows]
@@ -2025,8 +2073,10 @@ def _register_operation_routes(app: FastAPI, service: _Service) -> None:
         """Search file contents."""
         sandbox = await service.sandbox(session_id)
         with service.observe(session_id, "grep", body.pattern) as outcome:
-            found = await service.adapter(sandbox).grep_raw(
-                body.pattern, body.path, body.glob, body.ignore_hidden
+            found = await service.bounded(
+                service.adapter(sandbox).grep_raw(
+                    body.pattern, body.path, body.glob, body.ignore_hidden
+                )
             )
             outcome.ok = not isinstance(found, str)
             outcome.detail = found if isinstance(found, str) else f"{len(found)} matches"

--- a/src/pydantic_ai_backends/remote/wire.py
+++ b/src/pydantic_ai_backends/remote/wire.py
@@ -348,9 +348,9 @@ class ServicePolicy(BaseModel):
     execute_timeout: int = 0
     max_read_bytes: int = 0
     persist_containers: bool = False
+    """Whether a stopped sandbox keeps its filesystem for the next attach."""
     sandbox_uid: int | None = None
     """Uid built runtimes run as, or `None` when sandboxes run as root."""
-    """Whether a stopped sandbox keeps its filesystem for the next attach."""
     workspace_ttl: int | None = None
     """Seconds an unused workspace is kept before it is swept, or `None`."""
     container_ttl: int | None = None

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -101,6 +101,17 @@ GREP_LINE_WIDTH = 100
 
 DEFAULT_EXECUTE_TIMEOUT = 120
 
+EXECUTE_TOOLS = frozenset(
+    {"execute", "run_in_background", "read_output", "kill_shell", "list_shells"}
+)
+"""Every tool the "execute" operation governs.
+
+Named as a set because listing only `execute` is how a ruleset that denied shell
+execution still left `run_in_background` — which runs an arbitrary command —
+registered for the model to call. The background tools are the same operation
+reached a different way, so they live and die with it.
+"""
+
 
 @runtime_checkable
 class ConsoleDeps(Protocol):
@@ -466,18 +477,24 @@ the old_string must appear exactly once in the file.
             raw_backend = backend_for(ctx)
             backend = ensure_async(raw_backend)
 
-            stale = await _tracking.staleness_error(backend, raw_backend, path)
-            if stale is not None:
-                return stale
+            # Locked for the same reason `hashline_edit` is: every backend's
+            # `edit` is a read, a replace and a write, so two edits to one path
+            # in flight together lose one of them. The staleness check belongs
+            # inside the lock too — checked outside, it is answered before the
+            # other edit's write and passes on content that no longer exists.
+            async with _tracking.edit_lock(raw_backend, path):
+                stale = await _tracking.staleness_error(backend, raw_backend, path)
+                if stale is not None:
+                    return stale
 
-            result = await backend.edit(path, old_string, new_string, replace_all)
-            if result.error:
-                return f"Error: {result.error}"
+                result = await backend.edit(path, old_string, new_string, replace_all)
+                if result.error:
+                    return f"Error: {result.error}"
 
-            # The agent's view is the post-edit content now, so a follow-up edit
-            # must not be flagged as stale.
-            await _tracking.record_path_read(backend, raw_backend, path)
-            return f"Edited {result.path}: replaced {result.occurrences} occurrence(s)"
+                # The agent's view is the post-edit content now, so a follow-up
+                # edit must not be flagged as stale.
+                await _tracking.record_path_read(backend, raw_backend, path)
+                return f"Edited {result.path}: replaced {result.occurrences} occurrence(s)"
 
     @toolset.tool(description=described.get("glob", GLOB_DESCRIPTION))
     @_degrade_on_error
@@ -692,7 +709,7 @@ def _denied_tools(permissions: PermissionRuleset | None) -> set[str]:
     if _ruleset.is_denied(permissions, "edit"):
         denied.update({"edit_file", "hashline_edit"})
     if _ruleset.is_denied(permissions, "execute"):
-        denied.add("execute")
+        denied |= EXECUTE_TOOLS
     return denied
 
 

--- a/tests/test_base_sandbox.py
+++ b/tests/test_base_sandbox.py
@@ -7,9 +7,12 @@ identically. A drift between them is the bug this pairing exists to prevent.
 
 from __future__ import annotations
 
+import base64
+
 import pytest
 
 from pydantic_ai_backends import AsyncBaseSandbox, BaseSandbox
+from pydantic_ai_backends.backends.base import FILE_OP_TIMEOUT, SEARCH_TIMEOUT
 from pydantic_ai_backends.types import EditResult, ExecuteResponse
 
 LISTING = (
@@ -166,14 +169,22 @@ class TestParity:
 
         assert sync.write("/f", "body").path == "/f"
         assert (await asyncish.write("/f", "body")).path == "/f"
-        # The heredoc delimiter is random, so compare the shape not the text.
         assert len(sync.commands) == len(asyncish.commands) == 1
-        assert "cat > /f <<" in sync.commands[0]
-        assert "cat > /f <<" in asyncish.commands[0]
+        assert "base64 -d > /f" in sync.commands[0]
+        assert "base64 -d > /f" in asyncish.commands[0]
+
+    async def test_write_accepts_bytes(self):
+        """The protocol types `content` as `str | bytes`; both bases narrowed it."""
+        sync, asyncish = self._pair({})
+
+        assert sync.write("/img.png", b"\x89PNG").path == "/img.png"
+        assert (await asyncish.write("/img.png", b"\x89PNG")).path == "/img.png"
+        payload = sync.commands[0].split("printf %s ", 1)[1].split(" ", 1)[0]
+        assert base64.b64decode(payload) == b"\x89PNG"
 
     async def test_write_reports_a_failure(self):
         failed = ExecuteResponse(output="Permission denied", exit_code=1)
-        sync, asyncish = self._pair({"cat >": failed})
+        sync, asyncish = self._pair({"base64 -d": failed})
 
         assert sync.write("/f", "x").error == "Permission denied"
         assert (await asyncish.write("/f", "x")).error == "Permission denied"
@@ -225,3 +236,96 @@ class TestAbstractMethods:
     @pytest.mark.parametrize("base", [BaseSandbox, AsyncBaseSandbox])
     def test_execute_and_edit_are_the_only_abstract_methods(self, base):
         assert base.__abstractmethods__ == frozenset({"execute", "edit"})
+
+
+class TestEveryOperationIsBounded:
+    """A shell command with no timeout is one nothing can reclaim.
+
+    `DockerSandbox.execute` only wraps the `timeout` utility around a command it
+    was given a limit for, and `exec_run` has no deadline of its own — so an
+    uncapped operation pins a worker thread for good. `exists` passed a timeout;
+    the other seven did not, which is how a handful of `grep` requests wedged a
+    whole sandbox service.
+    """
+
+    @staticmethod
+    def _calls(sandbox) -> list[int | None]:
+        return [timeout for _command, timeout in sandbox.timed_commands]
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda s: s.exists("/f"),
+            lambda s: s.ls_info("/d"),
+            lambda s: s.read_bytes("/f"),
+            lambda s: s.read("/f"),
+            lambda s: s.write("/f", "x"),
+            lambda s: s.glob_info("*.py", "/d"),
+            lambda s: s.grep_raw("x", "/d"),
+        ],
+    )
+    def test_sync(self, operation):
+        sandbox = TimedShell()
+
+        operation(sandbox)
+
+        assert self._calls(sandbox) and all(t is not None for t in self._calls(sandbox))
+
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda s: s.exists("/f"),
+            lambda s: s.ls_info("/d"),
+            lambda s: s.read_bytes("/f"),
+            lambda s: s.read("/f"),
+            lambda s: s.write("/f", "x"),
+            lambda s: s.glob_info("*.py", "/d"),
+            lambda s: s.grep_raw("x", "/d"),
+        ],
+    )
+    async def test_async(self, operation):
+        sandbox = TimedAsyncShell()
+
+        await operation(sandbox)
+
+        assert self._calls(sandbox) and all(t is not None for t in self._calls(sandbox))
+
+    def test_a_search_gets_longer_than_a_listing(self):
+        """A grep over a large repository is slow in a way a `ls` never is."""
+        sandbox = TimedShell()
+
+        sandbox.ls_info("/d")
+        sandbox.grep_raw("x", "/d")
+
+        listing, search = self._calls(sandbox)
+        assert listing == FILE_OP_TIMEOUT < search == SEARCH_TIMEOUT
+
+
+class TimedShell(BaseSandbox):
+    """Records the timeout each derived operation asks for."""
+
+    def __init__(self) -> None:
+        super().__init__("timed")
+        self.timed_commands: list[tuple[str, int | None]] = []
+
+    def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+        self.timed_commands.append((command, timeout))
+        return ExecuteResponse(output="", exit_code=0)
+
+    def edit(self, path, old_string, new_string, replace_all=False) -> EditResult:
+        return EditResult(path=path)
+
+
+class TimedAsyncShell(AsyncBaseSandbox):
+    """Async counterpart to `TimedShell`."""
+
+    def __init__(self) -> None:
+        super().__init__("timed")
+        self.timed_commands: list[tuple[str, int | None]] = []
+
+    async def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+        self.timed_commands.append((command, timeout))
+        return ExecuteResponse(output="", exit_code=0)
+
+    async def edit(self, path, old_string, new_string, replace_all=False) -> EditResult:
+        return EditResult(path=path)

--- a/tests/test_base_sandbox.py
+++ b/tests/test_base_sandbox.py
@@ -153,13 +153,22 @@ class TestParity:
         assert sync.commands == asyncish.commands
 
     async def test_read_bytes(self):
-        sync, asyncish = self._pair({"cat ": ExecuteResponse(output="payload", exit_code=0)})
+        encoded = base64.b64encode(b"payload").decode()
+        sync, asyncish = self._pair({"base64 ": ExecuteResponse(output=encoded, exit_code=0)})
 
         assert sync.read_bytes("/f") == b"payload"
         assert await asyncish.read_bytes("/f") == b"payload"
 
+    async def test_read_bytes_round_trips_arbitrary_bytes(self):
+        raw = bytes(range(256))
+        encoded = base64.b64encode(raw).decode()
+        sync, asyncish = self._pair({"base64 ": ExecuteResponse(output=encoded, exit_code=0)})
+
+        assert sync.read_bytes("/f") == raw
+        assert await asyncish.read_bytes("/f") == raw
+
     async def test_read_bytes_degrades_to_empty(self):
-        sync, asyncish = self._pair({"cat ": ExecuteResponse(output="nope", exit_code=1)})
+        sync, asyncish = self._pair({"base64 ": ExecuteResponse(output="nope", exit_code=1)})
 
         assert sync.read_bytes("/f") == b""
         assert await asyncish.read_bytes("/f") == b""

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -12,8 +12,14 @@ from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_backends import LocalBackend
-from pydantic_ai_backends.capability import ConsoleCapability
-from pydantic_ai_backends.permissions.presets import PERMISSIVE_RULESET, READONLY_RULESET
+from pydantic_ai_backends.capability import TOOL_OPERATIONS, ConsoleCapability
+from pydantic_ai_backends.permissions.checker import PermissionDeniedError
+from pydantic_ai_backends.permissions.presets import (
+    DEFAULT_RULESET,
+    PERMISSIVE_RULESET,
+    READONLY_RULESET,
+)
+from pydantic_ai_backends.toolsets.console import EXECUTE_TOOLS, create_console_toolset
 
 
 def _make_ctx():
@@ -326,3 +332,91 @@ class TestCapabilityOwnedBackend:
 
         assert "edit_file" in toolset.tools
         assert "hashline_edit" not in toolset.tools
+
+
+class TestDeniedExecuteRemovesEveryShellTool:
+    """A denied `execute` used to leave the background shells behind.
+
+    `_denied_tools` listed only `execute`, and `TOOL_OPERATIONS` had no entry for
+    the background tools at all — so `prepare_tools` kept them and
+    `before_tool_execute` waved them through unchecked. The result was an agent
+    on `READONLY_RULESET`, whose docstring reads "nothing may change or run",
+    holding `run_in_background`, which runs an arbitrary shell command.
+    """
+
+    def test_the_toolset_drops_all_five(self):
+        toolset = create_console_toolset(permissions=READONLY_RULESET)
+
+        assert not EXECUTE_TOOLS & set(toolset.tools)
+
+    async def test_the_capability_drops_all_five(self):
+        cap = ConsoleCapability(permissions=READONLY_RULESET)
+        defs = [ToolDefinition(name=name) for name in sorted(EXECUTE_TOOLS)]
+
+        kept = await cap.prepare_tools(_make_ctx(), defs)
+
+        assert kept == []
+
+    @pytest.mark.parametrize("tool_name", sorted(EXECUTE_TOOLS))
+    async def test_every_shell_tool_is_refused_before_it_runs(self, tool_name: str):
+        """Belt and braces: even reached directly, the check must deny it."""
+        cap = ConsoleCapability(permissions=READONLY_RULESET)
+
+        with pytest.raises(PermissionDeniedError):
+            await cap.before_tool_execute(
+                _make_ctx(),
+                call=ToolCallPart(tool_name=tool_name, args={"command": "id"}),
+                tool_def=ToolDefinition(name=tool_name),
+                args={"command": "id"},
+            )
+
+    def test_every_registered_tool_maps_to_an_operation(self):
+        """An unmapped name is kept *and* unchecked, so the map must be total.
+
+        This is the assertion that would have caught the finding: the background
+        tools were registered by the toolset and absent from `TOOL_OPERATIONS`.
+        """
+        registered = set(create_console_toolset(edit_format="hashline").tools)
+        registered |= set(create_console_toolset(edit_format="str_replace").tools)
+
+        assert registered <= set(TOOL_OPERATIONS)
+
+
+class TestCapabilityApproval:
+    """`permissions` without `ask_callback` made every "ask" ruleset unusable."""
+
+    async def test_an_ask_reaches_the_callback(self):
+        asked: list[tuple[str, str]] = []
+
+        async def approve(operation: str, target: str, reason: str) -> bool:
+            asked.append((operation, target))
+            return True
+
+        cap = ConsoleCapability(permissions=DEFAULT_RULESET, ask_callback=approve)
+
+        args = await cap.before_tool_execute(
+            _make_ctx(),
+            call=ToolCallPart(tool_name="write_file", args={"path": "/a.txt"}),
+            tool_def=ToolDefinition(name="write_file"),
+            args={"path": "/a.txt"},
+        )
+
+        assert args == {"path": "/a.txt"}
+        assert asked == [("write", "/a.txt")]
+
+    async def test_ask_fallback_deny_refuses_instead_of_raising_an_ask_error(self):
+        cap = ConsoleCapability(permissions=DEFAULT_RULESET, ask_fallback="deny")
+
+        with pytest.raises(PermissionDeniedError):
+            await cap.before_tool_execute(
+                _make_ctx(),
+                call=ToolCallPart(tool_name="write_file", args={"path": "/a.txt"}),
+                tool_def=ToolDefinition(name="write_file"),
+                args={"path": "/a.txt"},
+            )
+
+    def test_background_tools_can_be_left_out(self):
+        cap = ConsoleCapability(include_background=False)
+
+        assert "run_in_background" not in cap.get_toolset().tools
+        assert "execute" in cap.get_toolset().tools

--- a/tests/test_kubernetes_sandbox.py
+++ b/tests/test_kubernetes_sandbox.py
@@ -760,8 +760,10 @@ class TestApiModeFallsBackToTheShell:
     def teardown_method(self) -> None:
         fake_k8s_stream_mod.stream = _stream_fn
 
-    def test_read_bytes_goes_through_cat(self):
-        assert self._sandbox("payload").read_bytes("/f.txt") == b"payload"
+    def test_read_bytes_goes_through_base64(self):
+        encoded = base64.b64encode(b"payload").decode()
+
+        assert self._sandbox(encoded).read_bytes("/f.txt") == b"payload"
 
     def test_read_goes_through_awk(self):
         assert self._sandbox("     1\thello").read("/f.txt") == "     1\thello"

--- a/tests/test_local_backend_failure_paths.py
+++ b/tests/test_local_backend_failure_paths.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -504,3 +505,64 @@ class TestBackgroundExecuteFailures:
 
         assert result.exit_code == 1
         assert "cannot spawn" in result.output
+
+
+class TestEditNeverRaises:
+    """`protocol.py`: "Every method here returns its failures and never raises."
+
+    `edit` read the file as strict UTF-8 and caught only `PermissionError` and
+    `OSError`. `UnicodeDecodeError` subclasses `ValueError`, so a file that is
+    not text raised straight out of a backend that sits in an agent's tool path.
+    `read`, four lines above it, decodes the same file fine.
+    """
+
+    def test_a_non_utf8_file_is_refused_not_raised(self, tmp_path: Path):
+        backend = LocalBackend(root_dir=tmp_path)
+        (tmp_path / "bin.dat").write_bytes(b"\xff\xfe\x00binary\xc3\x28")
+
+        result = backend.edit("bin.dat", "binary", "text")
+
+        assert result.path is None
+        assert "not valid UTF-8" in (result.error or "")
+
+    def test_the_file_is_left_untouched(self, tmp_path: Path):
+        """Decoding with replacement would substitute U+FFFD and write it back."""
+        backend = LocalBackend(root_dir=tmp_path)
+        raw = b"\xff\xfe\x00binary\xc3\x28"
+        (tmp_path / "bin.dat").write_bytes(raw)
+
+        backend.edit("bin.dat", "binary", "text")
+
+        assert (tmp_path / "bin.dat").read_bytes() == raw
+
+    def test_read_still_shows_what_it_can(self, tmp_path: Path):
+        backend = LocalBackend(root_dir=tmp_path)
+        (tmp_path / "bin.dat").write_bytes(b"\xff\xfe\x00binary\xc3\x28")
+
+        assert "binary" in backend.read("bin.dat")
+
+
+class TestListingSurvivesAVanishingEntry:
+    """`glob_info` was hardened against this; `ls_info`, its sibling, was not.
+
+    A file that disappears between `iterdir` and the `stat` in `_entry_info`
+    raised `FileNotFoundError` out of the whole listing, taking the directory's
+    other rows with it.
+    """
+
+    def test_one_unstattable_entry_does_not_lose_the_others(self, tmp_path: Path):
+        backend = LocalBackend(root_dir=tmp_path)
+        (tmp_path / "kept.txt").write_text("here")
+        (tmp_path / "vanishes.txt").write_text("gone in a moment")
+
+        real_stat = Path.stat
+
+        def stat_but_one(self: Path, *args: object, **kwargs: object):
+            if self.name == "vanishes.txt":
+                raise FileNotFoundError(self)
+            return real_stat(self, *args, **kwargs)
+
+        with patch.object(Path, "stat", stat_but_one):
+            rows = backend.ls_info(".")
+
+        assert [row["name"] for row in rows] == ["kept.txt"]

--- a/tests/test_permissions_checker.py
+++ b/tests/test_permissions_checker.py
@@ -375,3 +375,34 @@ class TestPermissionErrors:
         )
         error = PermissionDeniedError("execute", "rm -rf /", rule)
         assert "Dangerous command blocked" in str(error)
+
+
+class TestAnUnrenderablePatternIsInert:
+    """`[\\]` renders to `^[\\]$`, which `re` rejects as an unterminated set.
+
+    A rule carrying one used to raise `re.error` out of the permission check,
+    which every caller is promised only ever returns an action.
+    """
+
+    def test_it_compiles_to_something_that_matches_nothing(self):
+        compiled = glob_to_regex("[\\]")
+
+        assert compiled.match("") is None
+        assert compiled.match("[\\]") is None
+        assert compiled.match("anything at all") is None
+
+    def test_a_rule_carrying_one_does_not_raise(self):
+        checker = PermissionChecker(
+            ruleset=PermissionRuleset(
+                read=OperationPermissions(
+                    default="allow",
+                    rules=[PermissionRule(pattern="[\\]", action="deny")],
+                )
+            )
+        )
+
+        assert checker.check_sync("read", "/notes.md") == "allow"
+
+    def test_a_well_formed_class_still_works(self):
+        assert matches_pattern("a.py", "[ab].py")
+        assert not matches_pattern("c.py", "[ab].py")

--- a/tests/test_remote_sandbox.py
+++ b/tests/test_remote_sandbox.py
@@ -26,6 +26,7 @@ from fastapi.testclient import TestClient
 
 from pydantic_ai_backends import StateBackend
 from pydantic_ai_backends.remote import RemoteSandbox, wire
+from pydantic_ai_backends.remote.client import TRANSPORT_SLACK_SECONDS
 from pydantic_ai_backends.remote.server import (
     SandboxdConfig,
     SandboxRuntime,
@@ -75,6 +76,14 @@ class FakeSandbox:
         # Lets a test hold an open inside `start()`, which is where a real one
         # spends its seconds pulling an image.
         self.start_gate: threading.Event | None = None
+        # Seconds every operation blocks for, standing in for a slow command or
+        # a grep over a large tree. Blocking rather than sleeping on the loop,
+        # because that is what a real sandbox does to its worker thread.
+        self.stall = 0.0
+
+    def _work(self) -> None:
+        if self.stall:
+            time.sleep(self.stall)
 
     # lifecycle -----------------------------------------------------------
     @property
@@ -110,18 +119,22 @@ class FakeSandbox:
 
     # operations ----------------------------------------------------------
     def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+        self._work()
         self.commands.append((command, timeout))
         return ExecuteResponse(output=f"ran {command}", exit_code=0, truncated=False)
 
     def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+        self._work()
         return self._store.read(path, offset, limit)
 
     def read_bytes(self, path: str) -> bytes:
+        self._work()
         if path in self._blobs:
             return self._blobs[path]
         return self._store.read_bytes(path)
 
     def write(self, path: str, content: str | bytes) -> WriteResult:
+        self._work()
         raw = content if isinstance(content, bytes) else content.encode("utf-8")
         self._blobs[path] = raw
         return self._store.write(path, content)
@@ -129,15 +142,19 @@ class FakeSandbox:
     def edit(
         self, path: str, old_string: str, new_string: str, replace_all: bool = False
     ) -> EditResult:
+        self._work()
         return self._store.edit(path, old_string, new_string, replace_all)
 
     def exists(self, path: str) -> bool:
+        self._work()
         return self._store.exists(path)
 
     def ls_info(self, path: str) -> list[Any]:
+        self._work()
         return self._store.ls_info(path)
 
     def glob_info(self, pattern: str, path: str = "/") -> list[Any]:
+        self._work()
         return self._store.glob_info(pattern, path)
 
     def grep_raw(
@@ -147,6 +164,7 @@ class FakeSandbox:
         glob: str | None = None,
         ignore_hidden: bool = True,
     ) -> Any:
+        self._work()
         return self._store.grep_raw(pattern, path, glob, ignore_hidden)
 
 
@@ -3797,3 +3815,207 @@ class TestUnprivilegedSandboxes:
             )
 
         assert policy.sandbox_uid == os.getuid()
+
+
+class TestOperationsAreBoundedByTheServiceCeiling:
+    """`execute_timeout` is documented as applying to *every* command.
+
+    It was applied on `/exec` and nowhere else. `ls`, `glob`, `grep`, `read` and
+    `write` all reach the sandbox's shell too, so one slow search occupied a
+    worker of the `max_workers` pool with nothing able to reclaim it — and
+    `max_workers` of them wedged the service for every session.
+    """
+
+    @pytest.fixture
+    def slow(self):
+        harness = Harness(execute_timeout=1)
+        with harness.client() as running:
+            yield harness, running
+
+    @staticmethod
+    def _open(client: TestClient) -> tuple[str, dict[str, str]]:
+        created = client.post(
+            "/sessions", json={"session_id": "slow"}, headers=_service_headers()
+        ).json()
+        return created["session"]["session_id"], {wire.TOKEN_HEADER: created["token"]}
+
+    @pytest.mark.parametrize(
+        ("route", "body"),
+        [
+            ("exec", {"command": "sleep 60"}),
+            ("ls", {"path": "/"}),
+            ("read", {"path": "/f"}),
+            ("read_bytes", {"path": "/f"}),
+            ("write", {"path": "/f", "content_b64": "eA=="}),
+            ("edit", {"path": "/f", "old_string": "a", "new_string": "b"}),
+            ("exists", {"path": "/f"}),
+            ("glob", {"pattern": "*.py", "path": "/"}),
+            ("grep", {"pattern": "x"}),
+        ],
+    )
+    def test_an_operation_past_the_ceiling_is_a_504(self, slow, route: str, body: dict[str, Any]):
+        harness, client = slow
+        session_id, headers = self._open(client)
+        # Just past the ceiling: the worker thread cannot be interrupted, so a
+        # longer stall only makes the service's shutdown wait for it.
+        harness.built[session_id].stall = 1.2
+
+        response = client.post(f"/sessions/{session_id}/{route}", json=body, headers=headers)
+
+        assert response.status_code == 504
+        assert "service ceiling" in response.json()["detail"]
+
+    def test_an_operation_inside_the_ceiling_still_answers(self, slow):
+        harness, client = slow
+        session_id, headers = self._open(client)
+
+        response = client.post(f"/sessions/{session_id}/ls", json={"path": "/"}, headers=headers)
+
+        assert response.status_code == 200
+
+
+class TestClientWaitsOutTheServiceCeiling:
+    """The client's transport timeout and the service's ceiling are one contract.
+
+    `TRANSPORT_SLACK_SECONDS` exists so "the transport never gives up before the
+    command it is waiting for", but the two defaults were set independently — 60s
+    against 300s. Anything in between was reported to the agent as an unavailable
+    service while the command was in fact still running, and typically retried.
+    """
+
+    def test_the_ceiling_is_read_from_the_service(self, client: TestClient):
+        sandbox = RemoteSandbox(token=SERVICE_TOKEN, session_id="paired", client=client)
+
+        sandbox.start()
+
+        assert sandbox.server_timeout == float(SandboxdConfig(token="x").execute_timeout)
+
+    def test_a_command_with_no_timeout_waits_that_long_plus_slack(self, client: TestClient):
+        sandbox = RemoteSandbox(token=SERVICE_TOKEN, session_id="paired", client=client)
+        sandbox.start()
+        seen: list[float | None] = []
+        original = client.post
+
+        def record(url: str, **kwargs: Any):
+            seen.append(kwargs.get("timeout"))
+            return original(url, **kwargs)
+
+        sandbox._http.post = record  # type: ignore[method-assign]
+        sandbox.execute("sleep 120")
+
+        assert seen == [sandbox.server_timeout + TRANSPORT_SLACK_SECONDS]
+
+    def test_an_explicit_timeout_still_wins(self, client: TestClient):
+        sandbox = RemoteSandbox(token=SERVICE_TOKEN, session_id="paired", client=client)
+        sandbox.start()
+        seen: list[float | None] = []
+        original = client.post
+
+        def record(url: str, **kwargs: Any):
+            seen.append(kwargs.get("timeout"))
+            return original(url, **kwargs)
+
+        sandbox._http.post = record  # type: ignore[method-assign]
+        sandbox.execute("echo hi", timeout=5)
+
+        assert seen == [5 + TRANSPORT_SLACK_SECONDS]
+
+    def test_a_service_that_will_not_say_falls_back_to_the_local_default(self):
+        """No `/policy`, no pairing — the local timeout is the only answer left."""
+        harness = Harness()
+        with harness.client() as running:
+            sandbox = RemoteSandbox(
+                token=SERVICE_TOKEN, session_id="unpaired", timeout=12.0, client=running
+            )
+            sandbox._http = _NoPolicy(running)
+
+            sandbox.start()
+
+            assert sandbox.server_timeout == 12.0
+
+    def test_a_policy_that_is_not_one_falls_back_too(self):
+        """A proxy in front of the service answers 200 with an HTML page."""
+        harness = Harness()
+        with harness.client() as running:
+            sandbox = RemoteSandbox(
+                token=SERVICE_TOKEN, session_id="proxied", timeout=9.0, client=running
+            )
+            sandbox._http = _NonsensePolicy(running)
+
+            sandbox.start()
+
+            assert sandbox.server_timeout == 9.0
+
+    def test_a_forbidden_policy_falls_back_too(self):
+        """The session token cannot read `/policy`; only the service token can."""
+        harness = Harness()
+        with harness.client() as running:
+            sandbox = RemoteSandbox(
+                token="wrong-token", session_id="denied", timeout=7.0, client=running
+            )
+            sandbox._service_token = SERVICE_TOKEN
+            sandbox._http = _ForbiddenPolicy(running)
+
+            sandbox.start()
+
+            assert sandbox.server_timeout == 7.0
+
+
+class _PolicyProxy:
+    """Passes everything to the real client except `/policy`."""
+
+    def __init__(self, inner: TestClient) -> None:
+        self._inner = inner
+
+    def get(self, url: str, **kwargs: Any):
+        raise NotImplementedError
+
+    def post(self, url: str, **kwargs: Any):
+        return self._inner.post(url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any):
+        return self._inner.delete(url, **kwargs)
+
+    @property
+    def is_closed(self) -> bool:
+        return False
+
+    def close(self) -> None: ...
+
+
+class _NoPolicy(_PolicyProxy):
+    """A client whose `/policy` is unreachable, as one behind a proxy may be."""
+
+    def get(self, url: str, **kwargs: Any):
+        raise RuntimeError("no route to /policy")
+
+
+class _NonsensePolicy(_PolicyProxy):
+    """A 200 carrying something that is not a policy."""
+
+    def get(self, url: str, **kwargs: Any):
+        return self._inner.get("/healthz")
+
+
+class _ForbiddenPolicy(_PolicyProxy):
+    """A 403, which `_parse` is handed as no answer at all."""
+
+    def get(self, url: str, **kwargs: Any):
+        return self._inner.get("/policy", headers={wire.TOKEN_HEADER: "nope"})
+
+
+class TestEventsRaceWithTheReaper:
+    """`describe` re-looks-up and 404s; `events`, its sibling, subscripted."""
+
+    def test_a_session_reaped_mid_request_is_a_404_not_a_500(self, client: TestClient):
+        created = client.post(
+            "/sessions", json={"session_id": "vanishing"}, headers=_service_headers()
+        ).json()
+        service = client.app.state.service
+        service._sessions.pop("vanishing")
+
+        with pytest.raises(HTTPException) as raised:
+            service.events("vanishing", 0)
+
+        assert raised.value.status_code == 404
+        assert created["token"]

--- a/tests/test_root_path_parity.py
+++ b/tests/test_root_path_parity.py
@@ -1,0 +1,115 @@
+"""Every backend has to agree on how the root of its workspace is spelled.
+
+The console toolset's `ls` and `glob` default to `path="."`. `normalize_path`
+prefixed a slash without resolving the segment, so `"."` became `"/."` — a
+directory no file is ever stored under. `StateBackend` and `CompositeBackend`
+therefore answered every default listing, glob and grep with nothing at all, and
+an agent was told its workspace was empty. There was no error anywhere.
+
+Parametrised over the spellings and the backends because the bug was drift
+between them, not a mistake in any one: the root was `"/"` in the protocol,
+`"."` in `LocalBackend.glob_info`, and `("/", "")` in the composite's fan-out.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pydantic_ai_backends import CompositeBackend, LocalBackend, StateBackend
+from pydantic_ai_backends._paths import normalize_path
+
+ROOT_SPELLINGS = ["/", "", ".", "./", "/."]
+
+
+def _state() -> StateBackend:
+    backend = StateBackend()
+    backend.write("/a.py", "x = 1")
+    backend.write("/pkg/b.py", "y = 2")
+    return backend
+
+
+def _composite() -> CompositeBackend:
+    backend = CompositeBackend(default=StateBackend(), routes={"/scratch/": StateBackend()})
+    backend.write("/a.py", "x = 1")
+    backend.write("/scratch/b.py", "y = 2")
+    return backend
+
+
+class TestNormalizePath:
+    @pytest.mark.parametrize("spelling", ROOT_SPELLINGS)
+    def test_every_spelling_of_the_root_normalizes_to_it(self, spelling: str):
+        assert normalize_path(spelling) == "/"
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("./notes.md", "/notes.md"),
+            ("notes.md", "/notes.md"),
+            ("/a/./b", "/a/b"),
+            ("/a//b", "/a/b"),
+            ("/a/b/", "/a/b"),
+        ],
+    )
+    def test_no_op_segments_are_dropped(self, raw: str, expected: str):
+        assert normalize_path(raw) == expected
+
+    def test_dotdot_is_left_alone_for_unsafe_path_reason_to_reject(self):
+        """Resolving it here would turn a path the caller must be told about
+        into a valid one."""
+        assert ".." in normalize_path("/a/../b")
+
+
+class TestStateBackendRootSpellings:
+    @pytest.mark.parametrize("spelling", ROOT_SPELLINGS)
+    def test_ls(self, spelling: str):
+        assert [row["name"] for row in _state().ls_info(spelling)] == ["pkg", "a.py"]
+
+    @pytest.mark.parametrize("spelling", ROOT_SPELLINGS)
+    def test_glob(self, spelling: str):
+        found = _state().glob_info("**/*.py", spelling)
+
+        assert [row["path"] for row in found] == ["/a.py", "/pkg/b.py"]
+
+    @pytest.mark.parametrize("spelling", ROOT_SPELLINGS)
+    def test_grep(self, spelling: str):
+        found = _state().grep_raw("=", spelling)
+
+        assert [match["path"] for match in found] == ["/a.py", "/pkg/b.py"]
+
+
+class TestCompositeBackendRootSpellings:
+    @pytest.mark.parametrize("spelling", ROOT_SPELLINGS)
+    def test_glob_fans_out_to_every_route(self, spelling: str):
+        found = _composite().glob_info("**/*.py", spelling)
+
+        assert [row["path"] for row in found] == ["/a.py", "/scratch/b.py"]
+
+    @pytest.mark.parametrize("spelling", ROOT_SPELLINGS)
+    def test_ls_shows_the_route_mount_points(self, spelling: str):
+        assert [row["name"] for row in _composite().ls_info(spelling)] == ["scratch", "a.py"]
+
+    @pytest.mark.parametrize("spelling", ROOT_SPELLINGS)
+    def test_grep_covers_every_route(self, spelling: str):
+        found = _composite().grep_raw("=", spelling)
+
+        assert [match["path"] for match in found] == ["/a.py", "/scratch/b.py"]
+
+
+class TestLocalBackendRootSpellings:
+    """`LocalBackend` addresses the real filesystem, so `"/"` is the host root
+    rather than the workspace and is correctly refused. The relative spellings
+    have to work, since they are what the toolset sends."""
+
+    @pytest.mark.parametrize("spelling", [".", "./", ""])
+    def test_glob(self, spelling: str, tmp_path):
+        (tmp_path / "a.py").write_text("x = 1")
+        backend = LocalBackend(root_dir=tmp_path)
+
+        assert [row["name"] for row in backend.glob_info("*.py", spelling)] == ["a.py"]
+
+    @pytest.mark.parametrize("spelling", [".", "./", ""])
+    def test_ls(self, spelling: str, tmp_path):
+        (tmp_path / "a.py").write_text("x = 1")
+        backend = LocalBackend(root_dir=tmp_path)
+
+        assert [row["name"] for row in backend.ls_info(spelling)] == ["a.py"]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pydantic_ai_backends import RuntimeConfig, SessionManager
-from pydantic_ai_backends.backends.docker.session import SessionLimitExceeded
+from pydantic_ai_backends.backends.docker.session import SessionLimitExceeded, _SessionLock
 
 
 class MockDockerSandbox:
@@ -612,15 +612,39 @@ class TestSessionLockPruning:
 
         assert set(manager._locks) == {"kept"}
 
-    async def test_a_held_lock_is_never_pruned(self):
-        """A waiter depends on that exact object for mutual exclusion."""
+    async def test_a_lock_in_use_is_never_pruned(self):
+        """Whoever is inside depends on that exact object for mutual exclusion."""
         manager = SessionManager(sandbox_factory=lambda sid: MockCustomSandbox(sid))
-        manager._locks["in-flight"] = asyncio.Lock()
-        await manager._locks["in-flight"].acquire()
+
+        async def hold() -> None:
+            async with manager._session_lock("in-flight"):
+                await asyncio.sleep(0.05)
+
+        holder = asyncio.create_task(hold())
+        await asyncio.sleep(0)
 
         manager._prune_locks()
 
         assert "in-flight" in manager._locks
+        await holder
+
+    async def test_a_queued_waiter_is_never_pruned(self):
+        """`Lock.locked()` reads False between a release and the waiter resuming.
+
+        Pruning on that alone hands the next caller a fresh lock while a task is
+        still queued on the old one — two tasks in the critical section at once,
+        which is precisely what the lock exists to prevent.
+        """
+        manager = SessionManager(sandbox_factory=lambda sid: MockCustomSandbox(sid))
+        entry = manager._locks.setdefault("contended", _SessionLock())
+        # One holder, one waiter — the state where `locked()` is about to lie.
+        entry.users = 2
+        await entry.lock.acquire()
+        entry.lock.release()
+
+        manager._prune_locks()
+
+        assert manager._locks["contended"] is entry
 
 
 class TestSessionIdleLimits:
@@ -1035,3 +1059,100 @@ class TestAliveOf:
                 return "running"
 
         assert await alive_of(Odd()) is True
+
+
+class TestReleaseIsSerializedWithCreation:
+    """`release` used to mutate `_sessions` and `_locks` with no lock at all.
+
+    `get_or_create` documents its lock as the thing stopping two tasks from each
+    creating a sandbox for one id. A concurrent `release` walked straight past
+    it: it deleted the entry the creating task was about to delete — a `KeyError`
+    out of a public coroutine — and deleted the lock that task was holding, after
+    which the next caller interned a fresh one and both ran at once.
+    """
+
+    class SlowProbe:
+        """A sandbox whose `is_alive` genuinely awaits, as a real one's does.
+
+        The await is the whole point: `DockerSandbox.is_alive` is synchronous, so
+        `get_or_create` never suspends inside its critical section for one and
+        the race is invisible. An `AsyncBaseSandbox` subclass — an SSH or HTTP
+        probe, `RemoteSandbox` over a slow link — does suspend there.
+        """
+
+        built = 0
+
+        def __init__(self, session_id: str) -> None:
+            self.session_id = session_id
+            self.stopped = False
+            self.last_activity = 0.0
+            self._alive = False
+            type(self).built += 1
+
+        async def start(self) -> None:
+            self._alive = True
+
+        async def stop(self) -> None:
+            self._alive = False
+            self.stopped = True
+
+        async def is_alive(self) -> bool:
+            await asyncio.sleep(0)
+            return self._alive
+
+    async def test_a_release_mid_creation_does_not_raise(self):
+        """This raised `KeyError('X')` out of `get_or_create` before the fix."""
+        manager = SessionManager(sandbox_factory=self.SlowProbe)
+        first = await manager.get_or_create("X")
+        first._alive = False  # Dead, so the creator takes the replacement path.
+
+        creating = asyncio.create_task(manager.get_or_create("X"))
+        await asyncio.sleep(0)  # Park the creator inside the critical section.
+        released = await manager.release("X")
+
+        sandbox = await creating
+
+        assert released is True
+        assert sandbox is not None
+        # Serialized: the release ran to completion after the creation did, so
+        # the session is gone and nothing was left running behind it.
+        assert "X" not in manager
+        assert sandbox.stopped is True
+
+    async def test_concurrent_creations_still_share_one_sandbox(self):
+        manager = SessionManager(sandbox_factory=self.SlowProbe)
+        self.SlowProbe.built = 0
+
+        created = await asyncio.gather(*(manager.get_or_create("X") for _ in range(5)))
+
+        assert manager.session_count == 1
+        assert self.SlowProbe.built == 1
+        assert {id(sandbox) for sandbox in created} == {id(manager.sessions["X"])}
+
+    async def test_releasing_a_session_that_is_gone_reports_it(self):
+        manager = SessionManager(sandbox_factory=self.SlowProbe)
+
+        assert await manager.release("never-opened") is False
+
+    async def test_on_release_may_reopen_the_same_session(self):
+        """Called outside the lock, or a callback doing this would deadlock."""
+        manager: SessionManager = SessionManager(sandbox_factory=self.SlowProbe)
+        reopened: list[str] = []
+
+        def reopen(session_id: str) -> None:
+            reopened.append(session_id)
+
+        manager._on_release = reopen
+        await manager.get_or_create("X")
+
+        await asyncio.wait_for(manager.release("X"), timeout=1)
+
+        assert reopened == ["X"]
+
+    async def test_a_released_session_leaves_no_lock_behind(self):
+        manager = SessionManager(sandbox_factory=self.SlowProbe)
+        await manager.get_or_create("X")
+
+        await manager.release("X")
+
+        assert manager._locks == {}

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -121,15 +121,36 @@ drwxr-xr-x 2 root root 4096 Jan  1 00:00 src
 
 
 class TestReadBytes:
+    def test_it_reads_base64_not_raw_text(self):
+        """Command output crosses back as text, so raw bytes could not survive."""
+        assert _shell.read_bytes_command("/f") == "base64 /f"
+
     def test_content_is_returned(self):
-        assert _shell.parse_read_bytes(_ok("hello")) == b"hello"
+        assert _shell.parse_read_bytes(_ok("aGVsbG8=")) == b"hello"
+
+    def test_arbitrary_bytes_survive(self):
+        """A PNG through `cat` came back as U+FFFD for every non-UTF-8 byte."""
+        raw = bytes(range(256))
+
+        assert _shell.parse_read_bytes(_ok(base64.b64encode(raw).decode())) == raw
+
+    def test_the_wrapping_newlines_base64_adds_are_ignored(self):
+        payload = base64.encodebytes(b"x" * 200).decode()
+
+        assert _shell.parse_read_bytes(_ok(payload)) == b"x" * 200
 
     def test_failure_is_empty_never_a_message(self):
         """A caller cannot tell an error string from real file content."""
         assert _shell.parse_read_bytes(_failed("No such file")) == b""
 
-    def test_undecodable_bytes_are_replaced_not_raised(self):
-        assert _shell.parse_read_bytes(_ok("caf\udce9")) == b"caf?"
+    def test_a_truncated_payload_is_empty_not_wrong_bytes(self):
+        """Base64 cut short decodes to bytes that are not the file's."""
+        payload = base64.b64encode(b"x" * 300).decode()[:100]
+
+        assert _shell.parse_read_bytes(_ok(payload, truncated=True)) == b""
+
+    def test_output_that_is_not_base64_is_empty(self):
+        assert _shell.parse_read_bytes(_ok("not base64 at all !!!")) == b""
 
 
 class TestRead:

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -7,6 +7,10 @@ Kubernetes, and any third-party one — contributed nothing to the coverage gate
 
 from __future__ import annotations
 
+import base64
+import re
+import shlex
+
 import pytest
 
 from pydantic_ai_backends.backends import _shell
@@ -147,19 +151,34 @@ class TestRead:
 
 
 class TestWrite:
-    def test_the_delimiter_is_quoted_so_the_shell_expands_nothing(self):
+    @staticmethod
+    def _payload(command: str) -> bytes:
+        """What the command actually writes, decoded back out of it."""
+        encoded = command.split("printf %s ", 1)[1].split(" ", 1)[0]
+        return base64.b64decode(encoded)
+
+    def test_the_content_is_carried_encoded_so_the_shell_expands_nothing(self):
         command = _shell.write_command("/f.sh", "echo $HOME `id` \\n")
 
-        assert "<< 'EOF_" in command
-        # The body is verbatim: pre-escaping it here would corrupt it.
-        assert "echo $HOME `id` \\n" in command
+        assert "echo $HOME" not in command
+        assert self._payload(command) == b"echo $HOME `id` \\n"
 
-    def test_the_delimiter_is_random_per_call(self):
-        """A fixed delimiter could collide with a line of the content."""
-        first = _shell.write_command("/f", "x")
-        second = _shell.write_command("/f", "x")
+    def test_bytes_are_written_as_bytes(self):
+        """`b'\\x89PNG'` used to be interpolated as its Python repr."""
+        command = _shell.write_command("/img.png", b"\x89PNG\r\n\x1a\n")
 
-        assert first != second
+        assert self._payload(command) == b"\x89PNG\r\n\x1a\n"
+
+    def test_content_is_written_with_no_newline_added(self):
+        """A heredoc's terminator starts a line, so it appended one."""
+        assert self._payload(_shell.write_command("/f", "x")) == b"x"
+        assert self._payload(_shell.write_command("/f", "x\n")) == b"x\n"
+
+    def test_the_payload_needs_no_quoting(self):
+        """base64 is [A-Za-z0-9+/=], so nothing in it can reach the shell."""
+        command = _shell.write_command("/f", "'; id; echo '")
+
+        assert re.fullmatch(r"[A-Za-z0-9+/=]*", command.split("printf %s ", 1)[1].split(" ")[0])
 
     def test_the_parent_directory_is_created(self):
         assert "mkdir -p $(dirname" in _shell.write_command("/deep/f", "x")
@@ -232,3 +251,38 @@ class TestGrep:
         found = _shell.parse_grep(_ok("no colons here\na.py:notanumber:x\nb.py:2:kept"))
 
         assert found == [{"path": "b.py", "line_number": 2, "line": "kept"}]
+
+
+class TestGrepQuoting:
+    """The pattern and glob were wrapped in literal quotes, not `shlex.quote`d.
+
+    One of their own then closed the quoting: a search for `don't` produced an
+    unterminated command, and a crafted pattern ran whatever followed it.
+    """
+
+    def test_a_pattern_containing_a_quote_stays_one_argument(self):
+        command = _shell.grep_command("don't", "/w")
+
+        assert shlex.split(command)[-2:] == ["don't", "/w"]
+
+    def test_a_pattern_cannot_break_out_into_another_command(self):
+        command = _shell.grep_command("x'; id; echo '", "/w")
+
+        assert ";" not in shlex.split(command)
+        assert "id" not in shlex.split(command)
+        assert shlex.split(command)[-2] == "x'; id; echo '"
+
+    def test_a_glob_containing_a_quote_stays_one_argument(self):
+        command = _shell.grep_command("x", "/w", glob="a'b*.py")
+
+        assert "--include=a'b*.py" in shlex.split(command)
+
+    def test_a_pattern_starting_with_a_dash_is_a_pattern_not_an_option(self):
+        command = _shell.grep_command("-v", "/w")
+
+        assert shlex.split(command)[-3:] == ["-e", "-v", "/w"]
+
+    def test_the_hidden_excludes_stay_quoted(self):
+        """Unquoted, the shell expands `.*` against the working directory."""
+        assert "--exclude=.*" in shlex.split(_shell.grep_command("x", "/w"))
+        assert "'.*'" in _shell.grep_command("x", "/w")


### PR DESCRIPTION
A full audit of the library. Lint, pyright, mypy and 1381 tests at 100% branch coverage were all green before this, so none of the ten came from a tool — most live in the disagreement between two files that each read fine alone. Every fix ships with the regression test that fails without it (55 new assertions fail against `main`).

Version bumped to 0.2.21; the changelog carries the long form.

## The security one

`create_console_toolset(permissions=...)` promises that an operation defaulting to `"deny"` drops its tools entirely. `_denied_tools` listed only `execute`, so `run_in_background` — which runs an arbitrary command — stayed registered. With the shipped `READONLY_RULESET`, whose docstring reads *"Reads, listings and searches only — nothing may change or run"*, the model still had a working shell:

```python
sorted(create_console_toolset(permissions=READONLY_RULESET).tools)
# ['glob', 'grep', 'kill_shell', 'list_shells', 'ls', 'read_file',
#  'read_output', 'run_in_background']      <- execute gone, the shell is not
```

`ConsoleCapability` was worse. The background tools had no `TOOL_OPERATIONS` entry, and an unmapped name is both kept by `prepare_tools` *and* waved through `before_tool_execute` — so no permission check ran on them at all, reachable through the example in the capability's own module docstring.

All five shell tools now live and die with the `execute` operation, the capability forwards its ruleset to the toolset as well as filtering per request, and a test asserts the tool/operation map covers every registered tool so the next tool added cannot repeat this.

`grep_raw` was the other one: the pattern and glob went into the shell command in literal single quotes instead of `shlex.quote`, so one of their own closed the quoting. `grep_command("x'; id; echo '", "/w")` ran `id`. Reachable but not an escalation on its own — the caller already holds `/exec` — though the correctness half hits everyone, since an agent searching for `don't` got garbage back.

## The silent-wrong-answer ones

- **`path="."` returned nothing on the virtual-path backends.** `normalize_path` prefixed a slash without resolving the segment, so `"."` — the console toolset's default for `ls` and `glob` — became `"/."`. `StateBackend` and `CompositeBackend` answered every default listing, glob and grep with nothing, and the agent was told its workspace was empty. No error anywhere. `"/"`, `""`, `"."` and `"./"` all mean the root now; there is a new parametrised cross-backend test, since the bug was drift between three spellings rather than a mistake in any one.
- **`SessionManager.release` held no lock.** A release landing inside a concurrent `get_or_create` deleted the entry that call was about to delete — `KeyError` out of a public coroutine — and deleted the lock it was holding, after which the next caller interned a fresh one and two tasks built a sandbox for one session. Locks are reference-counted while in use now rather than pruned on `Lock.locked()`, which reads `False` between a holder releasing and the woken waiter resuming.
- **`execute_timeout` was applied to `/exec` alone**, despite being documented as "a hard ceiling applied to every command, so one client cannot occupy a worker indefinitely". `BaseSandbox` passed a timeout for `exists` and nothing else, so one slow grep pinned a worker thread nothing could reclaim and `max_workers` of them wedged the service. Derived operations now carry `FILE_OP_TIMEOUT` (30s) or `SEARCH_TIMEOUT` (120s), and every sandboxd route is bounded by the ceiling.
- **`RemoteSandbox` gave up before the service did** — 60s against a 300s ceiling, so a command taking anything in between was reported to the agent as `sandbox service unavailable` while it was still running, and typically retried. The ceiling is read from `GET /policy` on open now, exposed as `RemoteSandbox.server_timeout`.
- **`BaseSandbox.write` narrowed `str | bytes` to `str`** and the heredoc interpolated bytes as their repr, writing the 17 characters `b'\x89PNG\r\n'` into the file with no error.
- **`LocalBackend.edit` raised `UnicodeDecodeError`** on a non-UTF-8 file, from a backend `protocol.py` promises never raises.
- **`edit_file` had no edit lock** where `hashline_edit` does, so two concurrent edits to one path lost one of them.
- Six smaller ones, batched — see the changelog.

## Behaviour changes to know about

1. **Shell-derived `write` carries content base64-encoded**, so the sandbox image needs `base64` (GNU coreutils and BusyBox both provide it). This is what makes `bytes` work at all, and it also fixes the trailing newline a heredoc could not avoid adding: `write(p, "x\n")` used to produce `"x\n\n"`. `DockerSandbox`, `DaytonaSandbox` and `RemoteSandbox` override `write` and are unaffected; `KubernetesPodSandbox(mode="api")` and third-party `BaseSandbox` subclasses are the ones that change.
2. **`StateBackend` round-trips bytes exactly** via `surrogateescape` instead of substituting U+FFFD. Its reported `size` also grew by one byte per line, having been short by the separators.
3. **`normalize_path` now collapses `.` and duplicate slashes.** `StateBackend` and both composites use it; `LocalBackend` does not.

## Verification

- 1492 tests pass, 100.00% branch coverage (`fail_under = 100`)
- ruff, pyright and mypy strict all clean; still zero type suppressions in `src/`
- 55 of the new assertions fail against `main` — checked by reverting `src/` and re-running

## Not covered

The Docker and Kubernetes integration tests are deselected by `addopts` and never run in CI, so the base64 write and the new operation timeouts are verified against fakes rather than a real daemon. Worth one manual run against Docker before the release goes out.
