### PR TITLE
fix: enforce a ruleset's paths, unify stop, serve workspace bytes, and let an operator change the ceilings

### DIFF
--- a/docs/concepts/remote.md
+++ b/docs/concepts/remote.md
@@ -708,6 +708,7 @@ all needs to know why.
 | `GET /` | none | What the service is, and its mounted endpoints |
 | `GET /healthz` | none | Liveness, session count, capacity |
 | `GET /policy` | service token | The ceilings and image allowlist actually in force |
+| `PUT /policy` | service token | Change the ceilings and lifetimes, without a restart |
 | `GET /sessions` | service token | Every open session; `?usage=true` also samples memory and CPU |
 | `GET /sessions/{id}` | session or service token | One session, without reviving a dead sandbox |
 | `GET /sessions/{id}/events?after=<seq>` | session or service token | The session's operation log, for incremental polling |
@@ -716,6 +717,76 @@ The activity log records what each operation addressed, whether it succeeded and
 how long it took — never file contents or command output, which would turn an
 audit trail into a data leak that also grows without bound. It is a bounded ring
 buffer per session.
+
+### Changing the ceilings without a restart
+
+`PUT /policy` writes the ceilings and lifetimes onto the running service, and
+answers with the whole policy so a caller sees what is now in force — including
+the fields it did not touch. Before it, every one of the thirty-odd knobs was
+reachable only through the environment, and a restart drops every resident
+sandbox: raising one memory ceiling ended every conversation on the host.
+
+```bash
+curl -X PUT http://sandboxd:8080/policy \
+  -H "X-Sandbox-Token: $SANDBOXD_TOKEN" \
+  -d '{"mem_limit": "2g", "workspace_ttl": 86400,
+       "runtimes": {"coding": {"cpus": 4.0}}}'
+```
+
+**Ceilings and lifetimes only, and the omissions are the point.** A client cannot
+name an image, a mount or a device when it creates a session, because a process
+holding the Docker socket can start a privileged container that mounts the host.
+That reasoning does not stop applying because the caller holds the service token:
+in a multi-tenant deployment the token is held by an application, per tenant, and
+an organization's administrator is not the person who runs the host.
+
+So what may change is how much a sandbox may consume and how long it may live:
+
+`max_sessions`, `max_open_sessions`, `max_sessions_per_tenant`,
+`evict_idle_after`, `idle_timeout`, `execute_timeout`, `max_read_bytes`,
+`workspace_ttl`, `container_ttl`, `mem_limit`, `memswap_limit`, `cpus`,
+`cpu_shares`, `pids_limit`, `tmpfs_size`, `default_runtime`, and the same
+ceilings per already-allowed runtime under `runtimes`.
+
+What may **not**, and stays in the environment where changing it is a deployment
+action:
+
+| Refused | Because |
+|---|---|
+| `runtimes` membership | Adding an alias means naming an image |
+| `network_mode` | `host` is not a ceiling, it is an escape |
+| `oci_runtime` | The same, one level lower |
+| `sandbox_uid` | 0 is root |
+| `work_dir` | It is where the workspace volume mounts and the archive reads |
+| `persist_containers`, `prewarm` | Startup shape, not ceilings |
+
+Sending one of those is a `422` naming the field, not a key quietly dropped — an
+operator who tries to widen the network is told no rather than left believing they
+have. An unknown runtime, in `default_runtime` or under `runtimes`, is a `400`:
+refused rather than created.
+
+A change applies to the **next** sandbox. Docker sets a ceiling on the container,
+so one already running keeps what it was created with — lowering a memory limit
+does not reach into the sandbox currently using too much.
+
+### The overrides file
+
+`SANDBOXD_POLICY_OVERRIDES=/etc/sandboxd/policy.json` is the same thing without a
+write endpoint, for a deployment that would rather not have one. The file holds
+exactly what `PUT /policy` accepts, it is read once before anything is served, and
+re-read whenever its modification time moves — the service already sweeps on a
+timer, so this rides along with that and adds nothing to shut down.
+
+Both go through one function, so neither can put the service in a state the other
+cannot describe: the same writable set, the same validation, the same refusal for
+an alias that does not exist.
+
+A malformed file is logged and ignored, and the previous values stand. That is
+deliberate: an operator who mistypes a ceiling should get a log line, not a daemon
+that will not boot and takes every resident sandbox with it. A file *deleted*
+after being read is left alone rather than reverted — reverting would mean keeping
+a second copy of the environment's values to put back, and the honest reading of a
+deleted overrides file is "stop overriding from here", which is a restart.
 
 ### Dashboard
 

--- a/src/pydantic_ai_backends/backends/_guard.py
+++ b/src/pydantic_ai_backends/backends/_guard.py
@@ -14,10 +14,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pydantic_ai_backends.permissions.checker import PermissionAskError, PermissionChecker
+from pydantic_ai_backends.types import EditResult, WriteResult
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from pydantic_ai_backends.permissions.checker import AskCallback, AskFallback
     from pydantic_ai_backends.permissions.types import PermissionOperation, PermissionRuleset
+    from pydantic_ai_backends.protocol import AsyncBackendProtocol, BackendProtocol
+    from pydantic_ai_backends.types import FileInfo, GrepMatch
 
 GUARDED_COMMAND_OPERATIONS: tuple[PermissionOperation, ...] = ("read", "write")
 """Operations whose deny rules also block a command that names such a path."""
@@ -139,6 +144,228 @@ class PermissionGuard:
                 continue
             expanded = os.path.expanduser(candidate)
             path = Path(expanded)
-            resolved = path.resolve() if path.is_absolute() else (self._root / expanded).resolve()
-            targets.add(str(resolved))
+            absolute = path if path.is_absolute() else self._root / expanded
+            # Both forms, because a rule is written against the path a person
+            # types and `resolve()` answers with the path the filesystem means.
+            # On macOS `/etc` is a symlink to `/private/etc`, so a rule reading
+            # `/etc/**` matched nothing once resolved - and any symlinked
+            # directory does the same on any platform. Matching both can only
+            # deny more, never less, which is the right direction for a check
+            # that is defence in depth.
+            targets.add(str(absolute))
+            targets.add(str(absolute.resolve()))
         return targets
