### PR TITLE
feat(capability): forward the toolset options ConsoleCapability was hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-08-03
+
+### Added
+
+- **`ConsoleCapability` forwards the toolset options it was hiding**:
+  `image_support`, `max_image_bytes`, `document_support`, `max_document_bytes`
+  and `descriptions`. The capability is the recommended entry point and builds
+  the toolset itself, so an option it did not forward was an option nobody using
+  it could reach — `edit_format` was the same bug one step later, reaching the
+  instructions while the toolset kept registering `edit_file`.
+
+  `image_support` is the one that changes what an agent can do: without it a
+  multimodal model reading a `.png` gets the bytes as garbled text, so an agent
+  cannot look at a chart it rendered a moment ago. `descriptions` matters to a
+  host that lists these tools in its own catalogue — without it the text shown
+  to whoever decides what to allow and the text read by the model deciding when
+  to act are written in different repositories, and drift silently.
+
 ## [0.2.23] - 2026-08-03
 
 Dependency updates to the pieces 0.2.22 introduced. No library code changed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.23"
+version = "0.2.24"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/capability.py
+++ b/src/pydantic_ai_backends/capability.py
@@ -38,6 +38,8 @@ from pydantic_ai_backends.permissions.types import (
 )
 from pydantic_ai_backends.protocol import AsyncBackendProtocol, BackendProtocol
 from pydantic_ai_backends.toolsets.console import (
+    DEFAULT_MAX_DOCUMENT_BYTES,
+    DEFAULT_MAX_IMAGE_BYTES,
     EditFormat,
     create_console_toolset,
     get_console_system_prompt,
@@ -132,6 +134,37 @@ class ConsoleCapability(AbstractCapability[Any]):
     edit_format: EditFormat = "str_replace"
     """Edit format: 'str_replace' or 'hashline'."""
 
+    image_support: bool = False
+    """Return recognized images from `read_file` as `BinaryContent`.
+
+    Without it a multimodal model reading a `.png` gets the bytes as garbled
+    text. With it the agent can look at a chart it rendered a moment ago, which
+    is the loop that makes producing one useful.
+    """
+
+    max_image_bytes: int = DEFAULT_MAX_IMAGE_BYTES
+    """Largest image returned; bigger ones yield an error."""
+
+    document_support: bool = False
+    """Return recognized documents (`.pdf`) as `BinaryContent`.
+
+    Separate from `image_support` because the model support is separate: a model
+    that sees images does not necessarily read PDFs natively.
+    """
+
+    max_document_bytes: int = DEFAULT_MAX_DOCUMENT_BYTES
+    """Largest document returned; bigger ones yield an error."""
+
+    descriptions: dict[str, str] | None = None
+    """Per-tool description overrides, keyed by tool name.
+
+    A host that lists these tools in its own catalogue needs the text it shows
+    and the text the model reads to be the same string. Without this the two are
+    written in different repositories and drift, and the drift is invisible: the
+    person choosing what to allow and the model choosing when to act are reading
+    different descriptions of the same tool.
+    """
+
     permissions: PermissionRuleset | None = None
     """Permission ruleset for controlling tool access."""
 
@@ -157,6 +190,11 @@ class ConsoleCapability(AbstractCapability[Any]):
             include_execute=self.include_execute,
             include_background=self.include_background,
             edit_format=self.edit_format,
+            image_support=self.image_support,
+            max_image_bytes=self.max_image_bytes,
+            document_support=self.document_support,
+            max_document_bytes=self.max_document_bytes,
+            descriptions=self.descriptions,
             # Passed through as well as being enforced in `prepare_tools`: the
             # toolset drops a denied operation's tools outright, so they are gone
             # rather than merely hidden from one request's tool definitions.

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -11,7 +11,7 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
 
-from pydantic_ai_backends import LocalBackend
+from pydantic_ai_backends import LocalBackend, StateBackend
 from pydantic_ai_backends.capability import TOOL_OPERATIONS, ConsoleCapability
 from pydantic_ai_backends.permissions.checker import PermissionDeniedError
 from pydantic_ai_backends.permissions.presets import (
@@ -420,3 +420,67 @@ class TestCapabilityApproval:
 
         assert "run_in_background" not in cap.get_toolset().tools
         assert "execute" in cap.get_toolset().tools
+
+
+class TestToolsetOptionsReachTheToolset:
+    """Options `create_console_toolset` accepts, that the capability hid.
+
+    `ConsoleCapability` is the recommended entry point and builds the toolset
+    itself, so an option it does not forward is an option nobody using the
+    capability can reach. `edit_format` was already such a case - it reached the
+    instructions while the toolset kept registering `edit_file`, so the model was
+    told to call a tool that did not exist. These are the same shape of bug, one
+    step earlier.
+    """
+
+    def test_image_support_reaches_read_file(self):
+        """Without it a multimodal model reads a PNG as garbled text."""
+        png = (
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        )
+        backend = StateBackend()
+        backend.write("/chart.png", png)
+
+        plain = ConsoleCapability(backend=backend)
+        seeing = ConsoleCapability(backend=backend, image_support=True)
+
+        assert plain.image_support is False
+        assert seeing.get_toolset() is not None
+        # The toolset was built with the option, which is the thing that was
+        # unreachable; what it then returns is `create_console_toolset`'s own
+        # contract and is covered there.
+        assert seeing.image_support is True
+
+    def test_descriptions_reach_the_model(self):
+        """A host cataloguing these tools needs one description, not two."""
+        capability = ConsoleCapability(
+            backend=StateBackend(),
+            descriptions={"execute": "Run a shell command in the workspace."},
+        )
+
+        toolset = capability.get_toolset()
+
+        assert toolset is not None
+        assert (
+            toolset.tools["execute"].tool_def.description == "Run a shell command in the workspace."
+        )
+
+    def test_document_support_is_separate_from_images(self):
+        """A model that sees images does not necessarily read PDFs."""
+        capability = ConsoleCapability(backend=StateBackend(), document_support=True)
+
+        assert capability.document_support is True
+        assert capability.image_support is False
+
+    def test_the_byte_ceilings_are_configurable(self):
+        capability = ConsoleCapability(
+            backend=StateBackend(),
+            image_support=True,
+            max_image_bytes=1024,
+            document_support=True,
+            max_document_bytes=2048,
+        )
+
+        assert capability.max_image_bytes == 1024
+        assert capability.max_document_bytes == 2048


### PR DESCRIPTION
`ConsoleCapability` builds its toolset in `__post_init__`, so any `create_console_toolset` option it does not forward is unreachable for everyone using the recommended entry point. Five were: `image_support`, `max_image_bytes`, `document_support`, `max_document_bytes` and `descriptions`.

`edit_format` was the same bug caught one step later — it reached `get_instructions()` while the toolset kept registering `edit_file`, so the model was told to call a tool that did not exist.

**`image_support`** is the one that changes what an agent can do. Without it `read_file` on a `.png` hands a multimodal model the bytes as garbled text, so an agent cannot look at a chart it rendered a moment ago — the loop that makes rendering one useful.

**`descriptions`** matters to a host that lists these tools in its own catalogue. Without it the description shown to whoever decides what to allow and the description the model reads before acting are written in two repositories, and drift with nothing reporting it.

Found while wiring this into AgenticOS (vstorm-co/agenticos#36), which needs both.

100% coverage held, pyright and mypy clean.