### PR TITLE
fix: root a glob in the workspace, not in the machine

### DIFF
--- a/src/pydantic_ai_backends/backends/_shell.py
+++ b/src/pydantic_ai_backends/backends/_shell.py
@@ -151,15 +151,46 @@ def parse_write(result: ExecuteResponse, path: str) -> WriteResult:
     return WriteResult(path=path)
 
 
+ROOT_SPELLINGS = frozenset({"", "/", "."})
+"""The three ways a caller spells "the root of this backend".
+
+`normalize_path` collapses all three to `/` for a backend addressing files by
+virtual path, where `/` *is* the top of the namespace. A shell-backed one has a
+real filesystem under it and a working directory inside it, so the same three
+have to become `.` instead - see :func:`glob_command` for what passing `/`
+through cost.
+"""
+
+
 def glob_command(pattern: str, path: str) -> str:
-    """Match files with `find`.
+    """Match files with `find`, rooted where the caller's path means.
+
+    Two things to get right, and this got both wrong.
+
+    **The root.** A path naming the backend's root means the session's working
+    directory here, not the filesystem's. Passed through, `find /` read it as the
+    machine: a glob of `*` in a container answered 2540 paths from `/proc` and
+    `/usr` and not one from the workspace. So the agent's own search tool read
+    the image it was running on - into its context - and a channel's "what did
+    the agent write this turn" snapshot diffed two photographs of `/proc`.
+    Anything genuinely absolute is still passed through: `/etc` is a root a
+    caller may mean.
+
+    **Globstar.** `find -path` matches with fnmatch, where `**` is no different
+    from `*` and every `/` in the pattern must be present in the path. So `**/*`
+    - what anything walking a tree reaches for, including that snapshot - needed
+    two slashes and therefore missed every file at the top level. A leading
+    `**/` means "at any depth", which is exactly what the `*/` prefix below
+    already provides, so it is dropped rather than stacked.
 
     The pattern is matched as `-path '*/{pattern}'` so a basename glob like
     `*.py` matches files anywhere under the root, since `find -path` tests the
     whole pathname.
     """
-    quoted_path = shlex.quote(path)
-    quoted_pattern = shlex.quote(f"*/{pattern}")
+    root = "." if path.strip() in ROOT_SPELLINGS else path
+    anywhere = pattern[3:] if pattern.startswith("**/") else pattern
+    quoted_path = shlex.quote(root)
+    quoted_pattern = shlex.quote(f"*/{anywhere}")
     return f"find {quoted_path} -path {quoted_pattern} -type f 2>/dev/null"
 
 

--- a/tests/test_shell_commands.py
+++ b/tests/test_shell_commands.py
@@ -222,6 +222,32 @@ class TestGlob:
         assert "-path '*/*.py'" in command
         assert "-type f" in command
 
+    @pytest.mark.parametrize("root", ["", "/", "."])
+    def test_the_backend_s_root_is_the_working_directory(self, root: str):
+        """Not the machine's root, which is what `/` means to `find`.
+
+        A glob of `*` with `/` passed through answered 2540 paths from `/proc`
+        and `/usr` on a container and none from the workspace - so the agent's
+        own search tool read the image it runs on, and a channel's snapshot of
+        "what did the agent write" diffed two photographs of `/proc`.
+        """
+        assert _shell.glob_command("*.py", root).startswith("find . ")
+
+    def test_an_absolute_root_is_still_absolute(self):
+        # `/etc` is a root a caller may mean, and this is not the place to argue.
+        assert _shell.glob_command("*.conf", "/etc").startswith("find /etc ")
+
+    @pytest.mark.parametrize(
+        ("pattern", "expected"),
+        [("**/*", "*/*"), ("**/*.py", "*/*.py"), ("*.py", "*/*.py"), ("src/*.py", "*/src/*.py")],
+    )
+    def test_a_leading_globstar_is_dropped_rather_than_stacked(self, pattern: str, expected: str):
+        """`find -path` matches with fnmatch: `**` is `*`, and every `/` in the
+        pattern must be in the path. So `**/*` needed two slashes and missed
+        every file at the top level - and `**/*` is what anything walking a tree
+        reaches for."""
+        assert f"-path '{expected}'" in _shell.glob_command(pattern, "/")
+
     def test_matches_are_sorted_by_path(self):
         rows = _shell.parse_glob(_ok("/w/b.py\n/w/a.py\n"))
 


### PR DESCRIPTION
`glob_command` passed its root through to `find`, and a caller naming the
backend's root spells it `/`, `""` or `.`. For a backend addressing files
by virtual path, `/` *is* the top of the namespace; for a shell it is the
machine. So `find /` searched the whole container.

Measured against a running `sandboxd`, in a session holding three files:

    pattern   entries   outside the workspace
    *            2540                    2540
    **/*         2540                    2540
    *.txt          25                      22
    ./**/*          0                       -

Two things follow, and neither announces itself. An agent's own `glob`
tool reads the image it is running on - `/proc`, `/usr`, every path in the
base layer - into its context, and answers a question about the workspace
with 2540 paths that are not in it. And any caller diffing two globs to
learn what changed during a turn is comparing two photographs of `/proc`:
one such caller posts an agent's new files back into a chat channel.

The root now resolves to `.`, which is the session's working directory,
and an absolute path is still passed through - `/etc` is a root a caller
may mean and this is not the place to argue with them.

`**/*` is fixed with it, and it is the pattern that matters most: `find
-path` matches with fnmatch, where `**` is no different from `*` and every
`/` in the pattern must be present in the path, so `**/*` required two
slashes and missed every file at the top level. A leading `**/` means "at
any depth", which is exactly what the `*/` prefix already provides, so it
is dropped rather than stacked.

Verified on the same service after the change:

    pwd                        -> /workspace
    find . -path '*/*' -type f -> ./b.txt ./deep/deeper/c.txt ./uploads/a.txt

Six new tests - the three spellings of the root, an absolute root left
alone, and four patterns through the globstar rule. 1670 tests, 100%
coverage.

Found while tracking down why an agent's `ls` reported an empty workspace in a downstream product (vstorm-co/agenticos#1039). The attachment bug there was its own, but this one is why the same product's channel snapshots and the agent's `glob` tool were both reading the container's base image.