+
+
+class GuardedBackend:
+    """Any backend, with a ruleset's per-path rules actually applied.
+
+    `PermissionGuard` has existed since `LocalBackend` needed it, and only
+    `LocalBackend` ever used it — so a ruleset handed to `ConsoleCapability`
+    reached `requires_approval` (the approval flags) and `_denied_tools` (drop a
+    tool whose *operation* defaults to deny) and nothing else. Per-path `rules`
+    were never read. With every operation left at `default="allow"` and the
+    patterns in `rules`, a caller who had written out `**/.env`, `**/*.pem` and
+    `/etc/**` got no enforcement at all, and the result looked like a working
+    boundary — which is worse than rejecting the ruleset outright.
+
+    Wrapping the backend rather than checking inside each tool is what makes it
+    total: every console tool reaches the filesystem through this protocol, so a
+    tool added in a later release is covered on the day it arrives rather than the
+    day somebody remembers to list it.
+
+    **Content and mutation are refused; listings are filtered by their own rules.**
+    `read`, `read_bytes` and `grep_raw` are the three ways bytes leave a file, and
+    `write` and `edit` the two that change one. `grep_raw` is filtered rather than
+    refused because it takes a tree and not a path — a pattern over `/`
+    legitimately spans the workspace, and `GrepMatch` carries the matching *line*,
+    so an unfiltered grep would hand over the contents of exactly the files the
+    rules protect. It therefore drops a match on anything denied for `grep` *or*
+    `read`, which is what `PermissionGuard.hides_from_grep` is for.
+
+    `ls_info` and `glob_info` drop entries denied for `ls` and `glob`
+    respectively, matching `LocalBackend` — and deliberately **not** consulting
+    the `read` rules. So a ruleset that denies reading `**/.env` still lists it by
+    name, and one that wants the name hidden has to say so on `ls` and `glob`.
+    Worth knowing rather than guessing at: a name is a weaker claim than the
+    contents, `ls` returning nothing for a file an agent can see with `exists`
+    would send it rewriting one it cannot read, and a ruleset defaulting to
+    `"ask"` would otherwise blank out every listing.
+
+    `execute` goes through `execute_denial_reason`, so the obvious bypass
+    (`cat restricted/secret.txt`) is caught. That is defence in depth and not a
+    boundary: a shell reaches files in ways string inspection cannot see, and real
+    isolation is a sandboxed backend's job.
+
+    Async throughout, and `ensure_async` is applied to what it wraps. A sync guard
+    over an async backend would return un-awaited coroutines, and the alternative —
+    two parallel implementations — is two things to keep in agreement. The console
+    toolset calls `ensure_async` on every tool call anyway, so this costs nothing
+    that was not already paid.
+
+    Args:
+        backend: What to wrap. Sync or async; both come out async.
+        ruleset: Rules to apply.
+        root: Directory commands run in, for resolving their path arguments.
+        ask_callback: Async approval callback, passed to the checker.
+        ask_fallback: What an unanswerable "ask" does.
+    """
+
+    def __init__(
+        self,
+        backend: BackendProtocol | AsyncBackendProtocol,
+        ruleset: PermissionRuleset,
+        *,
+        root: Path | None = None,
+        ask_callback: AskCallback | None = None,
+        ask_fallback: AskFallback = "error",
+    ) -> None:
+        from pydantic_ai_backends.adapter import ensure_async
+
+        self._backend = ensure_async(backend)
+        # Kept as well: the async adapter proxies the protocol and `execute`, but
+        # not `stop`, `id` or a backend's own extras, and `__getattr__` below has
+        # to be able to reach them.
+        self._raw = backend
+        self._guard = PermissionGuard(
+            ruleset,
+            root if root is not None else Path("/"),
+            ask_callback=ask_callback,
+            ask_fallback=ask_fallback,
+        )
+
+    @property
+    def permissions(self) -> PermissionRuleset:
+        """The ruleset in force.
+
+        Present so a caller — and `create_console_toolset` — can tell a backend
+        that already enforces its own rules from one that does not, and avoid
+        wrapping twice.
+        """
+        return self._guard.checker.ruleset
+
+    async def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+        reason = self._guard.denial_reason("read", path)
+        if reason is not None:
+            raise PermissionError(reason)
+        return await self._backend.read(path, offset, limit)
+
+    async def read_bytes(self, path: str) -> bytes:
+        reason = self._guard.denial_reason("read", path)
+        if reason is not None:
+            raise PermissionError(reason)
+        return await self._backend.read_bytes(path)
+
+    async def write(self, path: str, content: str | bytes) -> WriteResult:
+        reason = self._guard.denial_reason("write", path)
+        if reason is not None:
+            return WriteResult(error=reason)
+        return await self._backend.write(path, content)
+
+    async def edit(
+        self, path: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> EditResult:
+        reason = self._guard.denial_reason("edit", path)
+        if reason is not None:
+            return EditResult(error=reason)
+        return await self._backend.edit(path, old_string, new_string, replace_all)
+
+    async def exists(self, path: str) -> bool:
+        return await self._backend.exists(path)
+
+    async def ls_info(self, path: str) -> list[FileInfo]:
+        entries = await self._backend.ls_info(path)
+        return [entry for entry in entries if not self._guard.is_denied("ls", entry["path"])]
+
+    async def glob_info(self, pattern: str, path: str = "/") -> list[FileInfo]:
+        entries = await self._backend.glob_info(pattern, path)
+        return [entry for entry in entries if not self._guard.is_denied("glob", entry["path"])]
+
+    async def grep_raw(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        ignore_hidden: bool = True,
+    ) -> list[GrepMatch] | str:
+        found = await self._backend.grep_raw(pattern, path, glob, ignore_hidden)
+        # A string is the backend's own error or "no matches", not a result set.
+        if isinstance(found, str):
+            return found
+        return [match for match in found if not self._guard.hides_from_grep(match["path"])]
+
+    def _guarded_execute(self) -> Any:
+        """`execute`, refusing a command that names a path the rules deny.
+
+        Deliberately **not** a method on the class, and that is not a style
+        choice. The console toolset asks `hasattr(backend, "execute")` to decide
+        whether a backend can run commands at all, and answers
+        "Backend does not support command execution" when it cannot. A declared
+        method would make that true for every backend - so a `StateBackend`, which
+        has no shell, would stop giving that answer and start raising instead.
+
+        Reached through `__getattr__`, the `getattr` below raises `AttributeError`
+        for a backend with no `execute`, which is exactly what `hasattr` needs to
+        see.
+
+        Raises:
+            AttributeError: If the wrapped backend cannot execute anything.
+        """
+        inner = getattr(self._backend, "execute")  # noqa: B009 - AttributeError is the point
+
+        async def execute(command: str, timeout: int | None = None) -> Any:
+            reason = self._guard.execute_denial_reason(command)
+            if reason is not None:
+                raise PermissionError(reason)
+            return await inner(command, timeout)
+
+        return execute
+
+    def __getattr__(self, name: str) -> Any:
+        """Everything the protocol does not name, straight through to the backend.
+
+        A sandbox is more than the protocol: `stop`, `start`, `id`, `files` on a
+        `StateBackend`. Delegating by name keeps this wrapper from quietly removing
+        a capability the way an explicit list would.
+
+        `execute` is the exception, because it is the one non-protocol operation
+        the rules have something to say about - see `_guarded_execute`.
+
+        Everything else comes back with the shape the *unwrapped* backend has, so
+        `stop` stays synchronous. That is the right contract for a transparent
+        wrapper: code that worked on the backend works on this.
+        """
+        if name == "execute":
+            return self._guarded_execute()
+        return getattr(self._raw, name)
+
+    def __repr__(self) -> str:
+        return f"<GuardedBackend({self._raw!r})>"
+
+
+def guarding(
+    backend: BackendProtocol | AsyncBackendProtocol,
+    ruleset: PermissionRuleset | None,
+    *,
+    root: Path | None = None,
+    ask_callback: AskCallback | None = None,
+    ask_fallback: AskFallback = "error",
+) -> BackendProtocol | AsyncBackendProtocol:
+    """`backend` with `ruleset` enforced, or `backend` unchanged.
+
+    Unchanged in the two cases where wrapping would be wrong rather than merely
+    unnecessary: there is no ruleset to apply, or the backend already applies one
+    of its own — `LocalBackend` does, and wrapping it would check every path twice
+    and report the second refusal.
+    """
+    if ruleset is None:
+        return backend
+    if getattr(backend, "permissions", None) is not None:
+        return backend
+    return GuardedBackend(
+        backend,
+        ruleset,
+        root=root,
+        ask_callback=ask_callback,
+        ask_fallback=ask_fallback,
+    )

--- a/src/pydantic_ai_backends/backends/base.py
+++ b/src/pydantic_ai_backends/backends/base.py
@@ -102,8 +102,20 @@ class BaseSandbox(_SandboxIdentity, ABC):
         """
         return False
 
-    def stop(self) -> None:
-        """Stop and clean up the sandbox."""
+    def stop(self, purge: bool = False) -> None:
+        """Stop and clean up the sandbox.
+
+        Args:
+            purge: Also discard what the sandbox accumulated — its filesystem,
+                and any workspace kept for it outside the container. Left off,
+                the sandbox ends while its files survive for the next attach;
+                turned on, the thing the sandbox belonged to is gone for good.
+
+                Accepted by every sandbox so one call site can end any of them,
+                and the subclasses that cannot tell the two apart say so: a
+                Daytona sandbox and a Kubernetes pod are deleted either way,
+                because neither keeps a filesystem this library can reattach to.
+        """
 
     @abstractmethod
     def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
@@ -230,8 +242,13 @@ class AsyncBaseSandbox(_SandboxIdentity, ABC):
         """
         return False
 
-    async def stop(self) -> None:
-        """Stop and clean up the sandbox."""
+    async def stop(self, purge: bool = False) -> None:
+        """Stop and clean up the sandbox.
+
+        Args:
+            purge: Also discard what the sandbox accumulated. See
+                :meth:`BaseSandbox.stop`.
+        """
 
     @abstractmethod
     async def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:

--- a/src/pydantic_ai_backends/backends/daytona.py
+++ b/src/pydantic_ai_backends/backends/daytona.py
@@ -203,8 +203,16 @@ class DaytonaSandbox(BaseSandbox):
         except Exception:
             return False
 
-    def stop(self) -> None:
-        """Delete the Daytona sandbox."""
+    def stop(self, purge: bool = False) -> None:
+        """Delete the Daytona sandbox.
+
+        Args:
+            purge: Accepted for one signature across every sandbox, and it makes
+                no difference here. Daytona has no "end it but keep the files"
+                state this library can reattach to, so stopping *is* deleting -
+                which is why the parameter is documented rather than quietly
+                ignored.
+        """
         client = getattr(self, "_client", None)
         sandbox = getattr(self, "_sandbox", None)
         if client is not None and sandbox is not None:

--- a/src/pydantic_ai_backends/backends/docker/sandbox.py
+++ b/src/pydantic_ai_backends/backends/docker/sandbox.py
@@ -7,6 +7,7 @@ import io
 import shlex
 import tarfile
 import time
+import warnings
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, cast
 
@@ -442,7 +443,7 @@ class DockerSandbox(BaseSandbox):
         except Exception:
             return None
 
-    def stop(self, remove: bool = False) -> None:
+    def stop(self, purge: bool = False, *, remove: bool | None = None) -> None:
         """Stop the container.
 
         A container created without `container_name` runs with
@@ -451,15 +452,31 @@ class DockerSandbox(BaseSandbox):
         whole point of naming it.
 
         Args:
-            remove: Also remove the container, discarding its filesystem state.
+            purge: Also remove the container, discarding its filesystem state.
+                Named `purge` so that one call site can end any sandbox this
+                library offers - `RemoteSandbox`, `DaytonaSandbox` and the
+                Kubernetes pod all spell the same idea this way, and this one
+                used to spell it `remove`. A caller holding "a sandbox" could
+                not call `stop` without knowing which it had.
+            remove: The old name for `purge`, still honoured so nothing that
+                passes it breaks. Deprecated; pass `purge` instead.
         """
+        if remove is not None:
+            warnings.warn(
+                "DockerSandbox.stop(remove=...) is deprecated; pass purge=... instead, "
+                "which is what every other sandbox calls the same argument.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            purge = remove
+
         container = getattr(self, "_container", None)
         if container is None:
             return
 
         with contextlib.suppress(Exception):
             container.stop()
-        if remove:
+        if purge:
             with contextlib.suppress(Exception):
                 container.remove(force=True)
         self._container = None

--- a/src/pydantic_ai_backends/backends/kubernetes.py
+++ b/src/pydantic_ai_backends/backends/kubernetes.py
@@ -236,7 +236,15 @@ class KubernetesPodSandbox(BaseSandbox):
             return False
         return bool(pod.status.phase == "Running")
 
-    def stop(self) -> None:
+    def stop(self, purge: bool = False) -> None:
+        """Close the connection and delete the pod when this sandbox owns it.
+
+        Args:
+            purge: Accepted for one signature across every sandbox, and it makes
+                no difference here. A pod is deleted or it is not, and that is
+                `delete_on_stop`'s decision rather than the caller's - there is
+                no state kept for a later attach to preserve.
+        """
         if self._stopped:
             return
         self._stopped = True

--- a/src/pydantic_ai_backends/capability.py
+++ b/src/pydantic_ai_backends/capability.py
@@ -197,8 +197,14 @@ class ConsoleCapability(AbstractCapability[Any]):
             descriptions=self.descriptions,
             # Passed through as well as being enforced in `prepare_tools`: the
             # toolset drops a denied operation's tools outright, so they are gone
-            # rather than merely hidden from one request's tool definitions.
+            # rather than merely hidden from one request's tool definitions - and
+            # it is what applies the per-path rules, which nothing used to.
             permissions=self.permissions,
+            # So the guard inside the toolset resolves an "ask" the same way this
+            # capability does. Without them a ruleset holding an "ask" would refuse
+            # or raise there on a different rule from the one stated here.
+            ask_callback=self.ask_callback,
+            ask_fallback=self.ask_fallback,
         )
         if self.permissions is not None:
             self._checker = PermissionChecker(

--- a/src/pydantic_ai_backends/remote/_workspace.py
+++ b/src/pydantic_ai_backends/remote/_workspace.py
@@ -149,3 +149,38 @@ def read_workspace(root: Path, path: str, offset: int, limit: int, max_bytes: in
         return chunk
     remaining = len(lines) - end
     return f"{chunk}\n\n[... {remaining} more lines. Use offset={end} to read more.]"
+
+
+def read_workspace_bytes(root: Path, path: str, max_bytes: int) -> bytes:
+    """Read a whole workspace file as bytes.
+
+    The sibling of :func:`read_workspace`, and the reason it exists is that
+    decoding is not always wanted. A chart, a rendered PDF, an image an agent
+    fetched — the most common things it actually produces — are not text, and
+    reading them as text then re-encoding yields a corrupt file that downloads
+    successfully. That is the worst available outcome, so a consumer with only
+    `read` had to refuse the whole class of file instead.
+
+    Whole rather than sliced: a byte range is meaningless for the formats this
+    exists to serve, and the listing already carries `size`, so a caller that
+    needs to bound a read can look before making it.
+
+    Args:
+        root: The session's workspace directory.
+        path: File to read, relative to `root`.
+        max_bytes: Largest file to read into memory.
+
+    Raises:
+        WorkspacePathError: If `path` escapes the workspace.
+        FileNotFoundError: If it is not a regular file.
+        ValueError: If the file is over `max_bytes`.
+    """
+    target = resolve_within(root, path)
+    if not target.is_file():
+        raise FileNotFoundError(f"No such file: {path}")
+
+    size = target.stat().st_size
+    if size > max_bytes:
+        raise ValueError(f"File is {size} bytes, over the {max_bytes}-byte read limit")
+
+    return target.read_bytes()

--- a/src/pydantic_ai_backends/remote/client.py
+++ b/src/pydantic_ai_backends/remote/client.py
@@ -526,6 +526,7 @@ class WorkspaceArchive:
         for entry in archive.ls(session_id):
             print(entry["path"], entry["size"])
         print(archive.read(session_id, "report.md"))
+        Path("chart.png").write_bytes(archive.read_bytes(session_id, "chart.png"))
         ```
     """
 
@@ -581,6 +582,29 @@ class WorkspaceArchive:
         payload = wire.ReadRequest(path=path, offset=offset, limit=limit).model_dump(mode="json")
         response = self._post(f"/workspaces/{session_id}/read", payload)
         return wire.ReadResponse.model_validate(response.json()).content
+
+    def read_bytes(self, session_id: str, path: str) -> bytes:
+        """Read a whole stored workspace file as bytes.
+
+        The sibling of :meth:`read`, and the one to use for anything an agent
+        produced that is not text - a chart, a rendered PDF, an image it fetched.
+        Those are the commonest contents of a real workspace, and `read` decodes
+        them: the result re-encodes to a corrupt file that nonetheless downloads
+        successfully, which is worse than an error, so a caller serving downloads
+        had to refuse them instead.
+
+        Whole rather than sliced, because a byte range means nothing for the
+        formats this exists for. `ls` carries `size`, so a caller that wants to
+        bound a read can look first.
+
+        Raises:
+            WorkspaceArchiveError: If the file is absent, over the service's read
+                ceiling, outside the workspace, or the service is unreachable.
+        """
+        payload = wire.ReadBytesRequest(path=path).model_dump(mode="json")
+        response = self._post(f"/workspaces/{session_id}/read_bytes", payload)
+        encoded = wire.ReadBytesResponse.model_validate(response.json()).content_b64
+        return base64.b64decode(encoded)
 
     def close(self) -> None:
         """Close the HTTP client, when this object built it."""

--- a/src/pydantic_ai_backends/remote/env.py
+++ b/src/pydantic_ai_backends/remote/env.py
@@ -121,6 +121,7 @@ def config_from_env(env: Mapping[str, str]) -> SandboxdConfig:
             execute_timeout=_value(env, "EXECUTE_TIMEOUT", defaults.execute_timeout, _as_int),
             max_workers=_value(env, "MAX_WORKERS", defaults.max_workers, _as_int),
             ui_enabled=_flag(env, "UI_ENABLED", defaults.ui_enabled),
+            policy_overrides=_optional(env, "POLICY_OVERRIDES", defaults.policy_overrides, str),
         )
     except ValueError as e:
         # `SandboxdConfig` refuses combinations no single variable is wrong in —

--- a/src/pydantic_ai_backends/remote/server.py
+++ b/src/pydantic_ai_backends/remote/server.py
@@ -55,7 +55,7 @@ from collections import Counter, deque
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, TypeVar, cast
@@ -506,6 +506,14 @@ class SandboxdConfig:
     execute_timeout: int = 300
     max_workers: int = 32
     ui_enabled: bool = False
+    policy_overrides: str | None = None
+    """JSON file holding a `PolicyUpdate`, re-read while the service runs.
+
+    The alternative to `PUT /policy` for a deployment that would rather not expose
+    a write endpoint. Both go through the same validation and write the same live
+    configuration, so neither can put the service in a state the other cannot
+    describe. `None` disables it, which is the default.
+    """
 
     def __post_init__(self) -> None:
         if not self.token:
@@ -573,6 +581,207 @@ class SandboxdConfig:
                 runtime.oci_runtime if runtime.oci_runtime is not None else self.oci_runtime
             ),
         }
+
+
+POLICY_SCALARS: tuple[str, ...] = (
+    "max_sessions",
+    "max_open_sessions",
+    "max_sessions_per_tenant",
+    "evict_idle_after",
+    "idle_timeout",
+    "execute_timeout",
+    "max_read_bytes",
+    "workspace_ttl",
+    "container_ttl",
+    "mem_limit",
+    "memswap_limit",
+    "cpus",
+    "cpu_shares",
+    "pids_limit",
+    "tmpfs_size",
+)
+"""Service-wide fields `PolicyUpdate` may write, and the only ones.
+
+Listed here rather than derived from the model's fields, so that adding a field
+to `PolicyUpdate` is a deliberate act in two places. The model is a wire shape
+somebody could widen without thinking about what it lets a caller reach; this is
+the list that decides what actually gets written, and `test_policy_updates.py`
+fails if the two drift.
+"""
+
+
+class PolicyUpdateError(ValueError):
+    """A policy update named something that does not exist, or may not change.
+
+    A `ValueError` because both the endpoint and the file watcher raise it, and
+    only one of them has an HTTP response to put it in.
+    """
+
+
+def apply_policy_update(config: SandboxdConfig, update: wire.PolicyUpdate) -> list[str]:
+    """Write an update onto the live configuration, and say what changed.
+
+    **One function for both entrances.** The endpoint and the overrides file are
+    two ways to ask for the same thing, and two code paths applying the same
+    update would eventually disagree about what is in force. So there is one
+    place that writes, one place that validates, and one definition of what may
+    be written.
+
+    Takes effect without a restart because the sandbox builder reads these fields
+    when it builds a sandbox rather than capturing them at startup. Sandboxes
+    *already resident* keep the ceilings they were created with — Docker sets them
+    on the container, and this does not reach in and change one. Worth knowing
+    rather than discovering: lowering a memory ceiling applies to the next
+    sandbox, not to the one currently using too much.
+
+    Args:
+        config: The live configuration, mutated in place.
+        update: What to change. Absent fields are left alone.
+
+    Returns:
+        The names of the fields that actually changed, for the caller to log.
+        Empty when the update asked for nothing new, which is not an error.
+
+    Raises:
+        PolicyUpdateError: If `default_runtime` or a `runtimes` key names an alias
+            the allowlist does not hold. Refused rather than created: an alias
+            that does not exist has no image, and inventing one here is exactly
+            the door this endpoint is not.
+    """
+    named = update.model_dump(exclude_unset=True)
+    changed: list[str] = []
+
+    if "default_runtime" in named:
+        alias = update.default_runtime
+        if alias not in config.runtimes:
+            raise PolicyUpdateError(
+                f"Unknown runtime '{alias}'. The default has to be one of: "
+                f"{', '.join(sorted(config.runtimes)) or '(none allowed)'}"
+            )
+        if config.default_runtime != alias:
+            config.default_runtime = alias or ""
+            changed.append("default_runtime")
+
+    for name in POLICY_SCALARS:
+        if name not in named:
+            continue
+        value = getattr(update, name)
+        if getattr(config, name) != value:
+            setattr(config, name, value)
+            changed.append(name)
+
+    replaced: dict[str, str | SandboxRuntime] = {}
+    for alias, limits in (update.runtimes or {}).items():
+        if alias not in config.runtimes:
+            raise PolicyUpdateError(
+                f"Unknown runtime '{alias}'. Ceilings can be changed for an allowed "
+                "runtime; a new one is a deployment change, because it names an image."
+            )
+        runtime = _as_runtime(config.runtimes[alias])
+        wanted = {
+            name: value
+            for name, value in limits.model_dump(exclude_unset=True).items()
+            if getattr(runtime, name) != value
+        }
+        if not wanted:
+            continue
+        # `replace`, because `SandboxRuntime` is frozen - which is the right shape
+        # for a thing an allowlist holds.
+        replaced[alias] = replace(runtime, **wanted)
+        changed.extend(f"runtimes.{alias}.{name}" for name in wanted)
+
+    if replaced:
+        # A whole new mapping rather than writes into the old one. `runtimes` is
+        # declared `Mapping` deliberately - an allowlist is not a thing to mutate -
+        # and swapping it means a reader that already holds one sees a consistent
+        # snapshot instead of a half-applied update. It is also what carries a
+        # change to an alias stored as a bare image string, which `_as_runtime`
+        # turned into a fresh object nothing else would ever have seen.
+        config.runtimes = {**config.runtimes, **replaced}
+
+    return changed
+
+
+def load_policy_overrides(config: SandboxdConfig, path: Path) -> list[str]:
+    """Apply the overrides file onto the live configuration, if it is there.
+
+    The second way in, for a deployment that would rather not expose a write
+    endpoint at all. It reaches `apply_policy_update` — the same validation, the
+    same writable set, the same refusal for an alias that does not exist — so the
+    two entrances cannot drift into disagreeing about what is in force.
+
+    An absent file is not an error: it is the normal state, and the setting exists
+    so an operator *can* drop one in later without restarting.
+
+    Args:
+        config: The live configuration, mutated in place.
+        path: JSON file holding a :class:`wire.PolicyUpdate`.
+
+    Returns:
+        The names of the fields that changed. Empty when the file is absent, holds
+        nothing new, or could not be read — the last of those is logged.
+
+    Raises:
+        Nothing. A malformed file must not be able to stop a running service or
+        prevent one from starting: an operator who mistypes a ceiling should get a
+        log line and the previous value, not a daemon that will not boot and takes
+        every resident sandbox with it.
+    """
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        _logger.warning("Could not read the policy overrides at %s: %s", path, exc)
+        return []
+
+    try:
+        update = wire.PolicyUpdate.model_validate_json(raw)
+    except ValueError as exc:
+        _logger.warning("Ignoring the policy overrides at %s: %s", path, exc)
+        return []
+
+    try:
+        changed = apply_policy_update(config, update)
+    except PolicyUpdateError as exc:
+        _logger.warning("Ignoring the policy overrides at %s: %s", path, exc)
+        return []
+
+    if changed:
+        _logger.info("Policy overrides from %s applied: %s", path, ", ".join(changed))
+    return changed
+
+
+class PolicyOverridesWatcher:
+    """Re-reads the overrides file when its modification time moves.
+
+    Polling its `stat` rather than watching the filesystem, deliberately: it is one
+    `stat` per interval against a dependency-free implementation, and the
+    alternatives (`inotify`, `watchdog`) buy sub-second latency for a file an
+    operator edits by hand. The service already runs a cleanup loop on a timer, so
+    there is a place for this to live and nothing new to shut down.
+
+    A file that has been deleted since it was last read is left alone rather than
+    reverted. Reverting would mean remembering the environment's values and putting
+    them back, which is a second source of truth — and the honest reading of a
+    deleted overrides file is "stop overriding from here", which is a restart.
+    """
+
+    def __init__(self, config: SandboxdConfig, path: Path) -> None:
+        self._config = config
+        self._path = path
+        self._seen: float | None = None
+
+    def poll(self) -> list[str]:
+        """Apply the file if it has changed since the last look."""
+        try:
+            stamp = self._path.stat().st_mtime
+        except OSError:
+            return []
+        if stamp == self._seen:
+            return []
+        self._seen = stamp
+        return load_policy_overrides(self._config, self._path)
 
 
 _EVENT_HISTORY = 200
@@ -944,6 +1153,13 @@ class _Service:
         self._executor: ThreadPoolExecutor | None = None
         self._sweep_task: asyncio.Task[None] | None = None
         self._prewarm_task: asyncio.Task[None] | None = None
+        # `None` when no overrides file is configured, which is the default - so
+        # the sweep loop skips even the `stat` for every deployment not using it.
+        self._policy_watcher = (
+            None
+            if config.policy_overrides is None
+            else PolicyOverridesWatcher(config, Path(config.policy_overrides))
+        )
         self._usage_cache: dict[str, tuple[float, wire.SessionUsage | None]] = {}
         # The clock the usage cache ages against, as an attribute so a test can
         # advance it. Patching `time.monotonic` in this module instead reaches
@@ -997,6 +1213,10 @@ class _Service:
         # Starting and stopping a sandbox blocks for seconds; the manager runs
         # both on this pool rather than on the loop every request shares.
         self.manager.executor = self._executor
+        # Read once before anything is served, so the first session is held to the
+        # ceilings the file names rather than to the environment's for one interval.
+        if self._policy_watcher is not None:
+            self._policy_watcher.poll()
         self.manager.start_cleanup_loop(interval=self.config.cleanup_interval)
         # Always: the manager only reaps sessions it holds a sandbox for, so
         # ending the hibernated ones is this loop's job whatever the TTLs say.
@@ -1029,6 +1249,11 @@ class _Service:
         while True:
             await asyncio.sleep(self.config.cleanup_interval)
             try:
+                # Before the sweep, so a ceiling raised in the overrides file is in
+                # force for this pass rather than the next one. A `stat` when no
+                # file is configured is skipped entirely.
+                if self._policy_watcher is not None:
+                    await self._in_thread(self._policy_watcher.poll)
                 await self._reap_hibernated()
                 await self._in_thread(self._sweep_once)
             except Exception:
@@ -1886,6 +2111,32 @@ def _register_session_routes(app: FastAPI, service: _Service) -> None:
     @app.get("/policy", response_model=wire.ServicePolicy, dependencies=[ServiceAuth])
     async def get_policy() -> wire.ServicePolicy:
         """The ceilings and allowlist every sandbox is held to."""
+        return service.policy()
+
+    @app.put("/policy", response_model=wire.ServicePolicy, dependencies=[ServiceAuth])
+    async def put_policy(body: wire.PolicyUpdate) -> wire.ServicePolicy:
+        """Change the ceilings and lifetimes, without a restart.
+
+        Ceilings and lifetimes *only* — see :class:`wire.PolicyUpdate` for what is
+        deliberately absent and why. The short version: how much a sandbox may
+        consume and how long it may live are an operator's to tune; what a runtime
+        *is*, and whether it is isolated, stay in the environment where changing
+        them is a deployment action.
+
+        Answers with the whole policy rather than an acknowledgement, so a caller
+        sees what is now in force including the fields it did not touch — which is
+        also how it learns that a ceiling it set was already the value there.
+
+        Restarting used to be the only way, and a restart drops every resident
+        sandbox: an operator raising one memory ceiling ended every conversation
+        on the host.
+        """
+        try:
+            changed = apply_policy_update(service.config, body)
+        except PolicyUpdateError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if changed:
+            _logger.info("Policy updated: %s", ", ".join(changed))
         return service.policy()
 
     @app.post("/sessions", response_model=wire.SessionCreated, dependencies=[ServiceAuth])

--- a/src/pydantic_ai_backends/remote/server.py
+++ b/src/pydantic_ai_backends/remote/server.py
@@ -78,6 +78,7 @@ from pydantic_ai_backends.remote._workspace import (
     WorkspacePathError,
     list_workspace,
     read_workspace,
+    read_workspace_bytes,
     relative_request_path,
     workspace_root_for,
 )
@@ -1753,6 +1754,28 @@ class _Service:
         )
         return wire.ReadResponse(content=content)
 
+    async def archive_read_bytes(
+        self, session_id: str, body: wire.ReadBytesRequest
+    ) -> wire.ReadBytesResponse:
+        """Read a stored workspace file as bytes, without starting a sandbox.
+
+        The sibling of :meth:`archive_read`, for the files that are not text. A
+        chart or a PDF read through `archive_read` comes back decoded and
+        re-encoded, which is a corrupt file rather than an error - so a consumer
+        serving downloads had to allowlist text suffixes and refuse everything
+        an agent is most likely to have produced.
+
+        Raises:
+            HTTPException: 400 for a path outside the workspace or a file over
+                the read ceiling, 404 when it is not a file.
+        """
+        workspace = self.workspace_of(session_id)
+        relative = relative_request_path(body.path, self.config.work_dir)
+        raw = await self._off_loop(
+            read_workspace_bytes, workspace, relative, self.config.max_read_bytes
+        )
+        return wire.ReadBytesResponse(content_b64=base64.b64encode(raw).decode("ascii"))
+
     async def _in_thread(self, call: Callable[[], Any]) -> Any:
         """Run one blocking call on the service's worker pool."""
         return await asyncio.get_running_loop().run_in_executor(self._executor, call)
@@ -1952,6 +1975,23 @@ def _register_workspace_routes(app: FastAPI, service: _Service) -> None:
     ) -> wire.ReadResponse:
         """Read a slice of a stored workspace file."""
         return await service.archive_read(session_id, body)
+
+    @app.post(
+        "/workspaces/{session_id}/read_bytes",
+        response_model=wire.ReadBytesResponse,
+        dependencies=[ServiceAuth],
+    )
+    async def read_archived_bytes(
+        session_id: Annotated[str, PathParam(pattern=wire.SESSION_ID_PATTERN)],
+        body: wire.ReadBytesRequest,
+    ) -> wire.ReadBytesResponse:
+        """Read a whole stored workspace file as base64.
+
+        Beside `read` rather than replacing it: text wants the slicing, the line
+        numbers and the encoding detection that `read` does, and a PNG wants none
+        of it.
+        """
+        return await service.archive_read_bytes(session_id, body)
 
 
 def _register_operation_routes(app: FastAPI, service: _Service) -> None:

--- a/src/pydantic_ai_backends/remote/wire.py
+++ b/src/pydantic_ai_backends/remote/wire.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 TOKEN_HEADER = "X-Sandbox-Token"
 """Header carrying either the service token or a session's own token."""
@@ -361,6 +361,90 @@ class ServicePolicy(BaseModel):
     """Whether the allowlist is pulled and built at startup rather than on demand."""
     buildkit: bool = False
     """Whether image builds use BuildKit, and so keep package caches between them."""
+
+
+class RuntimeLimitsUpdate(BaseModel):
+    """New ceilings for one already-allowed runtime.
+
+    Ceilings only. There is no `image`, no `description` and no `builds`: what a
+    runtime *is* stays the daemon's, set from its environment and never from a
+    request. An operator adjusts what a runtime may consume; nobody adjusts what
+    it runs.
+
+    Every field is optional, and absent means "leave it alone" rather than
+    "clear it" — `None` is a meaningful value for most of these (it pins swap to
+    memory, or takes the daemon's default), so a model that could not tell absent
+    from null would wipe a ceiling every time somebody changed a different one.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mem_limit: str | None = None
+    memswap_limit: str | None = None
+    cpus: float | None = Field(default=None, gt=0)
+    cpu_shares: int | None = Field(default=None, gt=0)
+    pids_limit: int | None = Field(default=None, gt=0)
+
+
+class PolicyUpdate(BaseModel):
+    """Ceilings and lifetimes an operator may change without a restart.
+
+    **Deliberately a narrow subset of `ServicePolicy`, and the omissions are the
+    point.** `CreateSessionRequest` carries no container settings because a
+    process holding the Docker socket can start a privileged container that
+    mounts the host — a client that could name its own image or volumes would own
+    the machine. That reasoning does not stop applying because the caller holds
+    the service token: in a multi-tenant deployment the token is held by an
+    application, per tenant, and an organization's administrator is not the
+    person who runs the host.
+
+    So what is writable here is resource ceilings and lifetimes — how much a
+    sandbox may consume and how long it may live. What is **not** writable is
+    anything that decides *isolation*:
+
+    - `runtimes` membership, because adding an alias means naming an image
+    - `network_mode`, because `host` is not a ceiling, it is an escape
+    - `oci_runtime`, for the same reason at a lower level
+    - `sandbox_uid`, because 0 is root
+    - `work_dir`, because it is where the workspace volume mounts and the archive
+      endpoints read
+    - `persist_containers`, `prewarm`, `buildkit` — startup shape, not ceilings
+
+    Those stay in the environment, where changing them is a deployment action
+    with a restart attached. `extra="forbid"`, so an attempt to send one is a 422
+    naming the field rather than a silently ignored key.
+
+    Absent means "leave it alone". Every field is optional for that reason: an
+    operator raising one ceiling must not have to restate the other twenty.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    default_runtime: str | None = None
+    """Must already be an allowed alias. Changing which of them is the default is
+    not the same as adding one."""
+
+    max_sessions: int | None = Field(default=None, ge=0)
+    max_open_sessions: int | None = Field(default=None, ge=0)
+    max_sessions_per_tenant: int | None = Field(default=None, ge=0)
+    evict_idle_after: int | None = Field(default=None, ge=0)
+    idle_timeout: int | None = Field(default=None, ge=0)
+    execute_timeout: int | None = Field(default=None, gt=0)
+    max_read_bytes: int | None = Field(default=None, gt=0)
+    workspace_ttl: int | None = Field(default=None, ge=0)
+    container_ttl: int | None = Field(default=None, ge=0)
+
+    mem_limit: str | None = None
+    memswap_limit: str | None = None
+    cpus: float | None = Field(default=None, gt=0)
+    cpu_shares: int | None = Field(default=None, gt=0)
+    pids_limit: int | None = Field(default=None, gt=0)
+    tmpfs_size: str | None = None
+
+    runtimes: dict[str, RuntimeLimitsUpdate] | None = None
+    """Per-alias ceilings, keyed by an alias the allowlist already holds. An
+    unknown one is refused rather than created, which is what keeps this from
+    being a way to name an image."""
 
 
 class ServiceIndex(BaseModel):

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -19,6 +19,7 @@ from pydantic_ai.exceptions import (
 from pydantic_ai.toolsets import FunctionToolset
 
 from pydantic_ai_backends.adapter import ensure_async
+from pydantic_ai_backends.backends import _guard
 from pydantic_ai_backends.protocol import AsyncBackendProtocol, BackendProtocol
 from pydantic_ai_backends.toolsets import _ruleset, _tracking
 from pydantic_ai_backends.toolsets._content import (
@@ -85,6 +86,7 @@ from pydantic_ai_backends.toolsets.descriptions import (
 from pydantic_ai_backends.types import GrepMatch
 
 if TYPE_CHECKING:
+    from pydantic_ai_backends.permissions.checker import AskCallback, AskFallback
     from pydantic_ai_backends.permissions.types import PermissionRuleset
 
 EditFormat = Literal["str_replace", "hashline"]
@@ -196,6 +198,8 @@ def create_console_toolset(  # noqa: C901
     require_execute_approval: bool = True,
     default_ignore_hidden: bool = True,
     permissions: PermissionRuleset | None = None,
+    ask_callback: AskCallback | None = None,
+    ask_fallback: AskFallback = "error",
     max_retries: int = 1,
     image_support: bool = False,
     max_image_bytes: int = DEFAULT_MAX_IMAGE_BYTES,
@@ -267,8 +271,38 @@ def create_console_toolset(  # noqa: C901
     """
     described = descriptions or {}
 
+    # Wrapped once, here, because the closure backend never changes. `guarding`
+    # answers with the backend untouched when there is no ruleset or when the
+    # backend enforces one of its own, so this is a no-op for every existing
+    # caller.
+    guarded_backend = (
+        None
+        if backend is None
+        else _guard.guarding(
+            backend, permissions, ask_callback=ask_callback, ask_fallback=ask_fallback
+        )
+    )
+
     def backend_for(ctx: RunContext[ConsoleDeps]) -> BackendProtocol | AsyncBackendProtocol:
-        return backend if backend is not None else ctx.deps.backend
+        """The backend this call operates on, with the ruleset applied to it.
+
+        The one place every tool resolves its backend, which is why the guard goes
+        here: a ruleset's per-path rules used to reach nothing at all, because the
+        toolset only ever read an operation's *default* action at construction
+        time. Applying them needs a path, and a path only exists per call.
+
+        The deps backend is wrapped per call rather than once, since it can differ
+        between runs. Cheap: the wrapper holds two references and a checker that
+        does the same.
+        """
+        if backend is not None:
+            return guarded_backend if guarded_backend is not None else backend
+        return _guard.guarding(
+            ctx.deps.backend,
+            permissions,
+            ask_callback=ask_callback,
+            ask_fallback=ask_fallback,
+        )
 
     write_approval = _ruleset.requires_approval(permissions, "write", require_write_approval)
     execute_approval = _ruleset.requires_approval(permissions, "execute", require_execute_approval)

--- a/tests/test_console_path_rules.py
+++ b/tests/test_console_path_rules.py
@@ -1,0 +1,349 @@
+"""A ruleset's per-path rules, applied to a backend that does not apply its own.
+
+`PermissionGuard` has existed since `LocalBackend` needed it, and only
+`LocalBackend` ever used it. So a ruleset handed to `ConsoleCapability` or
+`create_console_toolset` reached exactly two things — `requires_approval` for the
+write and execute approval flags, and `_denied_tools`, which drops a tool whose
+*operation* defaults to `"deny"`. Nothing read `OperationPermissions.rules`.
+
+With every operation left at `default="allow"` and the patterns in `rules` — the
+shape a caller writes when they want "allow the workspace, deny credentials and
+the system tree" — that was no enforcement at all. Which is worse than rejecting
+the ruleset, because the result looks like a working boundary.
+
+`tests/test_console_permissions.py` covers what a ruleset does at construction
+time: which tools exist, which need approval. This file covers what it does per
+call, with a path in hand.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from pydantic_ai_backends import ConsoleCapability, StateBackend
+from pydantic_ai_backends.backends._guard import GuardedBackend, guarding
+from pydantic_ai_backends.permissions import (
+    SECRETS_PATTERNS,
+    SYSTEM_PATTERNS,
+    OperationPermissions,
+    PermissionRule,
+    PermissionRuleset,
+)
+
+OFF_LIMITS = (*SECRETS_PATTERNS, *SYSTEM_PATTERNS)
+
+
+def ruleset() -> PermissionRuleset:
+    """Allow everything, deny the credentials and the system tree.
+
+    The shape this is all about: an operation default of `"allow"` with the
+    interesting part in `rules`.
+    """
+    deny = [
+        PermissionRule(pattern=pattern, action="deny", description="Off limits")
+        for pattern in OFF_LIMITS
+    ]
+    return PermissionRuleset(
+        default="allow",
+        read=OperationPermissions(default="allow", rules=deny),
+        write=OperationPermissions(default="allow", rules=deny),
+        edit=OperationPermissions(default="allow", rules=deny),
+    )
+
+
+def populated() -> StateBackend:
+    backend = StateBackend()
+    backend.write("/notes.txt", "ordinary work")
+    backend.write("/.env", "OPENAI_API_KEY=sk-live-secret")
+    backend.write("/sub/.env", "NESTED=sk-live-secret")
+    backend.write("/credentials.txt", "PASSWORD=hunter2")
+    backend.write("/etc/passwd", "root:x:0:0")
+    return backend
+
+
+def guarded() -> GuardedBackend:
+    wrapped = guarding(populated(), ruleset())
+    assert isinstance(wrapped, GuardedBackend)
+    return wrapped
+
+
+class TestContentAndMutation:
+    """The five ways bytes leave a file or change one."""
+
+    @pytest.mark.parametrize("path", ["/.env", "/sub/.env", "/credentials.txt", "/etc/passwd"])
+    @pytest.mark.anyio
+    async def test_reading_an_off_limits_path_is_refused(self, path: str) -> None:
+        with pytest.raises(PermissionError, match="Off limits"):
+            await guarded().read(path)
+
+    @pytest.mark.parametrize("path", ["/.env", "/etc/passwd"])
+    @pytest.mark.anyio
+    async def test_reading_one_as_bytes_is_refused_too(self, path: str) -> None:
+        """`read_file` on an image goes through `read_bytes`, so a guard on `read`
+        alone leaves the same file readable by asking differently."""
+        with pytest.raises(PermissionError, match="Off limits"):
+            await guarded().read_bytes(path)
+
+    @pytest.mark.anyio
+    async def test_the_workspaces_own_files_still_read(self) -> None:
+        assert "ordinary work" in await guarded().read("/notes.txt")
+        assert await guarded().read_bytes("/notes.txt") == b"ordinary work"
+
+    @pytest.mark.anyio
+    async def test_writing_over_a_credential_is_refused_as_a_value(self) -> None:
+        """An error result rather than a raise: it is what the model reads and can
+        act on, and the protocol has a place for it."""
+        result = await guarded().write("/sub/.env", "x")
+
+        assert result.error is not None
+        assert "Off limits" in result.error
+
+    @pytest.mark.anyio
+    async def test_an_ordinary_write_still_lands(self) -> None:
+        assert (await guarded().write("/report.csv", "a,b")).error is None
+
+    @pytest.mark.anyio
+    async def test_editing_a_credential_is_refused_as_a_value(self) -> None:
+        result = await guarded().edit("/.env", "sk-live-secret", "x")
+
+        assert result.error is not None
+
+    @pytest.mark.anyio
+    async def test_an_ordinary_edit_still_applies(self) -> None:
+        assert (await guarded().edit("/notes.txt", "ordinary", "usual")).error is None
+
+
+class TestSearchAndListing:
+    @pytest.mark.anyio
+    async def test_grep_does_not_return_a_line_from_a_file_it_may_not_read(self) -> None:
+        """The one a guard on `read` alone misses entirely.
+
+        `GrepMatch` carries the matching *line*, so an unfiltered grep hands over
+        the contents of exactly the files the rules protect — by a different tool,
+        with no refusal anywhere.
+        """
+        backend = StateBackend()
+        backend.write("/credentials.txt", "PASSWORD=hunter2")
+        backend.write("/notes.txt", "PASSWORD is stored elsewhere")
+        wrapped = guarding(backend, ruleset())
+
+        found = await wrapped.grep_raw("PASSWORD")  # type: ignore[union-attr]
+
+        assert [match["path"] for match in found] == ["/notes.txt"]
+
+    @pytest.mark.anyio
+    async def test_a_grep_that_answers_with_a_string_is_passed_through(self) -> None:
+        """ "No matches" and a backend error are strings, not result sets."""
+
+        class Backend:
+            async def read_bytes(self, path: str) -> bytes:
+                return b""
+
+            async def grep_raw(self, *args: object, **kwargs: object) -> str:
+                return "No matches for 'x'"
+
+        wrapped = GuardedBackend(Backend(), ruleset())  # type: ignore[arg-type]
+
+        assert await wrapped.grep_raw("x") == "No matches for 'x'"
+
+    @pytest.mark.anyio
+    async def test_a_listing_is_filtered_by_the_ls_and_glob_rules(self) -> None:
+        """Their own rules, not the `read` ones — which matches `LocalBackend`.
+
+        Hiding entries rather than refusing, because a ruleset defaulting to "ask"
+        would otherwise blank out every listing.
+        """
+        deny_listing = [
+            PermissionRule(pattern=pattern, action="deny", description="Off limits")
+            for pattern in OFF_LIMITS
+        ]
+        rules = PermissionRuleset(
+            default="allow",
+            ls=OperationPermissions(default="allow", rules=deny_listing),
+            glob=OperationPermissions(default="allow", rules=deny_listing),
+        )
+        wrapped = guarding(populated(), rules)
+
+        assert [entry["path"] for entry in await wrapped.glob_info("**/.env")] == []  # type: ignore[union-attr]
+        listed = [entry["path"] for entry in await wrapped.ls_info("/")]  # type: ignore[union-attr]
+        assert "/notes.txt" in listed
+        assert "/.env" not in listed
+
+    @pytest.mark.anyio
+    async def test_a_read_deny_alone_does_not_hide_the_name(self) -> None:
+        """Deliberate, and worth pinning so nobody "fixes" it: a name is a weaker
+        claim than the contents, and a listing that hid a file `exists` reports
+        would send an agent rewriting one it cannot read."""
+        wrapped = guarding(populated(), ruleset())
+
+        assert [entry["path"] for entry in await wrapped.glob_info("**/.env")] != []  # type: ignore[union-attr]
+        with pytest.raises(PermissionError):
+            await wrapped.read("/.env")  # type: ignore[union-attr]
+
+    @pytest.mark.anyio
+    async def test_exists_is_not_filtered(self) -> None:
+        """Whether a path is there is a weaker claim than what is in it, and a
+        listing that lied about it would make an agent rewrite a file it cannot
+        see."""
+        assert await guarded().exists("/etc/passwd") is True
+
+
+class TestExecute:
+    @pytest.mark.anyio
+    async def test_a_command_naming_a_denied_path_is_refused(self) -> None:
+        """The obvious bypass. Defence in depth rather than a boundary — a shell
+        reaches files in ways string inspection cannot see — which is what
+        `PermissionGuard.execute_denial_reason` already knew how to do and nothing
+        outside `LocalBackend` ever asked it."""
+
+        class Sandbox(StateBackend):
+            def execute(self, command: str, timeout: int | None = None) -> str:
+                return "ran"
+
+        wrapped = guarding(Sandbox(), ruleset())
+
+        with pytest.raises(PermissionError, match="denied"):
+            await wrapped.execute("cat /etc/passwd")  # type: ignore[union-attr]
+
+    @pytest.mark.anyio
+    async def test_a_backend_with_no_shell_still_says_so(self) -> None:
+        """The toolset asks `hasattr(backend, "execute")` to decide whether to
+        answer "Backend does not support command execution". A guard that declared
+        `execute` as a method would make that true for a `StateBackend` too, so the
+        friendly answer would become a raise - which is why `execute` is reached
+        through `__getattr__` rather than defined."""
+        wrapped = guarding(populated(), ruleset())
+
+        assert not hasattr(wrapped, "execute")
+
+    @pytest.mark.anyio
+    async def test_an_ordinary_command_runs(self) -> None:
+        class Sandbox(StateBackend):
+            def execute(self, command: str, timeout: int | None = None) -> str:
+                return "ran"
+
+        wrapped = guarding(Sandbox(), ruleset())
+
+        assert await wrapped.execute("ls -la") == "ran"  # type: ignore[union-attr]
+
+
+class TestWhatIsNotWrapped:
+    def test_no_ruleset_leaves_the_backend_alone(self) -> None:
+        backend = populated()
+
+        assert guarding(backend, None) is backend
+
+    def test_a_backend_that_enforces_its_own_rules_is_left_alone(self) -> None:
+        """`LocalBackend` applies a ruleset itself. Wrapping it would check every
+        path twice and report the second refusal, which is the same answer with a
+        worse message."""
+
+        class SelfEnforcing(StateBackend):
+            @property
+            def permissions(self) -> PermissionRuleset:
+                return ruleset()
+
+        backend = SelfEnforcing()
+
+        assert guarding(backend, ruleset()) is backend
+
+    def test_the_ruleset_is_readable_off_the_wrapper(self) -> None:
+        """Which is what stops it being wrapped twice."""
+        assert guarded().permissions is not None
+
+    def test_anything_the_protocol_does_not_name_passes_through(self) -> None:
+        """A sandbox is more than the protocol: `stop`, `id`, `files`. An explicit
+        method list would have dropped them."""
+
+        class Sandbox(StateBackend):
+            def stop(self, purge: bool = False) -> str:
+                return f"stopped purge={purge}"
+
+        wrapped = guarding(Sandbox(), ruleset())
+
+        assert wrapped.stop(purge=True) == "stopped purge=True"  # type: ignore[union-attr]
+        assert wrapped.files == {}  # type: ignore[union-attr]
+
+    def test_something_only_the_raw_backend_has_is_still_reachable(self) -> None:
+        """Two places to look, in order. `ensure_async` returns an adapter that
+        proxies the protocol and `execute` and nothing else - so `stop` and `id`
+        and a backend's own extras are only on the object underneath, and asking
+        the adapter first is what keeps `execute` awaitable."""
+
+        class Sandbox(StateBackend):
+            @property
+            def id(self) -> str:
+                return "sbx-1"
+
+        wrapped = guarding(Sandbox(), ruleset())
+
+        assert wrapped.id == "sbx-1"  # type: ignore[union-attr]
+
+    def test_it_says_what_it_wraps(self) -> None:
+        assert "GuardedBackend" in repr(guarded())
+
+
+class TestThroughTheCapability:
+    """The assertion that would have caught the original defect.
+
+    Not that the ruleset exists, but that the toolset the model is handed refuses.
+    """
+
+    @staticmethod
+    async def _call(capability: ConsoleCapability, name: str, **kwargs: Any) -> Any:
+        class Ctx:
+            pass
+
+        result = capability._toolset.tools[name].function(Ctx(), **kwargs)
+        return await result if asyncio.iscoroutine(result) else result
+
+    @pytest.mark.anyio
+    async def test_a_credential_is_refused_through_the_registered_tool(self) -> None:
+        capability = ConsoleCapability(
+            backend=populated(), permissions=ruleset(), include_execute=False
+        )
+
+        answer = await self._call(capability, "read_file", path="/etc/passwd")
+
+        assert "Permission denied" in answer
+
+    @pytest.mark.anyio
+    async def test_an_ordinary_file_is_still_served(self) -> None:
+        capability = ConsoleCapability(
+            backend=populated(), permissions=ruleset(), include_execute=False
+        )
+
+        answer = await self._call(capability, "read_file", path="/notes.txt")
+
+        assert "ordinary work" in answer
+
+    @pytest.mark.anyio
+    async def test_a_capability_with_no_ruleset_refuses_nothing(self) -> None:
+        """Every existing caller behaves exactly as before, which is the whole
+        reason `guarding` answers with the backend untouched."""
+        capability = ConsoleCapability(backend=populated(), include_execute=False)
+
+        answer = await self._call(capability, "read_file", path="/etc/passwd")
+
+        assert "root:x:0:0" in answer
+
+    @pytest.mark.anyio
+    async def test_the_backend_from_deps_is_guarded_too(self) -> None:
+        """A toolset built with no backend reads `ctx.deps.backend` per call, so
+        the guard has to be applied there rather than only to the closure."""
+        from pydantic_ai_backends.toolsets.console import create_console_toolset
+
+        toolset = create_console_toolset(permissions=ruleset(), include_execute=False)
+
+        class Deps:
+            backend = populated()
+
+        class Ctx:
+            deps = Deps()
+
+        answer = await toolset.tools["read_file"].function(Ctx(), path="/etc/passwd")
+
+        assert "Permission denied" in answer

--- a/tests/test_docker_sandbox.py
+++ b/tests/test_docker_sandbox.py
@@ -871,12 +871,12 @@ class TestDockerSandboxStop:
         assert container.stopped == 1
         assert container.removed == 0
 
-    def test_stop_with_remove_deletes_the_container(self):
+    def test_stop_with_purge_deletes_the_container(self):
         sandbox = _sandbox(container_name="reusable")
         container = TestDockerSandboxLiveness._Container()
         sandbox._container = container
 
-        sandbox.stop(remove=True)
+        sandbox.stop(purge=True)
 
         assert container.stopped == 1
         assert container.removed == 1
@@ -893,10 +893,67 @@ class TestDockerSandboxStop:
         sandbox = _sandbox()
         sandbox._container = Hostile()
 
-        sandbox.stop(remove=True)
-        sandbox.stop(remove=True)
+        sandbox.stop(purge=True)
+        sandbox.stop(purge=True)
 
         assert sandbox._container is None
+
+    def test_purge_is_what_every_other_sandbox_calls_it(self):
+        """One signature across the sandboxes, which is the point of the rename.
+
+        A caller holding "a sandbox" could not call `stop` without knowing which
+        it had: this one took `remove`, `RemoteSandbox` takes `purge`, and
+        `DaytonaSandbox` took nothing at all. Passing the wrong one raised a
+        `TypeError` from inside a teardown that was already wrapped in a broad
+        `except`, so the call that should have released the container was the one
+        that failed - silently.
+        """
+        removed: list[bool] = []
+
+        class Recording(TestDockerSandboxLiveness._Container):
+            def remove(self, force: bool = False) -> None:
+                removed.append(force)
+
+        sandbox = _sandbox()
+        sandbox._container = Recording()
+
+        sandbox.stop(purge=True)
+
+        assert removed == [True]
+
+    def test_the_old_name_still_works_and_says_it_is_going(self):
+        """`remove=` is honoured rather than broken: this is a patch release, and
+        somebody's teardown is calling it."""
+        removed: list[bool] = []
+
+        class Recording(TestDockerSandboxLiveness._Container):
+            def remove(self, force: bool = False) -> None:
+                removed.append(force)
+
+        sandbox = _sandbox()
+        sandbox._container = Recording()
+
+        with pytest.warns(DeprecationWarning, match="pass purge="):
+            sandbox.stop(remove=True)
+
+        assert removed == [True]
+
+    def test_the_old_name_can_also_ask_for_the_container_to_be_kept(self):
+        """`remove=False` is an explicit choice, not an absent one - so it must not
+        read as "no opinion" and fall through to `purge`'s default."""
+        removed: list[bool] = []
+
+        class Recording(TestDockerSandboxLiveness._Container):
+            def remove(self, force: bool = False) -> None:
+                removed.append(force)
+
+        sandbox = _sandbox()
+        sandbox._container = Recording()
+
+        with pytest.warns(DeprecationWarning):
+            sandbox.stop(purge=True, remove=False)
+
+        assert removed == []
 
 
 class TestDockerSandboxResourceUsage:

--- a/tests/test_policy_updates.py
+++ b/tests/test_policy_updates.py
@@ -1,0 +1,451 @@
+"""Changing the ceilings without a restart, and refusing to change anything else.
+
+An operator running `sandboxd` for several teams had about thirty knobs reachable
+only through the environment — and a restart drops every resident sandbox, so
+raising one memory ceiling ended every conversation on the host.
+
+Two ways in now, and the tests that matter most are the refusals.
+`CreateSessionRequest` carries no container settings because a process holding the
+Docker socket can start a privileged container that mounts the host; that reasoning
+does not stop applying because the caller holds the service token. In a
+multi-tenant deployment the token is held by an application, per tenant, and an
+organization's administrator is not the person who runs the host.
+
+So: ceilings and lifetimes are writable. Images, mounts, `network_mode`,
+`oci_runtime`, `sandbox_uid` and `work_dir` are not, and an attempt to send one is
+a refusal that names the field rather than a silently ignored key.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pydantic_ai_backends.remote import wire
+from pydantic_ai_backends.remote.server import (
+    POLICY_SCALARS,
+    PolicyOverridesWatcher,
+    PolicyUpdateError,
+    SandboxdConfig,
+    SandboxRuntime,
+    apply_policy_update,
+    load_policy_overrides,
+)
+
+
+def config(**overrides: object) -> SandboxdConfig:
+    return SandboxdConfig(
+        token="service-token",
+        runtimes={
+            "coding": SandboxRuntime(image="python:3.12", network_mode="bridge"),
+            "locked": SandboxRuntime(image="python:3.12-slim", mem_limit="256m"),
+        },
+        default_runtime="coding",
+        **overrides,  # type: ignore[arg-type]
+    )
+
+
+class TestWhatMayChange:
+    def test_a_service_wide_ceiling_is_written_and_reported(self) -> None:
+        live = config(mem_limit="512m")
+
+        changed = apply_policy_update(live, wire.PolicyUpdate(mem_limit="1g"))
+
+        assert live.mem_limit == "1g"
+        assert changed == ["mem_limit"]
+
+    def test_a_lifetime_is_a_ceiling_too(self) -> None:
+        live = config()
+
+        apply_policy_update(live, wire.PolicyUpdate(workspace_ttl=3600, idle_timeout=60))
+
+        assert live.workspace_ttl == 3600
+        assert live.idle_timeout == 60
+
+    def test_one_runtimes_ceilings_can_be_raised(self) -> None:
+        live = config()
+
+        changed = apply_policy_update(
+            live, wire.PolicyUpdate(runtimes={"locked": wire.RuntimeLimitsUpdate(mem_limit="2g")})
+        )
+
+        assert live.runtimes["locked"].mem_limit == "2g"  # type: ignore[union-attr]
+        assert changed == ["runtimes.locked.mem_limit"]
+
+    def test_a_runtime_stored_as_a_bare_image_string_still_takes_ceilings(self) -> None:
+        """The allowlist may hold a plain string, which `_as_runtime` turns into a
+        fresh object — so without writing it back the change would land on a
+        temporary nobody else ever sees."""
+        live = config()
+        live.runtimes["bare"] = "python:3.12"  # type: ignore[assignment]
+
+        apply_policy_update(
+            live, wire.PolicyUpdate(runtimes={"bare": wire.RuntimeLimitsUpdate(cpus=2.0)})
+        )
+
+        assert live.runtimes["bare"].cpus == 2.0  # type: ignore[union-attr]
+
+    def test_the_default_runtime_can_be_switched_between_allowed_ones(self) -> None:
+        live = config()
+
+        apply_policy_update(live, wire.PolicyUpdate(default_runtime="locked"))
+
+        assert live.default_runtime == "locked"
+
+    def test_absent_means_leave_it_alone(self) -> None:
+        """An operator raising one ceiling must not have to restate the other
+        twenty — and `None` is a meaningful value for most of these, so a model
+        that could not tell absent from null would wipe one every time."""
+        live = config(mem_limit="512m", cpus=1.5)
+
+        apply_policy_update(live, wire.PolicyUpdate(pids_limit=256))
+
+        assert live.mem_limit == "512m"
+        assert live.cpus == 1.5
+
+    def test_null_is_distinguishable_from_absent(self) -> None:
+        """Explicitly clearing a ceiling is a thing an operator may want: `None` on
+        `memswap_limit` pins swap to memory."""
+        live = config(memswap_limit="1g")
+
+        apply_policy_update(live, wire.PolicyUpdate.model_validate({"memswap_limit": None}))
+
+        assert live.memswap_limit is None
+
+    def test_asking_for_what_is_already_true_changes_nothing(self) -> None:
+        """Reported as no change rather than as a change, so a log line means
+        something actually moved."""
+        live = config(mem_limit="512m")
+
+        assert apply_policy_update(live, wire.PolicyUpdate(mem_limit="512m")) == []
+
+
+class TestWhatMayNot:
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "network_mode",
+            "oci_runtime",
+            "sandbox_uid",
+            "work_dir",
+            "workspace_root",
+            "persist_containers",
+            "prewarm",
+            "runtime",
+            "image",
+            "volumes",
+            "mounts",
+            "devices",
+            "privileged",
+        ],
+    )
+    def test_nothing_that_decides_isolation_is_even_accepted(self, field: str) -> None:
+        """`extra="forbid"`, so this is a 422 naming the field rather than a key
+        quietly dropped — an operator who tries to widen the network gets told no,
+        instead of believing they have."""
+        with pytest.raises(ValueError, match=field):
+            wire.PolicyUpdate.model_validate({field: "anything"})
+
+    def test_a_runtime_cannot_be_given_an_image_through_its_ceilings(self) -> None:
+        """The door this endpoint is not. What a runtime *is* stays the daemon's."""
+        with pytest.raises(ValueError, match="image"):
+            wire.RuntimeLimitsUpdate.model_validate({"image": "evil:latest"})
+
+    def test_an_unknown_runtime_is_refused_rather_than_created(self) -> None:
+        live = config()
+
+        with pytest.raises(PolicyUpdateError, match="Unknown runtime 'invented'"):
+            apply_policy_update(
+                live,
+                wire.PolicyUpdate(runtimes={"invented": wire.RuntimeLimitsUpdate(cpus=8.0)}),
+            )
+
+        assert "invented" not in live.runtimes
+
+    def test_an_unknown_default_runtime_is_refused(self) -> None:
+        live = config()
+
+        with pytest.raises(PolicyUpdateError, match="Unknown runtime 'nope'"):
+            apply_policy_update(live, wire.PolicyUpdate(default_runtime="nope"))
+
+        assert live.default_runtime == "coding"
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("cpus", 0), ("cpu_shares", 0), ("pids_limit", 0), ("execute_timeout", 0)],
+    )
+    def test_a_ceiling_of_zero_where_zero_is_meaningless_is_refused(
+        self, field: str, value: int
+    ) -> None:
+        """Zero CPUs is not a tighter ceiling, it is a sandbox that cannot run.
+        Refused at the model so it never reaches the daemon."""
+        with pytest.raises(ValueError):
+            wire.PolicyUpdate.model_validate({field: value})
+
+    def test_the_writable_list_and_the_model_agree(self) -> None:
+        """Two places on purpose, so widening the wire shape is not the same act as
+        widening what gets written — and this fails if somebody does one without
+        the other.
+        """
+        modelled = set(wire.PolicyUpdate.model_fields) - {"default_runtime", "runtimes"}
+
+        assert modelled == set(POLICY_SCALARS)
+
+
+class TestTheEndpoint:
+    def test_a_ceiling_is_changed_and_the_whole_policy_comes_back(self, tmp_path) -> None:
+        """The whole policy rather than an acknowledgement, so a caller sees what is
+        in force including the fields it did not touch."""
+        from tests.test_remote_sandbox import SERVICE_TOKEN, Harness
+
+        harness = Harness(workspace_root=str(tmp_path))
+        with harness.client() as client:
+            answer = client.put(
+                "/policy",
+                json={"mem_limit": "1g", "workspace_ttl": 7200},
+                headers={wire.TOKEN_HEADER: SERVICE_TOKEN},
+            )
+
+            assert answer.status_code == 200
+            assert answer.json()["mem_limit"] == "1g"
+            assert answer.json()["workspace_ttl"] == 7200
+            # Still there, which is the point of answering with all of it.
+            assert answer.json()["work_dir"] != ""
+
+    def test_it_needs_the_service_token(self, tmp_path) -> None:
+        """The ceilings are the host's. Reading them is already authenticated;
+        writing them cannot be less so."""
+        from tests.test_remote_sandbox import Harness
+
+        harness = Harness(workspace_root=str(tmp_path))
+        with harness.client() as client:
+            assert client.put("/policy", json={"mem_limit": "1g"}).status_code == 401
+
+    def test_an_unknown_runtime_is_a_bad_request_not_a_crash(self, tmp_path) -> None:
+        from tests.test_remote_sandbox import SERVICE_TOKEN, Harness
+
+        harness = Harness(workspace_root=str(tmp_path))
+        with harness.client() as client:
+            answer = client.put(
+                "/policy",
+                json={"default_runtime": "nope"},
+                headers={wire.TOKEN_HEADER: SERVICE_TOKEN},
+            )
+
+        assert answer.status_code == 400
+        assert "Unknown runtime" in answer.json()["detail"]
+
+    def test_a_forbidden_field_is_refused_by_name(self, tmp_path) -> None:
+        from tests.test_remote_sandbox import SERVICE_TOKEN, Harness
+
+        harness = Harness(workspace_root=str(tmp_path))
+        with harness.client() as client:
+            answer = client.put(
+                "/policy",
+                json={"network_mode": "host"},
+                headers={wire.TOKEN_HEADER: SERVICE_TOKEN},
+            )
+
+        assert answer.status_code == 422
+        assert "network_mode" in answer.text
+
+
+class TestTheOverridesFile:
+    def test_it_is_applied_when_it_is_there(self, tmp_path) -> None:
+        live = config(mem_limit="512m")
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"mem_limit": "4g", "max_sessions": 5}))
+
+        changed = load_policy_overrides(live, path)
+
+        assert live.mem_limit == "4g"
+        assert live.max_sessions == 5
+        assert sorted(changed) == ["max_sessions", "mem_limit"]
+
+    def test_an_absent_file_is_the_normal_state(self, tmp_path) -> None:
+        """The setting exists so an operator can drop one in later, so its absence
+        cannot be an error."""
+        live = config()
+
+        assert load_policy_overrides(live, tmp_path / "nothing.json") == []
+
+    def test_malformed_json_is_logged_and_the_previous_value_kept(self, tmp_path) -> None:
+        """A mistyped ceiling must not stop a running service or prevent one from
+        starting — that would take every resident sandbox with it."""
+        live = config(mem_limit="512m")
+        path = tmp_path / "policy.json"
+        path.write_text("{not json")
+
+        assert load_policy_overrides(live, path) == []
+        assert live.mem_limit == "512m"
+
+    def test_a_forbidden_field_in_the_file_is_ignored_not_obeyed(self, tmp_path) -> None:
+        """The same writable set as the endpoint, which is the whole reason both go
+        through one function: a deployment that chose the file over the endpoint
+        does not get a wider door for having chosen it."""
+        live = config()
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"network_mode": "host"}))
+
+        assert load_policy_overrides(live, path) == []
+        assert live.network_mode != "host"
+
+    def test_an_unknown_runtime_in_the_file_is_ignored(self, tmp_path) -> None:
+        live = config()
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"runtimes": {"invented": {"cpus": 8.0}}}))
+
+        assert load_policy_overrides(live, path) == []
+        assert "invented" not in live.runtimes
+
+    def test_a_file_that_cannot_be_read_is_logged_not_raised(self, tmp_path) -> None:
+        live = config()
+        directory = tmp_path / "policy.json"
+        directory.mkdir()
+
+        assert load_policy_overrides(live, directory) == []
+
+
+class TestTheWatcher:
+    def test_it_reads_the_file_once_and_then_only_on_a_change(self, tmp_path) -> None:
+        live = config(mem_limit="512m")
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"mem_limit": "1g"}))
+        watcher = PolicyOverridesWatcher(live, path)
+
+        assert watcher.poll() == ["mem_limit"]
+        assert watcher.poll() == []
+
+    def test_it_notices_an_edit(self, tmp_path) -> None:
+        live = config(mem_limit="512m")
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"mem_limit": "1g"}))
+        watcher = PolicyOverridesWatcher(live, path)
+        watcher.poll()
+
+        # The mtime is what it watches, and a same-second rewrite can land on the
+        # same value — so it is moved explicitly rather than by writing quickly.
+        path.write_text(json.dumps({"mem_limit": "2g"}))
+        import os
+
+        stamp = path.stat().st_mtime + 10
+        os.utime(path, (stamp, stamp))
+
+        assert watcher.poll() == ["mem_limit"]
+        assert live.mem_limit == "2g"
+
+    def test_an_absent_file_polls_to_nothing(self, tmp_path) -> None:
+        live = config()
+        watcher = PolicyOverridesWatcher(live, tmp_path / "nothing.json")
+
+        assert watcher.poll() == []
+
+    def test_a_deleted_file_is_left_alone_rather_than_reverted(self, tmp_path) -> None:
+        """Reverting would mean remembering the environment's values and putting
+        them back, which is a second source of truth. The honest reading of a
+        deleted overrides file is "stop overriding from here", which is a restart.
+        """
+        live = config(mem_limit="512m")
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"mem_limit": "1g"}))
+        watcher = PolicyOverridesWatcher(live, path)
+        watcher.poll()
+
+        path.unlink()
+
+        assert watcher.poll() == []
+        assert live.mem_limit == "1g"
+
+    def test_no_file_configured_builds_no_watcher(self) -> None:
+        """So the sweep loop skips even the `stat` for every deployment not using
+        it, which is all of them by default."""
+        from pydantic_ai_backends.remote.server import _Service
+
+        service = _Service(config(), lambda session_id, runtime: None)
+
+        assert service._policy_watcher is None
+
+
+class TestNothingToDo:
+    """The "already true" paths, which are what makes a log line mean something."""
+
+    def test_setting_the_default_runtime_to_what_it_is_reports_no_change(self) -> None:
+        live = config()
+
+        assert apply_policy_update(live, wire.PolicyUpdate(default_runtime="coding")) == []
+
+    def test_a_runtimes_update_that_matches_reports_no_change(self) -> None:
+        live = config()
+
+        changed = apply_policy_update(
+            live,
+            wire.PolicyUpdate(runtimes={"locked": wire.RuntimeLimitsUpdate(mem_limit="256m")}),
+        )
+
+        assert changed == []
+
+    def test_an_overrides_file_that_matches_reports_no_change(self, tmp_path) -> None:
+        live = config(mem_limit="512m")
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"mem_limit": "512m"}))
+
+        assert load_policy_overrides(live, path) == []
+
+    def test_a_put_that_changes_nothing_still_answers_with_the_policy(self, tmp_path) -> None:
+        from tests.test_remote_sandbox import SERVICE_TOKEN, Harness
+
+        harness = Harness(workspace_root=str(tmp_path))
+        with harness.client() as client:
+            answer = client.put(
+                "/policy",
+                json={"default_runtime": harness.config.default_runtime},
+                headers={wire.TOKEN_HEADER: SERVICE_TOKEN},
+            )
+
+        assert answer.status_code == 200
+        assert answer.json()["default_runtime"] == harness.config.default_runtime
+
+
+class TestTheServiceReadsTheFile:
+    def test_startup_applies_it_before_anything_is_served(self, tmp_path) -> None:
+        """So the first session is held to the ceilings the file names, rather than
+        to the environment's for one whole cleanup interval."""
+        from tests.test_remote_sandbox import Harness
+
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"mem_limit": "3g"}))
+        harness = Harness(workspace_root=str(tmp_path), policy_overrides=str(path))
+
+        with harness.client():
+            assert harness.config.mem_limit == "3g"
+
+    @pytest.mark.anyio
+    async def test_the_sweep_loop_notices_a_later_edit(self, tmp_path) -> None:
+        """An edit after startup is the case the watcher exists for - and it is
+        applied before the sweep, so a ceiling raised in the file is in force for
+        that pass rather than the next one."""
+        import asyncio
+        import os
+
+        from tests.test_remote_sandbox import Harness, _wait_until
+
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps({"mem_limit": "1g"}))
+        harness = Harness(
+            workspace_root=str(tmp_path), policy_overrides=str(path), cleanup_interval=0
+        )
+        service = harness.app.state.service
+        service.startup()
+        try:
+            assert harness.config.mem_limit == "1g"
+
+            path.write_text(json.dumps({"mem_limit": "5g"}))
+            stamp = path.stat().st_mtime + 10
+            os.utime(path, (stamp, stamp))
+
+            task = asyncio.create_task(service._sweep_loop())
+            assert await _wait_until(lambda: harness.config.mem_limit == "5g")
+            task.cancel()
+        finally:
+            await service.shutdown()

--- a/tests/test_remote_sandbox.py
+++ b/tests/test_remote_sandbox.py
@@ -1887,6 +1887,14 @@ class TestWorkspaceArchiveRoutes:
             assert wire.ReadResponse.model_validate(response.json()).content == "[End of file]"
 
 
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+)
+"""A one-pixel PNG. Bytes that do not survive being decoded as text, which is
+the whole reason `read_bytes` exists."""
+
+
 class TestWorkspaceArchiveClient:
     """The typed client raises, because no model is waiting on it."""
 
@@ -1898,14 +1906,73 @@ class TestWorkspaceArchiveClient:
         workspace = tmp_path / "cold" / "workspace"
         workspace.mkdir(parents=True)
         (workspace / "notes.md").write_text("kept\n")
+        # A real PNG header, because the point of `read_bytes` is the files that
+        # are not text - and "it round-trips" is only meaningful for bytes that
+        # would not have survived a decode.
+        (workspace / "chart.png").write_bytes(PNG_BYTES)
         with harness.client() as client:
             yield WorkspaceArchive(token=SERVICE_TOKEN, client=client)
 
     def test_ls_returns_file_infos(self, archive):
-        assert [row["name"] for row in archive.ls("cold")] == ["notes.md"]
+        assert [row["name"] for row in archive.ls("cold")] == ["chart.png", "notes.md"]
 
     def test_read_returns_the_content(self, archive):
         assert archive.read("cold", "notes.md") == "kept"
+
+    def test_read_bytes_serves_a_file_a_decode_would_have_ruined(self, archive):
+        """The acceptance criterion from the issue: the first four bytes are a PNG.
+
+        `read` decodes and re-encodes, which for a PNG yields a file that
+        downloads successfully and will not open - the worst available outcome, so
+        a consumer serving downloads had to allowlist text suffixes and refuse the
+        one thing an agent is most likely to have made.
+        """
+        raw = archive.read_bytes("cold", "chart.png")
+
+        assert raw == PNG_BYTES
+        assert raw[:4] == b"\x89PNG"
+
+    def test_read_bytes_reads_text_faithfully_too(self, archive):
+        """No suffix allowlist anywhere in it: bytes are bytes, and a caller that
+        wants the decoded, sliced, line-numbered form calls `read`."""
+        assert archive.read_bytes("cold", "notes.md") == b"kept\n"
+
+    def test_read_bytes_raises_for_a_missing_file(self, archive):
+        from pydantic_ai_backends.remote import WorkspaceArchiveError
+
+        with pytest.raises(WorkspaceArchiveError) as excinfo:
+            archive.read_bytes("cold", "nothing.png")
+
+        assert excinfo.value.status_code == 404
+
+    def test_read_bytes_refuses_a_file_over_the_services_read_ceiling(self, tmp_path):
+        """The ceiling is the service's, not the caller's: `read_bytes` returns a
+        whole file, so without it a caller could ask the daemon to hold an
+        arbitrarily large one in memory on their behalf."""
+        from pydantic_ai_backends.remote import WorkspaceArchive, WorkspaceArchiveError
+
+        harness = Harness(workspace_root=str(tmp_path), max_read_bytes=8)
+        workspace = tmp_path / "cold" / "workspace"
+        workspace.mkdir(parents=True)
+        (workspace / "big.png").write_bytes(PNG_BYTES)
+
+        with harness.client() as client:
+            archive = WorkspaceArchive(token=SERVICE_TOKEN, client=client)
+            with pytest.raises(WorkspaceArchiveError) as excinfo:
+                archive.read_bytes("cold", "big.png")
+
+        assert excinfo.value.status_code == 400
+        assert "read limit" in str(excinfo.value)
+
+    def test_read_bytes_refuses_a_path_outside_the_workspace(self, archive):
+        """The archive reads the host volume directly, so this is the one that
+        matters: a session id and a path are both attacker-shaped."""
+        from pydantic_ai_backends.remote import WorkspaceArchiveError
+
+        with pytest.raises(WorkspaceArchiveError) as excinfo:
+            archive.read_bytes("cold", "../../etc/passwd")
+
+        assert excinfo.value.status_code == 400
 
     def test_a_missing_workspace_raises_with_the_status(self, archive):
         from pydantic_ai_backends.remote import WorkspaceArchiveError

--- a/tests/test_sandbox_stop_contract.py
+++ b/tests/test_sandbox_stop_contract.py
@@ -1,0 +1,87 @@
+"""One signature for `stop`, across every sandbox that has one.
+
+Ending a sandbox is one idea, and it used to have three spellings:
+`RemoteSandbox.stop(purge=False)`, `DockerSandbox.stop(remove=False)`, and
+`DaytonaSandbox.stop()` / `KubernetesPodSandbox.stop()` taking nothing at all. A
+caller holding "a sandbox" could not call it without knowing which one it had:
+
+    >>> stop = getattr(sandbox, "stop")
+    >>> stop(purge=True)
+    TypeError: DaytonaSandbox.stop() got an unexpected keyword argument 'purge'
+
+The failure was quiet in the worst possible place. Teardown is best-effort and
+normally sits inside a broad `except`, so the `TypeError` was swallowed and
+logged - and the call that would have released the resource was the one that
+raised. In AgenticOS that meant a Daytona sandbox was never deleted on any path:
+once per run, on the customer's own cloud account, until somebody read the bill.
+
+So this file asserts the *shape* rather than any one backend's behaviour, which
+is what the individual test modules already cover. A backend added later fails
+here the moment it invents a fourth spelling.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from pydantic_ai_backends.backends.base import AsyncBaseSandbox, BaseSandbox
+from pydantic_ai_backends.backends.daytona import DaytonaSandbox
+from pydantic_ai_backends.backends.docker.sandbox import DockerSandbox
+from pydantic_ai_backends.backends.kubernetes import KubernetesPodSandbox
+from pydantic_ai_backends.remote.client import RemoteSandbox
+
+STOPPABLE = [
+    BaseSandbox,
+    AsyncBaseSandbox,
+    DaytonaSandbox,
+    DockerSandbox,
+    KubernetesPodSandbox,
+    RemoteSandbox,
+]
+
+
+@pytest.mark.parametrize("sandbox_type", STOPPABLE, ids=lambda cls: cls.__name__)
+def test_stop_takes_purge_and_defaults_to_keeping_what_it_holds(sandbox_type: type) -> None:
+    """Every `stop` accepts `purge`, and every one of them defaults to False.
+
+    The default matters as much as the name. `stop()` with no argument is what a
+    turn ending calls, and it must not discard files the next turn is meant to
+    find - so a backend that defaulted to purging would silently lose work for a
+    caller that had done nothing wrong.
+    """
+    parameters = inspect.signature(sandbox_type.stop).parameters
+
+    assert "purge" in parameters, f"{sandbox_type.__name__}.stop has no `purge`"
+    assert parameters["purge"].default is False
+
+
+@pytest.mark.parametrize("sandbox_type", STOPPABLE, ids=lambda cls: cls.__name__)
+def test_stop_can_be_called_with_purge_by_keyword(sandbox_type: type) -> None:
+    """`purge` is reachable by name, which is how a generic caller passes it.
+
+    Positionally it would work by accident on some of these and not others; the
+    call that broke was `stop(purge=True)`.
+    """
+    parameters = inspect.signature(sandbox_type.stop).parameters
+
+    assert parameters["purge"].kind in {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }
+
+
+def test_nothing_still_spells_it_remove() -> None:
+    """`DockerSandbox` is the one that used to, and keeps it only as an alias.
+
+    Honoured rather than removed, because this is a patch release and somebody's
+    teardown passes it - but it warns, and it is the only place the old name is
+    allowed to appear.
+    """
+    for sandbox_type in STOPPABLE:
+        parameters = inspect.signature(sandbox_type.stop).parameters
+        if sandbox_type is DockerSandbox:
+            assert parameters["remove"].default is None
+            continue
+        assert "remove" not in parameters, f"{sandbox_type.__name__}.stop still takes `remove`"


### PR DESCRIPTION
Closes #95, #96, #97, #98 — the four open issues, one commit each.

## #97 — a ruleset's per-path rules reached nothing

A `PermissionRuleset` handed to `ConsoleCapability` reached `requires_approval` (the approval flags) and `_denied_tools` (drop a tool whose *operation* defaults to deny). Nothing read `OperationPermissions.rules`. So the shape a caller writes when they want "allow the workspace, deny credentials and the system tree" was no enforcement at all:

```
read_file  /.env            -> 'OPENAI_API_KEY=sk-live-secret'
read_file  /etc/passwd      -> 'root:x:0:0'
write_file /sub/.env        -> 'Wrote 1 lines to /sub/.env'
grep       PASSWORD         -> matched /credentials.txt, with the line
```

Which is worse than rejecting the ruleset, because it looks like a working boundary. `PermissionChecker` answered correctly the whole time; it was never asked.

`PermissionGuard` has been here since `LocalBackend` needed it and only `LocalBackend` ever used it. `GuardedBackend` puts it on any backend, applied in `backend_for` — the one place every tool resolves its backend, which is what makes the cover total rather than a list somebody has to remember to extend. `guarding` returns the backend untouched when there is no ruleset or when it enforces one of its own, so **every existing caller behaves exactly as before**.

`grep_raw` is filtered rather than refused: `GrepMatch` carries the matching *line*, so an unfiltered grep hands over the contents of the very files the rules protect. `ls`/`glob` filter on their own rules and deliberately not on `read`, matching `LocalBackend` — documented, with a test pinning it.

Two things found writing it:

- `command_path_targets` resolved a path before matching, and `resolve()` follows symlinks — so on macOS `/etc/passwd` became `/private/etc/passwd` and a rule reading `/etc/**` matched nothing. Any symlinked directory does the same anywhere. Both forms are matched now, which can only deny more.
- `execute` is reached through `__getattr__` rather than declared. The toolset asks `hasattr(backend, "execute")` to decide whether to answer "Backend does not support command execution"; a declared method would make that true for a `StateBackend`, turning a friendly answer into a raise.

## #98 — `stop` had three signatures

`RemoteSandbox.stop(purge=False)`, `DockerSandbox.stop(remove=False)`, and `DaytonaSandbox.stop()` / `KubernetesPodSandbox.stop()` / `BaseSandbox.stop()` taking nothing. A caller holding "a sandbox" could not call it:

```
TypeError: DaytonaSandbox.stop() got an unexpected keyword argument 'purge'
```

Quiet in the worst place — teardown sits in a broad `except`, so the call that should have released the resource was the one that raised. In AgenticOS that meant a Daytona sandbox was never deleted on any path, once per run, on the customer's own cloud account.

`purge` everywhere, defaulting to `False` everywhere — the default matters as much as the name, since `stop()` is what a turn ending calls and must not discard files the next turn expects. Daytona and Kubernetes accept it and document that it makes no difference to them.

**Not breaking:** `stop()` works everywhere it did, and `DockerSandbox.stop(remove=...)` still works and warns. `test_sandbox_stop_contract.py` asserts the shape, so a backend added later fails the moment it invents a fourth spelling.

## #96 — the archive could only read text

`WorkspaceArchive.read` returns `str`, so a chart, a rendered PDF or an image came back decoded and re-encoded: a corrupt file that downloads successfully, which is worse than an error. Consumers had to allowlist text suffixes and refuse everything an agent is most likely to have produced — so the container backend, the one you would use for real work, was the one whose outputs could not be fetched.

`read_bytes` on the client, `POST /workspaces/{id}/read_bytes` on the service, reusing the `ReadBytesRequest`/`ReadBytesResponse` pair the live-session route already had. The service's `max_read_bytes` still applies, and that is the ceiling that matters: it returns a whole file. Tests cover the issue's own criterion (first four bytes `\x89PNG`) plus the two refusals worth having on a route that reads the host volume — a path escaping the workspace, and a file over the ceiling.

## #95 — no way to change the ceilings without a restart

Both shapes the issue offered, because they answer different questions. `PUT /policy` is what an operator screen sits on; `SANDBOXD_POLICY_OVERRIDES` is the same thing for a deployment that would rather not expose a write endpoint.

**One source of truth with two entrances, not two paths.** Both call `apply_policy_update` — the only place that validates, the only place that writes. Two implementations of "what may change" would drift, and the one that drifted wider would be the security hole.

Ceilings and lifetimes are writable. The refusals are the point:

| Refused | Because |
|---|---|
| `runtimes` membership | Adding an alias means naming an image |
| `network_mode` | `host` is not a ceiling, it is an escape |
| `oci_runtime` | The same, one level lower |
| `sandbox_uid` | 0 is root |
| `work_dir` | Where the workspace volume mounts and the archive reads |
| `persist_containers`, `prewarm` | Startup shape, not ceilings |

`CreateSessionRequest` carries no container settings because a process holding the Docker socket can start a privileged container that mounts the host, and that reasoning does not stop applying because the caller holds the service token: the token is held per tenant by an application, and an organization's administrator is not the person who runs the host.

`extra="forbid"`, so one of those is a 422 naming the field rather than a key quietly dropped. An unknown alias is a 400 — refused, never created. Absent means "leave it alone", because `None` is meaningful for most of these and a model that could not tell absent from null would wipe a ceiling every time somebody changed a different one.

A change applies to the **next** sandbox; Docker sets the ceiling on the container, so one already resident keeps what it was created with. Documented rather than worked around.

A malformed overrides file is logged and ignored — an operator who mistypes a ceiling should get a log line, not a daemon that will not boot and takes every resident sandbox with it. A deleted one is left alone rather than reverted, since reverting means keeping a second copy of the environment's values.

## Verified

1664 tests pass, **100% coverage**, `ruff`, `pyright` and `mypy` all clean.

Worth saying where the verification reaches and where it does not: the remote tests drive the real ASGI app through `TestClient`, so the routes, the wire models and the archive are exercised for real. The Docker and Daytona paths are fakes, as they were before — `test_sandbox_stop_contract.py` is written against the real classes' signatures precisely because a fake cannot catch a signature drift.

Three things deliberately not done:

- `runtimes` membership stays read-only. The issue asked for "the runtime allowlist and per-alias ceilings", and the allowlist cannot be writable without letting a caller name an image — which the same issue asks to reject. Ceilings per alias are writable; the aliases are not.
- `ls`/`glob` still show the name of a file whose contents are denied. Changing that is a behaviour change for `LocalBackend` too, and a listing that hid a file `exists` reports would send an agent rewriting one it cannot read.
- Commands are not filtered by pattern. `execute_denial_reason` catches path arguments, and that is defence in depth — real isolation is the container's.