### PR TITLE
fix: stop LocalBackend execute hanging on Windows date/time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Foreground shell execution could hang on Windows waiting for stdin.**
+  `LocalBackend` wraps commands in `cmd /c` on Windows, and built-ins such as
+  `date` and `time` print the current value then prompt for a new one. Agent
+  sessions inherit an open stdin, so `execute("date")` waited until the
+  backend timeout instead of returning. Background processes already close
+  stdin with `DEVNULL`; sync `execute()` and `async_execute()` now do the
+  same, so interactive prompts see EOF immediately. (#103)
+
 ## [0.2.27] - 2026-08-20
 
 ### Fixed

--- a/src/pydantic_ai_backends/backends/local.py
+++ b/src/pydantic_ai_backends/backends/local.py
@@ -577,6 +577,9 @@ class LocalBackend:
                 cwd=self._root,
                 capture_output=True,
                 text=True,
+                # Closed so Windows built-ins like `date`/`time` cannot block
+                # on an interactive prompt until the execute timeout.
+                stdin=subprocess.DEVNULL,
                 timeout=timeout if timeout is not None else DEFAULT_EXECUTE_TIMEOUT,
             )
         except subprocess.TimeoutExpired:
@@ -603,6 +606,7 @@ class LocalBackend:
         try:
             process = await asyncio.create_subprocess_exec(
                 *shell_argv(command),
+                stdin=asyncio.subprocess.DEVNULL,  # same as execute(): no interactive prompts
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self._root,

--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -330,6 +331,41 @@ class TestLocalBackendExecute:
         assert result.exit_code == 0
         assert str(tmp_path) in result.output
 
+    def test_execute_closes_stdin(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Foreground execution must not inherit stdin (Windows date/time hang)."""
+        recorded: dict[str, object] = {}
+
+        class Result:
+            stdout = "ok"
+            stderr = ""
+            returncode = 0
+
+        def run(*args: object, **kwargs: object) -> Result:
+            recorded.update(kwargs)
+            return Result()
+
+        monkeypatch.setattr("subprocess.run", run)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = backend.execute("echo hello")
+
+        assert recorded["stdin"] is subprocess.DEVNULL
+        assert result.exit_code == 0
+        assert "ok" in result.output
+
+    @pytest.mark.skipif(
+        sys.platform != "win32", reason="cmd.exe date/time prompts are Windows-specific"
+    )
+    def test_execute_windows_date_and_time_do_not_block_on_stdin(self, tmp_path: Path):
+        """Bare `date`/`time` must return immediately instead of waiting for input."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        for command in ("date", "time"):
+            result = backend.execute(command, timeout=2)
+            assert result.exit_code != 124, command
+            assert "timed out" not in result.output.lower(), command
+            assert result.output.strip(), command
+
 
 class TestLocalBackendAsyncExecute:
     """Test LocalBackend async shell execution."""
@@ -369,6 +405,44 @@ class TestLocalBackendAsyncExecute:
         result = await backend.async_execute("sleep 10", timeout=1)
         assert result.exit_code == 124
         assert "timed out" in result.output
+
+    async def test_async_execute_closes_stdin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Async foreground execution must not inherit stdin either."""
+        recorded: dict[str, object] = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return b"ok", b""
+
+        async def create(*args: object, **kwargs: object) -> FakeProc:
+            recorded.update(kwargs)
+            return FakeProc()
+
+        monkeypatch.setattr("asyncio.create_subprocess_exec", create)
+        backend = LocalBackend(root_dir=tmp_path)
+
+        result = await backend.async_execute("echo hello")
+
+        assert recorded["stdin"] is asyncio.subprocess.DEVNULL
+        assert result.exit_code == 0
+        assert "ok" in result.output
+
+    @pytest.mark.skipif(
+        sys.platform != "win32", reason="cmd.exe date/time prompts are Windows-specific"
+    )
+    async def test_async_execute_windows_date_and_time_do_not_block_on_stdin(self, tmp_path: Path):
+        """Bare `date`/`time` must return immediately on the async path too."""
+        backend = LocalBackend(root_dir=tmp_path)
+
+        for command in ("date", "time"):
+            result = await backend.async_execute(command, timeout=2)
+            assert result.exit_code != 124, command
+            assert "timed out" not in result.output.lower(), command
+            assert result.output.strip(), command
 
     async def test_async_execute_cancelled(self, tmp_path: Path):
         """Test that CancelledError propagates from async_execute."""


### PR DESCRIPTION
## Summary

- Close stdin with `DEVNULL` for foreground `LocalBackend.execute()` and `async_execute()`, matching the existing background-process behavior.
- Prevent interactive Windows shell built-ins such as `date` and `time` from blocking until the execution timeout.
- Add regression coverage for both synchronous and asynchronous execution.

Fixes #103

## Why

On Windows, commands run through `cmd /c`. Bare `date` and `time` are interactive commands: after displaying the current value, they wait for user input.

`LocalBackend` does not expose stdin to callers, so foreground executions should be non-interactive. Passing `DEVNULL` causes these commands to receive EOF immediately rather than hanging until timeout.

## Testing

Passed:

- `uv run ruff check .`
- `uv run ruff format --check .`
- Sync and async `DEVNULL` regression tests
- Windows `date` / `time` regression tests
- Existing ordinary command execution coverage

On Windows, `date` and `time` now return immediately rather than waiting for the configured execution timeout.

The broader test/typecheck commands expose existing Unix-specific assumptions when run on Windows, including Unix commands/filesystem behavior such as `sleep`, `pwd`, `os.chown`, Unix permissions and `/tmp`. These failures are unrelated to this change.