### PR TITLE
feat: report a file's modified time through every listing that can

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -15,6 +15,7 @@ file_info: FileInfo = {
     "path": "/workspace/app.py",
     "is_dir": False,
     "size": 1234,
+    "modified_at": "2026-08-16T12:00:00+00:00",  # absent when the backend cannot report one
 }
 ```
 

--- a/src/pydantic_ai_backends/_time.py
+++ b/src/pydantic_ai_backends/_time.py
@@ -1,0 +1,15 @@
+"""Timestamp rendering shared by the filesystem-backed listings.
+
+One function so `FileInfo.modified_at` is the same shape everywhere it is
+filled from a stat: ISO 8601, UTC, matching what `StateBackend` records on
+write.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def iso_mtime(epoch: float) -> str:
+    """Render a `st_mtime` epoch as an ISO 8601 UTC timestamp."""
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()

--- a/src/pydantic_ai_backends/backends/kubernetes.py
+++ b/src/pydantic_ai_backends/backends/kubernetes.py
@@ -587,4 +587,7 @@ def _to_file_info(row: dict[str, Any]) -> FileInfo:
         path=row.get("path", ""),
         is_dir=bool(row.get("is_dir", False)),
         size=row.get("size"),
+        # The in-pod server ships with the user's image, so an older one simply
+        # does not send this yet.
+        modified_at=row.get("modified_at"),
     )

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from pydantic_ai_backends._editing import Replacement, replace_in_content
 from pydantic_ai_backends._limits import DEFAULT_READ_LIMIT, MAX_EXECUTE_OUTPUT_BYTES
+from pydantic_ai_backends._time import iso_mtime
 from pydantic_ai_backends.backends._background import BackgroundProcesses
 from pydantic_ai_backends.backends._guard import PermissionGuard
 from pydantic_ai_backends.types import (
@@ -428,7 +429,13 @@ class LocalBackend:
                     # and worse than an error. `ls_info` and grep both skip and
                     # carry on; this now matches them.
                     continue
-                info = FileInfo(name=match.name, path=str(match), is_dir=False, size=stat.st_size)
+                info = FileInfo(
+                    name=match.name,
+                    path=str(match),
+                    is_dir=False,
+                    size=stat.st_size,
+                    modified_at=iso_mtime(stat.st_mtime),
+                )
                 collected.append((stat.st_mtime, str(match), info))
         except (PermissionError, OSError):
             # The walk itself failed, so there is nothing left to collect.
@@ -690,11 +697,14 @@ def _numbered_line(number: int, line: str) -> str:
 
 
 def _entry_info(path: Path) -> FileInfo:
+    stat = path.stat()
+    is_file = path.is_file()
     return FileInfo(
         name=path.name,
         path=str(path),
         is_dir=path.is_dir(),
-        size=path.stat().st_size if path.is_file() else None,
+        size=stat.st_size if is_file else None,
+        modified_at=iso_mtime(stat.st_mtime) if is_file else None,
     )
 
 

--- a/src/pydantic_ai_backends/backends/state.py
+++ b/src/pydantic_ai_backends/backends/state.py
@@ -336,4 +336,6 @@ def _file_entry(name: str, path: str, data: FileData) -> FileInfo:
         # count too: text is stored split on "\n" and rejoined on the way out,
         # so summing the lines alone reported one byte less per line.
         size=len(_content_bytes(data)),
+        # `.get`: a document persisted before the key existed loads without it.
+        modified_at=data.get("modified_at"),
     )

--- a/src/pydantic_ai_backends/remote/_workspace.py
+++ b/src/pydantic_ai_backends/remote/_workspace.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from pathlib import Path, PurePosixPath
 
 from pydantic_ai_backends._text import bytes_to_text
+from pydantic_ai_backends._time import iso_mtime
 from pydantic_ai_backends.types import FileInfo
 
 
@@ -103,10 +104,16 @@ def list_workspace(root: Path, path: str) -> list[FileInfo]:
             relative = str(entry.relative_to(resolved_root))
             target = resolve_within(root, relative)
             is_dir = target.is_dir()
-            size = None if is_dir else target.stat().st_size
+            stat = target.stat()
+            size = None if is_dir else stat.st_size
+            modified_at = None if is_dir else iso_mtime(stat.st_mtime)
         except (WorkspacePathError, ValueError, OSError):
             continue
-        entries.append(FileInfo(name=entry.name, path=relative, is_dir=is_dir, size=size))
+        entries.append(
+            FileInfo(
+                name=entry.name, path=relative, is_dir=is_dir, size=size, modified_at=modified_at
+            )
+        )
     return sorted(entries, key=lambda item: (not item["is_dir"], item["name"]))
 
 

--- a/src/pydantic_ai_backends/remote/client.py
+++ b/src/pydantic_ai_backends/remote/client.py
@@ -479,7 +479,10 @@ def _to_file_infos(response: Any) -> list[FileInfo]:
         entries = [wire.FileEntry.model_validate(row) for row in response.json()]
     except Exception:
         return []
-    return [FileInfo(name=e.name, path=e.path, is_dir=e.is_dir, size=e.size) for e in entries]
+    return [
+        FileInfo(name=e.name, path=e.path, is_dir=e.is_dir, size=e.size, modified_at=e.modified_at)
+        for e in entries
+    ]
 
 
 class WorkspaceArchiveError(Exception):
@@ -567,7 +570,12 @@ class WorkspaceArchive:
         payload = wire.LsRequest(path=path).model_dump(mode="json")
         response = self._post(f"/workspaces/{session_id}/ls", payload)
         entries = [wire.FileEntry.model_validate(row) for row in response.json()]
-        return [FileInfo(name=e.name, path=e.path, is_dir=e.is_dir, size=e.size) for e in entries]
+        return [
+            FileInfo(
+                name=e.name, path=e.path, is_dir=e.is_dir, size=e.size, modified_at=e.modified_at
+            )
+            for e in entries
+        ]
 
     def read(self, session_id: str, path: str, offset: int = 0, limit: int = 2000) -> str:
         """Read a slice of a stored workspace file.

--- a/src/pydantic_ai_backends/remote/wire.py
+++ b/src/pydantic_ai_backends/remote/wire.py
@@ -123,6 +123,9 @@ class FileEntry(BaseModel):
     path: str
     is_dir: bool
     size: int | None = None
+    modified_at: str | None = None
+    """ISO 8601, when the backend reports one. Defaults absent so a client and a
+    service on either side of this release keep understanding each other."""
 
 
 class GrepRequest(BaseModel):

--- a/src/pydantic_ai_backends/types.py
+++ b/src/pydantic_ai_backends/types.py
@@ -49,13 +49,27 @@ class FileData(_FileDataFields, total=False):
     """Present only when `content` holds base64 rather than lines of text."""
 
 
-class FileInfo(TypedDict):
-    """Information about a file or directory."""
+class _FileInfoFields(TypedDict):
+    """The keys every listing entry has. Split out so `modified_at` can be optional."""
 
     name: str
     path: str
     is_dir: bool
     size: int | None
+
+
+class FileInfo(_FileInfoFields, total=False):
+    """Information about a file or directory.
+
+    `modified_at` is an ISO 8601 timestamp, present when the backend can report
+    one: `StateBackend` records it on every write, filesystem-backed listings
+    take `st_mtime`, and the remote wire carries it end to end. A backend that
+    derives its listing from shell `ls` output has no reliable timestamp to
+    give, so the key is absent there — read it with `.get("modified_at")` and
+    treat a missing key as unknown, never as "just now".
+    """
+
+    modified_at: str | None
 
 
 @dataclass

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -85,6 +85,33 @@ class TestStateBackend:
         assert "file2.txt" in names
         assert "subdir" in names
 
+    def test_ls_info_reports_when_a_file_was_modified(self):
+        """A listing entry carries the timestamp the store records on write."""
+        backend = StateBackend()
+        backend.write("/dir/file.txt", "content")
+
+        entries = backend.ls_info("/dir")
+
+        assert entries[0]["modified_at"] == backend.files["/dir/file.txt"]["modified_at"]
+
+    def test_a_directory_entry_has_no_modified_time(self):
+        """Directories are synthesised from paths; there is nothing to date."""
+        backend = StateBackend()
+        backend.write("/dir/subdir/file.txt", "content")
+
+        (subdir,) = [e for e in backend.ls_info("/dir") if e["is_dir"]]
+
+        assert subdir.get("modified_at") is None
+
+    def test_a_document_from_before_the_timestamp_lists_none(self):
+        """A persisted document written by an older release loads without the key."""
+        legacy = {"/old.txt": {"content": ["hi"], "created_at": "2020-01-01T00:00:00+00:00"}}
+        backend = StateBackend(files=legacy)  # type: ignore[arg-type]  # the old shape, deliberately
+
+        (entry,) = backend.ls_info("/")
+
+        assert entry.get("modified_at") is None
+
     def test_glob_info(self):
         """Test glob pattern matching."""
         backend = StateBackend()

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -157,6 +158,19 @@ class TestLocalBackendFileOps:
         assert "file2.txt" in names
         assert "subdir" in names
 
+    def test_ls_info_reports_the_files_mtime(self, tmp_path: Path):
+        """A file's entry carries its `st_mtime` as ISO 8601 UTC; a directory's carries none."""
+        backend = LocalBackend(root_dir=tmp_path)
+        backend.write("file.txt", "a")
+        (tmp_path / "subdir").mkdir()
+
+        entries = {e["name"]: e for e in backend.ls_info(".")}
+
+        stat = (tmp_path / "file.txt").stat()
+        expected = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+        assert entries["file.txt"]["modified_at"] == expected
+        assert entries["subdir"]["modified_at"] is None
+
     def test_glob_info(self, tmp_path: Path):
         """Test finding files with glob pattern."""
         backend = LocalBackend(root_dir=tmp_path)
@@ -167,6 +181,7 @@ class TestLocalBackendFileOps:
 
         entries = backend.glob_info("*.py")
         assert len(entries) == 2
+        assert all(e["modified_at"] is not None for e in entries)
 
     def test_grep_raw(self, tmp_path: Path):
         """Test searching files with grep."""

--- a/tests/test_remote_sandbox.py
+++ b/tests/test_remote_sandbox.py
@@ -16,7 +16,7 @@ import threading
 import time
 import types
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -1730,6 +1730,28 @@ class TestWorkspaceArchiveRoutes:
             assert [(r.name, r.is_dir) for r in rows] == [("src", True), ("report.md", False)]
             # Nothing was started to answer that.
             assert harness.built == {}
+
+    def test_listing_reports_when_a_file_was_modified(self, stored):
+        """A stored file's row carries its mtime; a directory's carries none."""
+        harness, workspace = stored
+        with harness.client() as client:
+            response = client.post(
+                "/workspaces/cold/ls", json={"path": "."}, headers=_service_headers()
+            )
+
+            rows = {row["name"]: row for row in response.json()}
+            stat = (workspace / "report.md").stat()
+            expected = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+            assert rows["report.md"]["modified_at"] == expected
+            assert rows["src"]["modified_at"] is None
+
+    def test_a_row_from_an_older_service_still_validates(self):
+        """A service released before `modified_at` sends rows without it."""
+        entry = wire.FileEntry.model_validate(
+            {"name": "a.txt", "path": "a.txt", "is_dir": False, "size": 2}
+        )
+
+        assert entry.modified_at is None
 
     def test_reading_needs_no_container(self, stored):
         harness, _ = stored


### PR DESCRIPTION
`FileInfo` gains an optional `modified_at` (ISO 8601, UTC), so a listing can say when a file changed instead of stopping at its size. The consumer that needs it is vstorm-co/agenticos#500 — the shared file viewer's header reads `MD · 3 B · modified 2 minutes ago` for a knowledge-base document and stops at the size for a workspace file, because this library's listings had no time to give.

Filled where a real timestamp exists, absent where none does:

- **StateBackend** — `FileData` already records `modified_at` on every write; the listing now surfaces it. A document persisted before the key existed lists `None` rather than inventing a time.
- **LocalBackend** — `st_mtime`, on `ls` and `glob`. A directory entry carries `None`.
- **Stored workspace archives (sandboxd)** — `st_mtime` through the wire. `wire.FileEntry.modified_at` defaults to `None`, so a client and a service on either side of this release keep understanding each other; a row from an older service validates to `None`.
- **KubernetesPodSandbox (http mode)** — read from the in-pod server's row when it sends one.
- **Shell-derived listings (docker/daytona exec)** stay absent: `ls -la` output has no timestamp that survives locale, busybox and timezone, and a guessed time is worse than none. `FileInfo`'s docstring says to read the key with `.get()` and treat a missing one as unknown.

Additive only — the key is optional (`total=False`, matching the `FileData` split), so no existing constructor or consumer changes meaning.

Verified: 1670 tests, 100% coverage, ruff/pyright/mypy clean.
