### PR TITLE
feat(toolsets): one text object per tool, and ModelRetry for a fixable mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.28] - 2026-08-22
+
+### Changed
+
+- **Every console tool now says what it returns, and its text is one object
+  rather than two.** A tool definition is a prompt, and these were written as
+  Claude Code's are: shouty (`NEVER`, `ALWAYS`, `MUST` and `IMPORTANT` between
+  them 16 times), thin on arguments, and silent on the one thing a model cannot
+  infer — the shape of the answer. Nothing said that `grep` replies in three
+  different shapes depending on `output_mode`, that `glob` lists 100 paths and
+  `grep` 50 before summarising the rest as `... and N more`, that `read_file`'s
+  `offset` counts from 0 while the line numbers it prints count from 1, that a
+  failed `execute` still returns its output under `Command failed (exit code N)`,
+  or that a timeout answers `Error: Command timed out` with code 124. All of it
+  is in the descriptions now, under a `Returns:` paragraph.
+
+  The mechanism behind that: each tool's text is a `ToolText` — `summary`,
+  `usage`, `coding`, `args`, `returns` — and the description handed to the model
+  is rendered from it, while `args` becomes the per-argument text in the JSON
+  schema. Previously the description was a constant and the argument text was a
+  docstring beside the function, so a host could override one and not the other,
+  and `docs/api/toolsets.md` held a third copy that had gone stale. The
+  `*_DESCRIPTION` constants are still exported and are rendered from the same
+  objects.
+
+  `tests/test_tool_text.py` holds the drift shut: every argument of every tool in
+  both edit formats carries a description, and `TOOL_TEXT` names exactly the
+  arguments the function takes — an argument the registry forgets reaches the
+  model undescribed, and one it names that no longer exists is stale text nobody
+  would notice.
+
+### Added
+
+- **`profile="agent"`, for a host whose agent is not working in a repository.**
+  `execute` carried 2501 characters of coding-agent guidance — git safety,
+  package managers, what to do after three failed attempts — on every request,
+  including for an agent whose workspace is scratch space for one conversation.
+  That guidance is now the `coding` half of the text, kept under the default
+  `profile="coding"` and dropped under `"agent"`: about 240 tokens a request
+  across the seven tools a typical host registers, and the return shapes are kept
+  either way.
+
+- **`descriptions` accepts a `ToolText`, and refuses an unknown key.** A string
+  still replaces the description alone; a `ToolText` replaces the argument text
+  with it, which was previously unreachable from outside the library. A key that
+  is not a tool name now raises `UserError` — it used to be ignored, so a
+  misspelled or renamed key meant an override that silently reached nothing,
+  including for a host whose own catalogue then showed one text while the model
+  read another.
+
 ## [0.2.27] - 2026-08-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A mistake the model can fix now raises `ModelRetry`, and a refusal still does
+  not.** Every failure used to be a returned string, including the ones the model
+  had plainly got wrong: an `old_string` matching three places, a file edited
+  between the read and the edit, a path that does not exist. The model was told in
+  a sentence indistinguishable from a real answer and left to notice. Those cases
+  — a missing file, an offset past the end, an absent or ambiguous `old_string`, a
+  stale read, a hashline hash that no longer matches — come back as a retry prompt
+  now.
+
+  What stays a returned string is as deliberate: a non-zero exit from `execute` is
+  a *result* to reason about rather than a malformed call, `grep` finding nothing
+  is an answer, a dropped connection is not something different arguments would
+  fix, and a **permission refusal must never be a retry**, because a retry prompt
+  invites the model to look for a way around the rule. `PERMISSION_DENIED_PREFIX`
+  is now one constant that `PermissionGuard` writes and `toolsets/_failures.py`
+  reads, with a test holding the two ends together.
+
+  `max_retries` becomes a floor as well as a ceiling: on a tool's last attempt the
+  message is returned rather than raised. `ModelRetry` past the budget ends the
+  whole run with `UnexpectedModelBehavior`, so without that floor a model that
+  mistyped an `old_string` twice would kill a run that used to carry on. The worst
+  case is now exactly the old behaviour, never a dead run — and `max_retries=0`
+  reproduces it entirely.
+
 - **`profile="agent"`, for a host whose agent is not working in a repository.**
   `execute` carried 2501 characters of coding-agent guidance — git safety,
   package managers, what to do after three failed attempts — on every request,

--- a/README.md
+++ b/README.md
@@ -338,13 +338,12 @@ toolset = create_console_toolset(
     require_execute_approval=True,
 )
 
-# With custom tool descriptions
-toolset = create_console_toolset(
-    descriptions={
-        "execute": "Run shell commands in the workspace",
-        "read_file": "Read file contents from the workspace",
-    }
-)
+# Leaner descriptions for an agent that is not working in a repository
+toolset = create_console_toolset(profile="agent")
+
+# With custom tool text — a string replaces the description, a ToolText
+# replaces the per-argument text with it
+toolset = create_console_toolset(descriptions={"execute": "Run shell commands in the workspace"})
 ```
 
 **Available tools:** `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `execute`

--- a/docs/api/toolsets.md
+++ b/docs/api/toolsets.md
@@ -18,125 +18,48 @@
     options:
       show_root_heading: true
 
+## ToolText
+
+::: pydantic_ai_backends.toolsets.descriptions.ToolText
+    options:
+      show_root_heading: true
+
 ## Console Tools
 
-The toolset provides these tools:
-
-### ls
-
-```python
-async def ls(ctx: RunContext[ConsoleDeps], path: str = ".") -> str:
-    """List files and directories at the given path.
-
-    Args:
-        path: Directory path to list. Defaults to current directory.
-    """
-```
-
-### read_file
+The toolset registers these tools. What each one *says* — its description and the
+text describing every argument — is not written beside the function: it lives in
+`TOOL_TEXT`, keyed by tool name, and is assigned when the tool is registered. Read
+`TOOL_TEXT["grep"].render()` to see exactly what the model is handed.
 
 ```python
-async def read_file(
-    ctx: RunContext[ConsoleDeps],
-    path: str,
-    offset: int = 0,
-    limit: int = 2000,
-) -> str:
-    """Read file content with line numbers.
-
-    Args:
-        path: Path to the file to read.
-        offset: Line number to start reading from (0-indexed).
-        limit: Maximum number of lines to read.
-    """
-```
-
-### write_file
-
-```python
-async def write_file(
-    ctx: RunContext[ConsoleDeps],
-    path: str,
-    content: str,
-) -> str:
-    """Write content to a file (creates or overwrites).
-
-    Args:
-        path: Path to the file to write.
-        content: Content to write to the file.
-    """
-```
-
-### edit_file
-
-```python
+async def ls(ctx, path: str = ".") -> str: ...
+async def read_file(ctx, path: str, offset: int = 0, limit: int = 2000) -> str: ...
+async def write_file(ctx, path: str, content: str) -> str: ...
 async def edit_file(
-    ctx: RunContext[ConsoleDeps],
+    ctx, path: str, old_string: str, new_string: str, replace_all: bool = False
+) -> str: ...
+async def hashline_edit(
+    ctx,
     path: str,
-    old_string: str,
-    new_string: str,
-    replace_all: bool = False,
-) -> str:
-    """Edit a file by replacing strings.
-
-    Args:
-        path: Path to the file to edit.
-        old_string: String to find and replace.
-        new_string: Replacement string.
-        replace_all: If True, replace all occurrences.
-    """
-```
-
-### glob
-
-```python
-async def glob(
-    ctx: RunContext[ConsoleDeps],
-    pattern: str,
-    path: str = ".",
-) -> str:
-    """Find files matching a glob pattern.
-
-    Args:
-        pattern: Glob pattern to match (e.g., "**/*.py").
-        path: Base directory to search from.
-    """
-```
-
-### grep
-
-```python
+    start_line: int,
+    start_hash: str,
+    new_content: str,
+    end_line: int | None = None,
+    end_hash: str | None = None,
+    insert_after: bool = False,
+) -> str: ...
+async def glob(ctx, pattern: str, path: str = ".") -> str: ...
 async def grep(
-    ctx: RunContext[ConsoleDeps],
+    ctx,
     pattern: str,
     path: str | None = None,
     glob_pattern: str | None = None,
     output_mode: Literal["content", "files_with_matches", "count"] = "files_with_matches",
     ignore_hidden: bool = True,
-) -> str:
-    """Search for a regex pattern in files.
-
-    Args:
-        pattern: Regex pattern to search for.
-        path: Specific file or directory to search.
-        glob_pattern: Glob pattern to filter files.
-        output_mode: Output format.
-        ignore_hidden: Whether to skip hidden files (defaults to the toolset setting).
-    """
-```
-
-### execute
-
-```python
-async def execute(
-    ctx: RunContext[ConsoleDeps],
-    command: str,
-    timeout: int | None = 120,
-) -> str:
-    """Execute a shell command.
-
-    Args:
-        command: The shell command to execute.
-        timeout: Maximum execution time in seconds.
-    """
+) -> str: ...
+async def execute(ctx, command: str, timeout: int | None = 120) -> str: ...
+async def run_in_background(ctx, command: str) -> str: ...
+async def read_output(ctx, shell_id: str) -> str: ...
+async def kill_shell(ctx, shell_id: str) -> str: ...
+async def list_shells(ctx) -> str: ...
 ```

--- a/docs/concepts/console-toolset.md
+++ b/docs/concepts/console-toolset.md
@@ -135,6 +135,32 @@ Valid keys are the tool names: `ls`, `read_file`, `write_file`, `edit_file`,
 ignored — a misspelled override that silently reaches nothing is one nobody
 discovers.
 
+## Failures
+
+A tool reports trouble in one of two shapes, and they say different things to the
+model.
+
+**A mistake it can fix raises `ModelRetry`** — the message goes back as a retry
+prompt and the model gets another attempt at the call:
+
+- a file that is not there, or an offset past its end
+- an `old_string` that matches nothing, or matches more than once
+- a file edited between the read and the edit, or a hashline hash that no longer
+  matches
+
+**Everything else is returned as text**, because it is the answer rather than a
+malformed call: a non-zero exit from `execute`, a `grep` that found nothing, a
+backend with no shell, a dropped connection — and a **permission refusal**, which
+is deliberate. A retry prompt on a refusal invites the model to look for a way
+around the rule.
+
+`max_retries` is the budget, and it is a floor as much as a ceiling: on a tool's
+final attempt the message is returned instead of raised. `ModelRetry` past the
+budget ends the whole run with `UnexpectedModelBehavior`, so a model that mistypes
+an `old_string` twice would kill a run that would otherwise have carried on. The
+worst case here is the behaviour this library had before — an error string the
+model reads and adapts to.
+
 ## Permission-based Configuration
 
 For fine-grained control, use the permission system:

--- a/docs/concepts/console-toolset.md
+++ b/docs/concepts/console-toolset.md
@@ -74,20 +74,66 @@ The `edit_format` parameter selects how the model edits files. The default
 `"hashline"` swaps it for a `hashline_edit` tool — see [Hashline Edit
 Format](#hashline-edit-format) below.
 
-## Custom Tool Descriptions
+## What the Model Reads
 
-You can override the default description of any tool with the `descriptions` parameter. This is useful when you want to tailor tool descriptions to your specific use case for better LLM behavior:
+Each tool's text is one `ToolText` object: what the tool does, when to use it and
+when to reach for another one, what every argument means, and what comes back —
+including how a result is truncated and what a failure looks like. The
+description handed to the model is composed from it, and the per-argument text
+becomes the descriptions in the tool's JSON schema.
 
 ```python
+from pydantic_ai_backends import TOOL_TEXT
+
+TOOL_TEXT["grep"].summary  # one sentence — what a catalogue should show
+TOOL_TEXT["grep"].returns  # the three shapes `output_mode` can answer with
+TOOL_TEXT["grep"].args  # keyed by parameter name
+TOOL_TEXT["grep"].render()  # the description the model is given
+```
+
+### Profiles
+
+Two kinds of agent read these tools and they need different amounts of text. A
+coding agent wants the git, dependency and debugging guidance; an agent whose
+workspace is scratch space for one conversation never sees a repository and pays
+for those sentences on every request.
+
+```python
+coding = create_console_toolset()  # the default
+lean = create_console_toolset(profile="agent")  # ~240 tokens lighter
+```
+
+`"agent"` drops the repository guidance from `execute` and `write_file` and
+keeps everything true of any workspace, the return shapes included.
+
+### Custom Tool Descriptions
+
+Override any tool's text with the `descriptions` parameter — useful when a host
+lists these tools in its own catalogue and needs the text it shows and the text
+the model reads to be one string:
+
+```python
+from pydantic_ai_backends import ToolText
+
 toolset = create_console_toolset(
     descriptions={
-        "execute": "Run shell commands in the workspace",
-        "read_file": "Read file contents from the workspace",
+        # A string replaces the description; the argument text is kept.
+        "execute": "Run a shell command in the customer's workspace.",
+        # A ToolText replaces both halves.
+        "read_file": ToolText(
+            summary="Read a file from the shared drive.",
+            args={"path": "Path under /drive.", "offset": "...", "limit": "..."},
+            returns="The file's lines, numbered from 1.",
+        ),
     }
 )
 ```
 
-Only the tools you specify are overridden; all others keep their built-in descriptions. Valid keys are: `ls`, `read_file`, `write_file`, `edit_file`, `hashline_edit`, `glob`, `grep`, `execute`.
+Valid keys are the tool names: `ls`, `read_file`, `write_file`, `edit_file`,
+`hashline_edit`, `glob`, `grep`, `execute`, `run_in_background`, `read_output`,
+`kill_shell`, `list_shells`. An unknown key raises `UserError` rather than being
+ignored — a misspelled override that silently reaches nothing is one nobody
+discovers.
 
 ## Permission-based Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-backend"
-version = "0.2.27"
+version = "0.2.28"
 description = "File storage and sandbox backends for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_backends/__init__.py
+++ b/src/pydantic_ai_backends/__init__.py
@@ -137,6 +137,7 @@ if TYPE_CHECKING:
         create_console_toolset,
         get_console_system_prompt,
     )
+    from pydantic_ai_backends.toolsets.descriptions import TOOL_TEXT, Profile, ToolText
 
 _LAZY_MODULES: dict[str, tuple[str, ...]] = {
     "pydantic_ai_backends.hashline": (
@@ -168,6 +169,7 @@ _LAZY_MODULES: dict[str, tuple[str, ...]] = {
         "create_console_toolset",
         "get_console_system_prompt",
     ),
+    "pydantic_ai_backends.toolsets.descriptions": ("TOOL_TEXT", "Profile", "ToolText"),
     "pydantic_ai_backends.capability": ("ConsoleCapability",),
     "pydantic_ai_backends.backends.base": ("AsyncBaseSandbox", "BaseSandbox"),
     "pydantic_ai_backends.backends.daytona": ("DaytonaSandbox",),
@@ -208,6 +210,7 @@ _LAZY_IMPORTS = {name: module for module, names in _LAZY_MODULES.items() for nam
 # Spelled out rather than derived from the two groups above: type checkers only
 # understand a literal `__all__`, and this is the library's public API reference.
 __all__ = [
+    "TOOL_TEXT",
     "AskCallback",
     "AskFallback",
     "AsyncBackendAdapter",
@@ -229,6 +232,8 @@ __all__ = [
     "ConsoleCapability",
     "ConsoleDeps",
     "ConsoleToolset",
+    "Profile",
+    "ToolText",
     "DEFAULT_MAX_DOCUMENT_BYTES",
     "DEFAULT_MAX_IMAGE_BYTES",
     "DEFAULT_RULESET",

--- a/src/pydantic_ai_backends/backends/_guard.py
+++ b/src/pydantic_ai_backends/backends/_guard.py
@@ -27,6 +27,15 @@ if TYPE_CHECKING:
 GUARDED_COMMAND_OPERATIONS: tuple[PermissionOperation, ...] = ("read", "write")
 """Operations whose deny rules also block a command that names such a path."""
 
+PERMISSION_DENIED_PREFIX = "Permission denied"
+"""How every refusal this module returns rather than raises begins.
+
+A constant because the console toolset has to tell a refusal from a mistake: a
+mistake is handed back as `ModelRetry` so the model tries again, and a refusal
+must not be, since a retry prompt invites it to look for a way around the rule.
+`toolsets/_failures.py` is the reader.
+"""
+
 
 class PermissionGuard:
     """Decides synchronously whether one operation may proceed.
@@ -73,11 +82,11 @@ class PermissionGuard:
         if action == "deny":
             rule = self._checker.find_matching_rule(operation, target)
             if rule and rule.description:
-                return f"Permission denied: {rule.description}"
-            return f"Permission denied for {operation} on '{target}'"
+                return f"{PERMISSION_DENIED_PREFIX}: {rule.description}"
+            return f"{PERMISSION_DENIED_PREFIX} for {operation} on '{target}'"
 
         if self._ask_fallback == "deny":
-            return f"Permission denied for {operation} on '{target}' (approval required)"
+            return f"{PERMISSION_DENIED_PREFIX} for {operation} on '{target}' (approval required)"
         raise PermissionAskError(operation, target, "Approval required but no callback")
 
     def is_denied(self, operation: PermissionOperation, target: str) -> bool:
@@ -116,7 +125,7 @@ class PermissionGuard:
             for operation in GUARDED_COMMAND_OPERATIONS:
                 if self.is_denied(operation, target):
                     return (
-                        f"Permission denied: command references '{target}', "
+                        f"{PERMISSION_DENIED_PREFIX}: command references '{target}', "
                         f"which is denied for {operation}"
                     )
         return None

--- a/src/pydantic_ai_backends/capability.py
+++ b/src/pydantic_ai_backends/capability.py
@@ -18,6 +18,7 @@ Example:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -44,6 +45,7 @@ from pydantic_ai_backends.toolsets.console import (
     create_console_toolset,
     get_console_system_prompt,
 )
+from pydantic_ai_backends.toolsets.descriptions import DEFAULT_PROFILE, Profile, ToolText
 
 TOOL_OPERATIONS: dict[str, PermissionOperation] = {
     "ls": "ls",
@@ -155,14 +157,27 @@ class ConsoleCapability(AbstractCapability[Any]):
     max_document_bytes: int = DEFAULT_MAX_DOCUMENT_BYTES
     """Largest document returned; bigger ones yield an error."""
 
-    descriptions: dict[str, str] | None = None
-    """Per-tool description overrides, keyed by tool name.
+    descriptions: Mapping[str, str | ToolText] | None = None
+    """Per-tool text overrides, keyed by tool name.
 
     A host that lists these tools in its own catalogue needs the text it shows
     and the text the model reads to be the same string. Without this the two are
     written in different repositories and drift, and the drift is invisible: the
     person choosing what to allow and the model choosing when to act are reading
     different descriptions of the same tool.
+
+    A string replaces the tool's description and leaves its argument text alone;
+    a `ToolText` replaces both. An unknown tool name raises rather than being
+    ignored.
+    """
+
+    profile: Profile = DEFAULT_PROFILE
+    """How much guidance the tool descriptions carry.
+
+    `"coding"` includes what an agent working in a repository needs — git,
+    dependencies, reading a failed command's output. `"agent"` leaves it out,
+    which is what an agent whose workspace is scratch space for one conversation
+    should be paying for.
     """
 
     permissions: PermissionRuleset | None = None
@@ -195,6 +210,7 @@ class ConsoleCapability(AbstractCapability[Any]):
             document_support=self.document_support,
             max_document_bytes=self.max_document_bytes,
             descriptions=self.descriptions,
+            profile=self.profile,
             # Passed through as well as being enforced in `prepare_tools`: the
             # toolset drops a denied operation's tools outright, so they are gone
             # rather than merely hidden from one request's tool definitions - and

--- a/src/pydantic_ai_backends/toolsets/__init__.py
+++ b/src/pydantic_ai_backends/toolsets/__init__.py
@@ -16,9 +16,11 @@ from pydantic_ai_backends.toolsets.console import (
     create_console_toolset,
     get_console_system_prompt,
 )
+from pydantic_ai_backends.toolsets.descriptions import TOOL_TEXT, Profile, ToolText
 
 __all__ = [
     "CONSOLE_SYSTEM_PROMPT",
+    "TOOL_TEXT",
     "EDIT_FILE_DESCRIPTION",
     "EXECUTE_DESCRIPTION",
     "GLOB_DESCRIPTION",
@@ -30,6 +32,8 @@ __all__ = [
     "WRITE_FILE_DESCRIPTION",
     "ConsoleDeps",
     "ConsoleToolset",
+    "Profile",
+    "ToolText",
     "create_console_toolset",
     "get_console_system_prompt",
 ]

--- a/src/pydantic_ai_backends/toolsets/_failures.py
+++ b/src/pydantic_ai_backends/toolsets/_failures.py
@@ -1,0 +1,68 @@
+"""Which failures steer the model, and which are simply its answer.
+
+A tool has two ways to report that something went wrong, and they say different
+things. `ModelRetry` means *you can fix this by calling again differently* — the
+message goes back as a retry prompt and the model gets another attempt. A
+returned string means *this is the result; reason about it* — the run moves on.
+
+Every failure in this toolset used to take the second form, including the ones
+the model could plainly have fixed: an `old_string` that matched three places, a
+file edited between the read and the edit, a path that does not exist. The model
+was told, in a sentence indistinguishable from a real answer, and it was left to
+notice.
+
+So the rule, and it is the same rule in every tool here:
+
+- **Argument-fixable → `ModelRetry`.** A missing file, an offset past the end, an
+  `old_string` that is absent or not unique, a stale read, a hash that no longer
+  matches. Calling again with different arguments is a plausible fix.
+- **Everything else → a string.** A non-zero exit from `execute` is a *result*,
+  not a malformed call; `grep` finding nothing is an answer; a backend with no
+  shell is a fact about the deployment; and a **permission refusal must never be
+  a retry**, because a retry prompt invites the model to look for a way around
+  it. Those come back as text and the model adapts.
+
+`last_attempt` is what makes the first half safe. `ModelRetry` is not free: when
+a tool exhausts its retries, pydantic-ai raises `UnexpectedModelBehavior` and the
+whole run ends — so a model that mistypes an `old_string` twice would kill a run
+that previously just carried on. On the final attempt the message is therefore
+returned rather than raised: the model is steered while there is budget for it,
+and the worst case is the behaviour this library had before, never a dead run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai import ModelRetry
+from pydantic_ai.tools import RunContext
+
+from pydantic_ai_backends.backends._guard import PERMISSION_DENIED_PREFIX
+
+
+def is_refusal(message: str) -> bool:
+    """Whether `message` is a permission refusal rather than a fixable mistake.
+
+    The prefix is `PermissionGuard`'s own, imported rather than repeated: both
+    ends are in this repository, and a refusal that stopped being recognised
+    would quietly become a retry prompt telling the model to try again.
+    """
+    return PERMISSION_DENIED_PREFIX in message
+
+
+def steer(ctx: RunContext[Any], message: str) -> str:
+    """Ask the model to try again, while it still has an attempt left.
+
+    Args:
+        ctx: The tool call's context, for how many retries remain.
+        message: What went wrong, and what a different call should do about it.
+
+    Returns:
+        `message`, on the last attempt, for the caller to return as its result.
+
+    Raises:
+        ModelRetry: Otherwise — the message reaches the model as a retry prompt.
+    """
+    if is_refusal(message) or ctx.last_attempt:
+        return message
+    raise ModelRetry(message)

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -21,7 +21,7 @@ from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai_backends.adapter import ensure_async
 from pydantic_ai_backends.backends import _guard
 from pydantic_ai_backends.protocol import AsyncBackendProtocol, BackendProtocol
-from pydantic_ai_backends.toolsets import _ruleset, _tracking
+from pydantic_ai_backends.toolsets import _failures, _ruleset, _tracking
 from pydantic_ai_backends.toolsets._content import (
     DEFAULT_MAX_DOCUMENT_BYTES as DEFAULT_MAX_DOCUMENT_BYTES,
 )
@@ -246,8 +246,12 @@ def create_console_toolset(  # noqa: C901
         permissions: Ruleset deciding which tools exist and which need approval:
             an operation defaulting to "deny" drops its tools entirely, one
             defaulting to "ask" marks them as requiring approval.
-        max_retries: Times a tool may retry within one run after invalid
-            arguments, with the validation error fed back to the model.
+        max_retries: Times a tool may retry within one run, with the message
+            fed back to the model — pydantic-ai's own argument validation, and
+            the mistakes `toolsets/_failures.py` steers on: a missing file, an
+            `old_string` that is absent or matches twice, a stale read. Past the
+            budget the message is returned rather than raised, so a run never
+            ends on one.
         image_support: Return recognized image files (`.png`, `.jpg`, `.jpeg`,
             `.gif`, `.webp`) as `BinaryContent` a multimodal model can see,
             instead of garbled text.
@@ -424,7 +428,11 @@ def create_console_toolset(  # noqa: C901
 
             backend = ensure_async(backend_for(ctx))
             if not await backend.exists(path):
-                return f"Error: File '{path}' not found"
+                return _failures.steer(
+                    ctx,
+                    f"Error: File '{path}' not found. Check the path with `ls` or "
+                    "`glob`, then read it again.",
+                )
 
             raw = await backend.read_bytes(path)
             _tracking.record_read(backend_for(ctx), path, raw)
@@ -447,8 +455,9 @@ def create_console_toolset(  # noqa: C901
 
             backend = ensure_async(backend_for(ctx))
             result = await backend.read(path, offset, limit)
-            if not result.startswith("Error"):
-                await _tracking.record_path_read(backend, backend_for(ctx), path)
+            if result.startswith("Error"):
+                return _failures.steer(ctx, result)
+            await _tracking.record_path_read(backend, backend_for(ctx), path)
             return result
 
     @described("write_file", requires_approval=write_approval)
@@ -461,7 +470,7 @@ def create_console_toolset(  # noqa: C901
         """Write content to a file."""
         result = await ensure_async(backend_for(ctx)).write(path, content)
         if result.error:
-            return f"Error: {result.error}"
+            return _failures.steer(ctx, f"Error: {result.error}")
 
         # The agent knows this file's content now, so an immediate edit must not
         # be refused as stale.
@@ -490,7 +499,7 @@ def create_console_toolset(  # noqa: C901
 
             async with _tracking.edit_lock(raw_backend, path):
                 if not await backend.exists(path):
-                    return f"Error: File '{path}' not found"
+                    return _failures.steer(ctx, f"Error: File '{path}' not found")
 
                 current = (await backend.read_bytes(path)).decode("utf-8", errors="replace")
                 new_text, error, summary = apply_hashline_edit_with_summary(
@@ -503,11 +512,11 @@ def create_console_toolset(  # noqa: C901
                     insert_after,
                 )
                 if error:
-                    return f"Error: {error}"
+                    return _failures.steer(ctx, f"Error: {error}")
 
                 written = await backend.write(path, new_text)
                 if written.error:
-                    return f"Error: {written.error}"
+                    return _failures.steer(ctx, f"Error: {written.error}")
                 return f"Edited {written.path}: {summary}"
 
     else:
@@ -533,11 +542,11 @@ def create_console_toolset(  # noqa: C901
             async with _tracking.edit_lock(raw_backend, path):
                 stale = await _tracking.staleness_error(backend, raw_backend, path)
                 if stale is not None:
-                    return stale
+                    return _failures.steer(ctx, stale)
 
                 result = await backend.edit(path, old_string, new_string, replace_all)
                 if result.error:
-                    return f"Error: {result.error}"
+                    return _failures.steer(ctx, f"Error: {result.error}")
 
                 # The agent's view is the post-edit content now, so a follow-up
                 # edit must not be flagged as stale.

--- a/src/pydantic_ai_backends/toolsets/console.py
+++ b/src/pydantic_ai_backends/toolsets/console.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast, runtime_checkable
 
 from pydantic_ai import RunContext
@@ -48,6 +48,13 @@ from pydantic_ai_backends.toolsets.descriptions import (
     CONSOLE_SYSTEM_PROMPT as CONSOLE_SYSTEM_PROMPT,
 )
 from pydantic_ai_backends.toolsets.descriptions import (
+    DEFAULT_PROFILE,
+    OVERRIDE_KEYS,
+    TOOL_TEXT,
+    Profile,
+    ToolText,
+)
+from pydantic_ai_backends.toolsets.descriptions import (
     EDIT_FILE_DESCRIPTION as EDIT_FILE_DESCRIPTION,
 )
 from pydantic_ai_backends.toolsets.descriptions import (
@@ -69,16 +76,22 @@ from pydantic_ai_backends.toolsets.descriptions import (
     HASHLINE_READ_FILE_DESCRIPTION as HASHLINE_READ_FILE_DESCRIPTION,
 )
 from pydantic_ai_backends.toolsets.descriptions import (
-    KILL_SHELL_DESCRIPTION,
-    LIST_SHELLS_DESCRIPTION,
-    READ_OUTPUT_DESCRIPTION,
-    RUN_IN_BACKGROUND_DESCRIPTION,
+    KILL_SHELL_DESCRIPTION as KILL_SHELL_DESCRIPTION,
+)
+from pydantic_ai_backends.toolsets.descriptions import (
+    LIST_SHELLS_DESCRIPTION as LIST_SHELLS_DESCRIPTION,
 )
 from pydantic_ai_backends.toolsets.descriptions import (
     LS_DESCRIPTION as LS_DESCRIPTION,
 )
 from pydantic_ai_backends.toolsets.descriptions import (
     READ_FILE_DESCRIPTION as READ_FILE_DESCRIPTION,
+)
+from pydantic_ai_backends.toolsets.descriptions import (
+    READ_OUTPUT_DESCRIPTION as READ_OUTPUT_DESCRIPTION,
+)
+from pydantic_ai_backends.toolsets.descriptions import (
+    RUN_IN_BACKGROUND_DESCRIPTION as RUN_IN_BACKGROUND_DESCRIPTION,
 )
 from pydantic_ai_backends.toolsets.descriptions import (
     WRITE_FILE_DESCRIPTION as WRITE_FILE_DESCRIPTION,
@@ -206,7 +219,8 @@ def create_console_toolset(  # noqa: C901
     document_support: bool = False,
     max_document_bytes: int = DEFAULT_MAX_DOCUMENT_BYTES,
     edit_format: EditFormat = "str_replace",
-    descriptions: dict[str, str] | None = None,
+    descriptions: Mapping[str, str | ToolText] | None = None,
+    profile: Profile = DEFAULT_PROFILE,
 ) -> FunctionToolset[ConsoleDeps]:
     """Create a console toolset for file operations and shell execution.
 
@@ -245,10 +259,18 @@ def create_console_toolset(  # noqa: C901
         edit_format: `"str_replace"` matches exact strings; `"hashline"` tags
             each line with a content hash so the model references lines by
             `number:hash` instead of reproducing text.
-        descriptions: Per-tool description overrides, keyed by tool name: `ls`,
+        descriptions: Per-tool text overrides, keyed by tool name: `ls`,
             `read_file`, `write_file`, `edit_file`, `hashline_edit`, `glob`,
             `grep`, `execute`, `run_in_background`, `read_output`, `kill_shell`,
-            `list_shells`.
+            `list_shells`. A string replaces the tool's description and leaves
+            its argument text alone; a :class:`ToolText` replaces both. An
+            unknown key raises `UserError` rather than being ignored, since a
+            silent override is one nobody discovers.
+        profile: How much guidance the descriptions carry. `"coding"` includes
+            the guidance written for an agent working in a repository — git,
+            dependencies, debugging a failed command — and `"agent"` leaves it
+            out, which is about 250 tokens a request an agent with a scratch
+            workspace was paying for advice it could not use.
 
     Example:
         ```python
@@ -269,7 +291,13 @@ def create_console_toolset(  # noqa: C901
         guarded = create_console_toolset(permissions=DEFAULT_RULESET)
         ```
     """
-    described = descriptions or {}
+    overrides: Mapping[str, str | ToolText] = descriptions or {}
+    unknown = sorted(set(overrides) - OVERRIDE_KEYS)
+    if unknown:
+        raise UserError(
+            f"Unknown tool name(s) in `descriptions`: {', '.join(unknown)}. "
+            f"Valid names: {', '.join(sorted(OVERRIDE_KEYS))}."
+        )
 
     # Wrapped once, here, because the closure backend never changes. `guarding`
     # answers with the backend untouched when there is no ruleset or when the
@@ -309,6 +337,42 @@ def create_console_toolset(  # noqa: C901
 
     toolset: FunctionToolset[ConsoleDeps] = FunctionToolset(id=id, max_retries=max_retries)
 
+    def described(
+        text_id: str,
+        tool_name: str | None = None,
+        *,
+        requires_approval: bool = False,
+    ) -> Callable[[_ToolFn], _ToolFn]:
+        """Register a tool with the text this configuration gives it.
+
+        One `ToolText` supplies both halves of what the model reads, but they
+        travel separately: the description is passed to the decorator, while the
+        per-argument text reaches the JSON schema through the function's
+        docstring and through nothing else — hence the assignment. It is also
+        why the tools below carry a one-line docstring rather than a second copy
+        of the argument text, which is a copy that drifts.
+
+        Args:
+            text_id: Key in `TOOL_TEXT`. Differs from the tool name only for
+                `read_file`, which has one text per edit format.
+            tool_name: Name a caller overrides this tool by, when it is not the
+                text id.
+            requires_approval: Whether the tool call is suspended for a human.
+        """
+        name = tool_name or text_id
+        override = overrides.get(name)
+        text = override if isinstance(override, ToolText) else TOOL_TEXT[text_id]
+        description = override if isinstance(override, str) else text.render(profile)
+
+        def register(fn: _ToolFn) -> _ToolFn:
+            cast("Any", fn).__doc__ = text.docstring()
+            registered = toolset.tool(description=description, requires_approval=requires_approval)(
+                fn
+            )
+            return cast("_ToolFn", registered)
+
+        return register
+
     async def binary_content(
         target: BackendProtocol | AsyncBackendProtocol, path: str
     ) -> Any | None:  # pragma: no cover - exercised through read_file
@@ -321,17 +385,13 @@ def create_console_toolset(  # noqa: C901
             return await document_content(target, path, max_document_bytes)
         return None
 
-    @toolset.tool(description=described.get("ls", LS_DESCRIPTION))
+    @described("ls")
     @_degrade_on_error
     async def ls(
         ctx: RunContext[ConsoleDeps],
         path: str = ".",
     ) -> str:
-        """List files and directories at the given path.
-
-        Args:
-            path: Directory path to list. Defaults to current directory.
-        """
+        """List files and directories at the given path."""
         entries = await ensure_async(backend_for(ctx)).ls_info(path)
         if not entries:
             return f"Directory '{path}' is empty or does not exist"
@@ -347,7 +407,7 @@ def create_console_toolset(  # noqa: C901
 
     if edit_format == "hashline":
 
-        @toolset.tool(description=described.get("read_file", HASHLINE_READ_FILE_DESCRIPTION))
+        @described("hashline_read_file", "read_file")
         @_degrade_on_error
         async def read_file(
             ctx: RunContext[ConsoleDeps],
@@ -355,13 +415,7 @@ def create_console_toolset(  # noqa: C901
             offset: int = 0,
             limit: int = 2000,
         ) -> Any:
-            """Read file content with hashline tags.
-
-            Args:
-                path: Absolute or relative path to the file to read.
-                offset: Line number to start reading from (0-indexed).
-                limit: Maximum number of lines to read.
-            """
+            """Read file content with hashline tags."""
             binary = await binary_content(backend_for(ctx), path)
             if binary is not None:
                 return binary
@@ -378,7 +432,7 @@ def create_console_toolset(  # noqa: C901
 
     else:
 
-        @toolset.tool(description=described.get("read_file", READ_FILE_DESCRIPTION))
+        @described("read_file")
         @_degrade_on_error
         async def read_file(
             ctx: RunContext[ConsoleDeps],
@@ -386,13 +440,7 @@ def create_console_toolset(  # noqa: C901
             offset: int = 0,
             limit: int = 2000,
         ) -> Any:
-            """Read file content with line numbers.
-
-            Args:
-                path: Absolute or relative path to the file to read.
-                offset: Line number to start reading from (0-indexed).
-                limit: Maximum number of lines to read.
-            """
+            """Read file content with line numbers."""
             binary = await binary_content(backend_for(ctx), path)
             if binary is not None:
                 return binary
@@ -403,22 +451,14 @@ def create_console_toolset(  # noqa: C901
                 await _tracking.record_path_read(backend, backend_for(ctx), path)
             return result
 
-    @toolset.tool(
-        description=described.get("write_file", WRITE_FILE_DESCRIPTION),
-        requires_approval=write_approval,
-    )
+    @described("write_file", requires_approval=write_approval)
     @_degrade_on_error
     async def write_file(
         ctx: RunContext[ConsoleDeps],
         path: str,
         content: str,
     ) -> str:
-        """Write content to a file.
-
-        Args:
-            path: Path to the file to write.
-            content: Complete content to write to the file.
-        """
+        """Write content to a file."""
         result = await ensure_async(backend_for(ctx)).write(path, content)
         if result.error:
             return f"Error: {result.error}"
@@ -430,10 +470,7 @@ def create_console_toolset(  # noqa: C901
 
     if edit_format == "hashline":
 
-        @toolset.tool(
-            description=described.get("hashline_edit", HASHLINE_EDIT_DESCRIPTION),
-            requires_approval=write_approval,
-        )
+        @described("hashline_edit", requires_approval=write_approval)
         @_degrade_on_error
         async def hashline_edit(
             ctx: RunContext[ConsoleDeps],
@@ -445,18 +482,7 @@ def create_console_toolset(  # noqa: C901
             end_hash: str | None = None,
             insert_after: bool = False,
         ) -> str:
-            """Edit a file by referencing lines with their content hashes.
-
-            Args:
-                path: Path to the file to edit.
-                start_line: 1-indexed line number to start the edit.
-                start_hash: 2-char content hash of the start line (from read_file).
-                new_content: Replacement text. Empty string deletes line(s).
-                end_line: 1-indexed end of range (inclusive). Omit for single-line edit.
-                end_hash: 2-char content hash of the end line. Optional validation.
-                insert_after: If True, insert new_content after start_line instead \
-of replacing it.
-            """
+            """Edit a file by referencing lines with their content hashes."""
             from pydantic_ai_backends.hashline import apply_hashline_edit_with_summary
 
             raw_backend = backend_for(ctx)
@@ -486,10 +512,7 @@ of replacing it.
 
     else:
 
-        @toolset.tool(
-            description=described.get("edit_file", EDIT_FILE_DESCRIPTION),
-            requires_approval=write_approval,
-        )
+        @described("edit_file", requires_approval=write_approval)
         @_degrade_on_error
         async def edit_file(
             ctx: RunContext[ConsoleDeps],
@@ -498,16 +521,7 @@ of replacing it.
             new_string: str,
             replace_all: bool = False,
         ) -> str:
-            """Edit a file by performing exact string replacement.
-
-            Args:
-                path: Path to the file to edit.
-                old_string: Exact string to find and replace. Must match file content exactly \
-including whitespace and indentation.
-                new_string: Replacement string. Must be different from old_string.
-                replace_all: If True, replace all occurrences. If False (default), \
-the old_string must appear exactly once in the file.
-            """
+            """Edit a file by performing exact string replacement."""
             raw_backend = backend_for(ctx)
             backend = ensure_async(raw_backend)
 
@@ -530,19 +544,14 @@ the old_string must appear exactly once in the file.
                 await _tracking.record_path_read(backend, raw_backend, path)
                 return f"Edited {result.path}: replaced {result.occurrences} occurrence(s)"
 
-    @toolset.tool(description=described.get("glob", GLOB_DESCRIPTION))
+    @described("glob")
     @_degrade_on_error
     async def glob(
         ctx: RunContext[ConsoleDeps],
         pattern: str,
         path: str = ".",
     ) -> str:
-        """Find files matching a glob pattern.
-
-        Args:
-            pattern: Glob pattern to match.
-            path: Base directory to search from. Defaults to current directory.
-        """
+        """Find files matching a glob pattern."""
         entries = await ensure_async(backend_for(ctx)).glob_info(pattern, path)
         if not entries:
             return f"No files matching '{pattern}' in {path}"
@@ -553,7 +562,7 @@ the old_string must appear exactly once in the file.
             lines.append(f"  ... and {len(entries) - GLOB_RESULT_LIMIT} more")
         return "\n".join(lines)
 
-    @toolset.tool(description=described.get("grep", GREP_DESCRIPTION))
+    @described("grep")
     @_degrade_on_error
     async def grep(
         ctx: RunContext[ConsoleDeps],
@@ -563,15 +572,7 @@ the old_string must appear exactly once in the file.
         output_mode: Literal["content", "files_with_matches", "count"] = "files_with_matches",
         ignore_hidden: bool = default_ignore_hidden,
     ) -> str:
-        """Search for a regex pattern across files.
-
-        Args:
-            pattern: Regex pattern to search for.
-            path: File or directory to search in. If None, searches current directory.
-            glob_pattern: Filter files by pattern (e.g., `"*.py"`, `"*.{js,ts}"`).
-            output_mode: Output format — `"content"`, `"files_with_matches"`, or `"count"`.
-            ignore_hidden: Whether to skip hidden files/directories.
-        """
+        """Search for a regex pattern across files."""
         result = await ensure_async(backend_for(ctx)).grep_raw(
             pattern, path, glob_pattern, ignore_hidden
         )
@@ -599,23 +600,14 @@ the old_string must appear exactly once in the file.
 
     if include_execute:
 
-        @toolset.tool(
-            description=described.get("execute", EXECUTE_DESCRIPTION),
-            requires_approval=execute_approval,
-        )
+        @described("execute", requires_approval=execute_approval)
         @_degrade_on_error
         async def execute(
             ctx: RunContext[ConsoleDeps],
             command: str,
             timeout: int | None = DEFAULT_EXECUTE_TIMEOUT,
         ) -> str:
-            """Execute a shell command in the working directory.
-
-            Args:
-                command: Shell command to execute.
-                timeout: Maximum execution time in seconds. Increase \
-for long-running builds or test suites.
-            """
+            """Execute a shell command in the working directory."""
             target = backend_for(ctx)
             async_backend = ensure_async(target)
 
@@ -643,20 +635,13 @@ for long-running builds or test suites.
             backend = ensure_async(backend_for(ctx))
             return backend if hasattr(backend, "execute_background") else None
 
-        @toolset.tool(
-            description=described.get("run_in_background", RUN_IN_BACKGROUND_DESCRIPTION),
-            requires_approval=execute_approval,
-        )
+        @described("run_in_background", requires_approval=execute_approval)
         @_degrade_on_error
         async def run_in_background(
             ctx: RunContext[ConsoleDeps],
             command: str,
         ) -> str:
-            """Start a long-lived command in the background.
-
-            Args:
-                command: Shell command to run detached (e.g. a dev server).
-            """
+            """Start a long-lived command in the background."""
             sandbox = background(ctx)
             if sandbox is None:
                 return _NO_BACKGROUND_SUPPORT
@@ -667,17 +652,13 @@ for long-running builds or test suites.
                 f"kill_shell('{handle.shell_id}') to stop it."
             )
 
-        @toolset.tool(description=described.get("read_output", READ_OUTPUT_DESCRIPTION))
+        @described("read_output")
         @_degrade_on_error
         async def read_output(
             ctx: RunContext[ConsoleDeps],
             shell_id: str,
         ) -> str:
-            """Read new output from a background shell.
-
-            Args:
-                shell_id: The id returned by run_in_background.
-            """
+            """Read new output from a background shell."""
             sandbox = background(ctx)
             if sandbox is None:
                 return _NO_BACKGROUND_SUPPORT
@@ -687,20 +668,13 @@ for long-running builds or test suites.
             body = (result.stdout + result.stderr).strip() or "(no new output)"
             return f"[{result.shell_id}] {status}\n{body}"
 
-        @toolset.tool(
-            description=described.get("kill_shell", KILL_SHELL_DESCRIPTION),
-            requires_approval=execute_approval,
-        )
+        @described("kill_shell", requires_approval=execute_approval)
         @_degrade_on_error
         async def kill_shell(
             ctx: RunContext[ConsoleDeps],
             shell_id: str,
         ) -> str:
-            """Stop a background shell.
-
-            Args:
-                shell_id: The id returned by run_in_background.
-            """
+            """Stop a background shell."""
             sandbox = background(ctx)
             if sandbox is None:
                 return _NO_BACKGROUND_SUPPORT
@@ -708,7 +682,7 @@ for long-running builds or test suites.
                 return f"Killed background shell {shell_id}."
             return f"Background shell {shell_id} was already finished or unknown."
 
-        @toolset.tool(description=described.get("list_shells", LIST_SHELLS_DESCRIPTION))
+        @described("list_shells")
         @_degrade_on_error
         async def list_shells(
             ctx: RunContext[ConsoleDeps],

--- a/src/pydantic_ai_backends/toolsets/descriptions.py
+++ b/src/pydantic_ai_backends/toolsets/descriptions.py
@@ -1,12 +1,103 @@
-"""Prompts and tool descriptions for the console toolset.
+"""What the model reads about each console tool.
 
-Each constant is the full description handed to `@toolset.tool(description=...)`.
-Usage guidance lives here, next to the tool it governs, rather than in the
-system prompt — a model reads a tool's description when it is choosing that
-tool, which is exactly when the guidance is needed.
+A tool definition is a prompt: the model chooses a tool, and fills in its
+arguments, from nothing but the text here. So each tool's text is one object
+rather than a loose string — :class:`ToolText` holds what the tool does, when to
+use it and when not, what every argument means, and **what comes back**, which
+is the half a tool description usually leaves out. The model then knows that
+`grep` answers three different shapes, that a listing may be a truncated slice,
+and that a failed `execute` still returns its output.
+
+Two audiences read this text and they need different amounts of it. A coding
+agent wants the git and dependency guidance; an agent that keeps a scratch
+workspace for a report never sees a repository and pays for those sentences on
+every request. `profile` decides: `"coding"` includes the extra block, `"agent"`
+leaves it out.
+
+The `*_DESCRIPTION` constants are still exported, rendered from the same objects,
+so a caller that imports one keeps working.
 """
 
 from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+Profile = Literal["agent", "coding"]
+"""How much guidance a tool's description carries.
+
+`"coding"` is everything, including the block written for an agent working in a
+repository. `"agent"` drops that block and keeps what is true of any workspace.
+"""
+
+DEFAULT_PROFILE: Profile = "coding"
+"""Profile used when a caller names none — what every existing caller had."""
+
+
+@dataclass(frozen=True)
+class ToolText:
+    """Everything the model reads about one tool.
+
+    Held as fields rather than one string because the parts have different
+    destinations: `summary`, `usage`, `coding` and `returns` are composed into
+    the tool's description, while `args` becomes the per-argument text in its
+    JSON schema. Splitting them is also what lets a host show `summary` in its
+    own catalogue and know it is the first sentence the model reads, rather than
+    a paraphrase written in another repository.
+    """
+
+    summary: str
+    """One sentence: what the tool does. Also what a catalogue should show."""
+
+    usage: str = ""
+    """When to use it, when to use another tool, and what it will not do."""
+
+    coding: str = ""
+    """Guidance only an agent working in a repository needs.
+
+    Rendered under the `"coding"` profile and omitted under `"agent"`. Anything
+    true of any workspace belongs in `usage` instead.
+    """
+
+    args: Mapping[str, str] = field(default_factory=dict)
+    """One entry per argument, keyed exactly as the parameter is named."""
+
+    returns: str = ""
+    """The shape of the result, including its failures and its truncation."""
+
+    def render(self, profile: Profile = DEFAULT_PROFILE) -> str:
+        """The description handed to the model.
+
+        Args:
+            profile: Which audience to write for.
+        """
+        parts = [self.summary]
+        if self.usage:
+            parts.append(self.usage)
+        if self.coding and profile == "coding":
+            parts.append(self.coding)
+        if self.returns:
+            parts.append(f"Returns: {self.returns}")
+        return "\n\n".join(parts)
+
+    def docstring(self) -> str:
+        """A Google-style docstring carrying the argument text.
+
+        Set on the tool function before it is registered, because per-argument
+        descriptions reach the JSON schema through the docstring and through
+        nothing else — which is why they cannot simply live in `render`. The
+        summary is repeated here for a reader of the generated docstring; the
+        model reads `render` instead, since an explicit description wins over
+        the docstring's own summary.
+        """
+        lines = [self.summary]
+        if self.args:
+            lines.append("")
+            lines.append("Args:")
+            lines.extend(f"    {name}: {text}" for name, text in self.args.items())
+        return "\n".join(lines)
+
 
 CONSOLE_SYSTEM_PROMPT = """\
 ## Console Tools
@@ -25,193 +116,324 @@ glob, grep) and shell execution (execute). File contents use **hashline format**
 detailed usage guidance.
 """
 
-LS_DESCRIPTION = """\
-List files and directories at the given path, showing names and sizes.
 
-Use `glob` instead when you need to find files by pattern (e.g., all *.py files).
-Use `ls` when you need to see the full contents of a specific directory."""
+LS_TEXT = ToolText(
+    summary="List the files and directories at a path, with their sizes.",
+    usage=(
+        "Use it to see what one directory holds. To find files by name or extension "
+        "anywhere below it, use `glob`: that searches recursively and this does not."
+    ),
+    args={"path": "Directory to list. Defaults to the working directory."},
+    returns=(
+        "One line per entry, directories marked with a trailing `/` and files with "
+        "their size in bytes. An empty directory and a missing one answer with the "
+        "same sentence, so an empty listing is not proof the directory exists."
+    ),
+)
 
-READ_FILE_DESCRIPTION = """\
-Read file content with line numbers. ALWAYS read a file before editing it.
+READ_FILE_TEXT = ToolText(
+    summary="Read a file's contents, with line numbers.",
+    usage=(
+        "Read a file before editing it: `edit_file` matches on exact text and refuses "
+        "an edit to a file that changed since your last read, so this is both how you "
+        "learn what to replace and how you clear that check.\n\n"
+        "`offset` counts from 0 while the line numbers shown count from 1, so "
+        "`offset=100` starts at the line labelled 101. For a long file, read a first "
+        "slice with `limit=100` to see its shape, then read the part you need. Call "
+        "this tool more than once in a response when you need several files.\n\n"
+        "An image or PDF may come back as content you can look at directly rather "
+        "than as text; work from what you see instead of parsing it."
+    ),
+    args={
+        "path": "File to read, absolute or relative to the working directory.",
+        "offset": "First line to return, counting from 0. Defaults to 0.",
+        "limit": "How many lines to return. Defaults to 2000.",
+    },
+    returns=(
+        "The requested lines, each prefixed with its 1-based line number and a tab, "
+        "with a `... (N more lines)` trailer when the slice stops short of the end. A "
+        "missing file, a binary one or an offset past the end come back as a line "
+        "starting `Error:` — the run continues, so correct it and call again."
+    ),
+)
 
-Results are returned with line numbers (like `cat -n`).
+HASHLINE_READ_FILE_TEXT = ToolText(
+    summary="Read a file's contents, each line tagged with a content hash.",
+    usage=(
+        "Read a file before editing it: `hashline_edit` addresses lines by the "
+        "`line:hash` pair this returns, and refuses an edit whose hash no longer "
+        "matches — which is how it notices the file changed under you.\n\n"
+        "`offset` counts from 0 while the tags count from 1. For a long file, read a "
+        "first slice with `limit=100`, then read the part you need."
+    ),
+    args={
+        "path": "File to read, absolute or relative to the working directory.",
+        "offset": "First line to return, counting from 0. Defaults to 0.",
+        "limit": "How many lines to return. Defaults to 2000.",
+    },
+    returns=(
+        "One line per line of the file, formatted `{line_number}:{hash}|{content}`, "
+        "the hash being two characters belonging to that line's exact content. A "
+        "slice that stops short of the end carries a `... (N more lines)` trailer, "
+        "and a missing file or an out-of-range offset a line starting `Error:`."
+    ),
+)
 
-Usage:
-- For large files (>200 lines), use pagination: first scan with `limit=100` \
-to understand structure, then read targeted sections with `offset` and `limit`.
-- For small files, read the whole file by not providing offset/limit.
-- You can read multiple files in parallel — call read_file multiple times \
-in a single response for maximum efficiency.
-- If a file doesn't exist, an error is returned.
-- Read existing files before modifying them — understand the codebase first.
-- Mimic existing code style, naming conventions, and patterns."""
+WRITE_FILE_TEXT = ToolText(
+    summary="Write a file, creating it or replacing everything in it.",
+    usage=(
+        "For a file that already exists, prefer `edit_file`: it changes the part you "
+        "name, where this replaces the whole file and loses anything you left out. "
+        "Use `write_file` to create a file, or when a full rewrite is what you mean. "
+        "Missing parent directories are created for you.\n\n"
+        "Keep credentials out of it — a workspace is not a secret store, and its "
+        "files are readable by anyone who can see this conversation."
+    ),
+    coding=(
+        "Create a new file only when the work needs one; extending a file that exists "
+        "is usually the smaller change. Leave README, documentation and summary files "
+        "alone unless they were asked for."
+    ),
+    args={
+        "path": "File to write, absolute or relative to the working directory.",
+        "content": "The file's complete new content.",
+    },
+    returns=(
+        "`Wrote N lines to {path}`, or a line starting `Error:`. A successful write "
+        "counts as a read, so the file can be edited straight afterwards."
+    ),
+)
 
-HASHLINE_READ_FILE_DESCRIPTION = """\
-Read file content with hashline tags. ALWAYS read a file before editing it.
+EDIT_FILE_TEXT = ToolText(
+    summary="Replace an exact string in a file.",
+    usage=(
+        "`old_string` has to match the file character for character, indentation "
+        "included, which is why you read the file first. It also has to identify one "
+        "place: if it appears more than once the edit is refused, so include the "
+        "surrounding lines until it is unique — or pass `replace_all=True` when every "
+        "occurrence is what you mean, as in a rename.\n\n"
+        "Change only the tokens you meant to change, leaving the wording and "
+        "formatting around them alone. A formatter or a commit hook can rewrite the "
+        "file after an edit, so read it again before the next edit to it."
+    ),
+    args={
+        "path": "File to edit, absolute or relative to the working directory.",
+        "old_string": "Text to replace, matched exactly, whitespace included.",
+        "new_string": "Text to put in its place. Must differ from `old_string`.",
+        "replace_all": (
+            "Replace every occurrence. Defaults to false, which requires "
+            "`old_string` to appear exactly once."
+        ),
+    },
+    returns=(
+        "`Edited {path}: replaced N occurrence(s)`, or a line starting `Error:` "
+        "saying the string was not found, was found N times, or that the file changed "
+        "since your last read. All three are recoverable: read the file again and "
+        "send an `old_string` that matches one place."
+    ),
+)
 
-Each line is tagged with a content hash: `{line_number}:{hash}|{content}`.
-Use the `line:hash` pair when calling `hashline_edit`.
+HASHLINE_EDIT_TEXT = ToolText(
+    summary="Replace, insert or delete lines addressed by their content hashes.",
+    usage=(
+        "Every edit anchors on a `line:hash` pair from `read_file`. Replace one line "
+        "with `start_line`, `start_hash` and `new_content`; replace a range by adding "
+        "`end_line` and `end_hash`; insert with `insert_after=True`; delete by sending "
+        "an empty `new_content`.\n\n"
+        "A hash that no longer matches means the file changed since you read it — "
+        "read it again rather than guessing at the new numbering. Making several "
+        "edits to one file, work from the bottom up so the lines above stay valid."
+    ),
+    args={
+        "path": "File to edit, absolute or relative to the working directory.",
+        "start_line": "1-based line the edit starts at, as shown in its tag.",
+        "start_hash": "The two-character hash shown for that line.",
+        "new_content": "Replacement text. An empty string deletes the line or range.",
+        "end_line": "1-based last line of an inclusive range. Omit for a single line.",
+        "end_hash": "The two-character hash shown for `end_line`.",
+        "insert_after": (
+            "Insert `new_content` after `start_line` instead of replacing it. Defaults to false."
+        ),
+    },
+    returns=(
+        "`Edited {path}:` and what changed — lines replaced, inserted or deleted, and "
+        "where — or a line starting `Error:`. A hash mismatch is recoverable by "
+        "reading the file again."
+    ),
+)
 
-Usage:
-- For large files (>200 lines), use pagination: first scan with \
-`limit=100` to understand structure, then read targeted sections.
-- For small files, read the whole file by not providing offset/limit.
-- You can read multiple files in parallel for maximum efficiency.
-- Read existing files before modifying them — understand the codebase first."""
+GLOB_TEXT = ToolText(
+    summary="Find files whose path matches a glob pattern.",
+    usage=(
+        "This is how you discover files before reading or editing them. `*` matches "
+        "within one path segment and `**` across directories, so `*.py` finds Python "
+        "files beside you and `**/*.py` finds them at any depth; `**/*.{js,ts}` "
+        "matches either extension. To search what is inside files, use `grep`."
+    ),
+    args={
+        "pattern": 'Glob pattern, e.g. `"*.py"`, `"**/*.ts"`, `"**/test_*.py"`.',
+        "path": "Directory to search from. Defaults to the working directory.",
+    },
+    returns=(
+        "A count, then up to 100 matching paths; the rest are summarised as `... and "
+        "N more`, which means you are seeing a slice — narrow the pattern when the "
+        "whole set matters. No match answers `No files matching ...`."
+    ),
+)
 
-WRITE_FILE_DESCRIPTION = """\
-Write content to a file. Creates the file if it doesn't exist, \
-or completely overwrites it if it does. Parent directories are created as needed.
+GREP_TEXT = ToolText(
+    summary="Search the contents of files for a regular expression.",
+    usage=(
+        "Use this rather than a shell `grep` or `rg` through `execute`: it works on "
+        "every backend, including those with no shell. Full regex syntax is "
+        'supported, e.g. `"log.*Error"`. Narrow the search with `path` for a subtree '
+        "and `glob_pattern` for a file type, and choose how much comes back with "
+        "`output_mode`."
+    ),
+    args={
+        "pattern": "Regular expression to search for.",
+        "path": "File or directory to search. Defaults to the working directory.",
+        "glob_pattern": 'Only search files matching this, e.g. `"*.py"`, `"*.{js,ts}"`.',
+        "output_mode": (
+            '`"files_with_matches"` for paths (the default), `"content"` for the '
+            'matching lines, `"count"` for how many there are.'
+        ),
+        "ignore_hidden": "Skip hidden files and directories.",
+    },
+    returns=(
+        "`files_with_matches` lists paths, `content` lists `path:line: text` with each "
+        "line cut to 100 characters, `count` returns a number. The two lists stop at "
+        "50 entries and say `... and N more`, so read a full list as a slice. No match "
+        "answers `No matches for ...`."
+    ),
+)
 
-IMPORTANT:
-- ALWAYS prefer `edit_file` over `write_file` for existing files — \
-`edit_file` makes targeted changes while `write_file` replaces the entire file.
-- Only use `write_file` for: (1) creating new files, or (2) complete rewrites.
-- NEVER create new files unless explicitly required — prefer editing existing ones.
-- Do NOT create README, documentation, or summary files unless asked.
-- Never write secrets (.env, credentials.json, API keys) to files."""
+EXECUTE_TEXT = ToolText(
+    summary="Run a shell command in the working directory.",
+    usage=(
+        "Use it for work that needs a shell — running a program, a build, a test "
+        "suite, a package manager. For anything the other tools already do, use them: "
+        "`read_file` rather than `cat`, `write_file` rather than a redirect, "
+        "`edit_file` rather than `sed`, `glob` rather than `find`, `grep` rather than "
+        "shell `grep`. They work on every backend and report what happened in a form "
+        "you can act on.\n\n"
+        "Quote paths containing spaces. Chain steps that depend on each other into "
+        "one command with `&&`, and run independent ones as separate calls in the "
+        "same response. Raise `timeout` for a command that will take longer than two "
+        "minutes; a command that never exits on its own, such as a server, blocks "
+        "until that timeout and is then killed. When output is long, redirect it to a "
+        "file and read that."
+    ),
+    coding=(
+        "When a command fails, read the whole output before changing anything — the "
+        "cause is usually above the last line. Reproduce a failure before fixing it, "
+        "change one thing at a time, and after three failed attempts at one approach "
+        "try a different one. If something is missing, check what is installed "
+        "(`which <tool>`, `pip list`) and install it with the package manager the "
+        "project implies.\n\n"
+        "With git: make new commits rather than amending, stage the paths you changed "
+        "rather than `git add -A`, which is how a `.env` gets committed, and commit "
+        "only when asked. `push --force`, `reset --hard`, `clean -f`, `branch -D` and "
+        "`--no-verify` discard someone's work or their checks, so run them only when "
+        "the request names them, and check what a destructive command points at first."
+    ),
+    args={
+        "command": "Shell command to run.",
+        "timeout": "Seconds to allow before the command is killed. Defaults to 120.",
+    },
+    returns=(
+        "The command's stdout and stderr together. A non-zero exit arrives as "
+        "`Command failed (exit code N):` and that output, a timeout as `Error: "
+        "Command timed out` with code 124, and long output is cut with a `... (output "
+        "truncated)` trailer. A failed command is a result, not the end of the run."
+    ),
+)
 
-EDIT_FILE_DESCRIPTION = """\
-Edit a file by performing exact string replacement. This is the preferred \
-way to modify existing files.
+RUN_IN_BACKGROUND_TEXT = ToolText(
+    summary="Start a long-running command and return immediately.",
+    usage=(
+        "For a process that does not exit on its own — a dev server, a watcher, a log "
+        "tail. `execute` blocks until its command finishes and kills it at the "
+        "timeout, so a server started that way is reaped before it is useful. Follow "
+        "this one with `read_output`, probe it from a separate `execute` call, and "
+        "stop it with `kill_shell` when you are done."
+    ),
+    args={"command": "Shell command to start detached, e.g. a dev server."},
+    returns="The shell's id and process id, and the calls that follow it.",
+)
 
-IMPORTANT:
-- You MUST `read_file` first before editing — you need to see the exact content \
-to construct a correct `old_string`.
-- Preserve exact indentation (tabs vs spaces) as it appears in the file.
-- The edit will FAIL if `old_string` is not found, or if it appears more \
-than once (unless `replace_all=True`). If it fails, provide more surrounding \
-context to make `old_string` unique.
-- After editing a file, re-read it before making subsequent edits to the same \
-file — auto-formatters or pre-commit hooks may have changed content on disk.
-- When making substitutions or replacements, change ONLY the exact tokens \
-specified. Do NOT adjust surrounding text (articles, grammar, punctuation).
-- Use `replace_all=True` when renaming a variable, function, or string \
-across the entire file."""
+READ_OUTPUT_TEXT = ToolText(
+    summary="Read what a background shell has printed since your last read.",
+    usage=("Call it again to follow a slow startup: each call returns only what is new."),
+    args={"shell_id": "The id `run_in_background` returned."},
+    returns=(
+        "The shell id, whether it is still running or the code it exited with, and "
+        "its new stdout and stderr — `(no new output)` when there was none."
+    ),
+)
 
-HASHLINE_EDIT_DESCRIPTION = """\
-Edit a file by referencing lines with their content hashes. \
-This is the preferred way to modify existing files.
+KILL_SHELL_TEXT = ToolText(
+    summary="Stop a background shell.",
+    usage=(
+        "Stop one as soon as you no longer need it: a shell left running holds its "
+        "port and its process for whatever comes next here."
+    ),
+    args={"shell_id": "The id `run_in_background` returned."},
+    returns="Confirmation, or a note that the shell had already finished.",
+)
 
-You MUST `read_file` first to see the `line:hash` tags.
+LIST_SHELLS_TEXT = ToolText(
+    summary="List the background shells started in this session.",
+    usage="Use it to find a shell whose id you no longer have.",
+    returns=(
+        "One line per shell: its id, whether it is running or the code it exited "
+        "with, and the command it was started from."
+    ),
+)
 
-Operations:
-- **Replace single line**: set `start_line` + `start_hash` + `new_content`
-- **Replace range**: also set `end_line` + `end_hash`
-- **Insert after**: set `insert_after=True` to add lines after the anchor
-- **Delete**: set `new_content=""`
 
-If the hash doesn't match, the file changed since your last read — \
-re-read it first. When making multiple edits, work **bottom-to-top** so \
-line numbers don't shift.
+TOOL_TEXT: Mapping[str, ToolText] = {
+    "ls": LS_TEXT,
+    "read_file": READ_FILE_TEXT,
+    "hashline_read_file": HASHLINE_READ_FILE_TEXT,
+    "write_file": WRITE_FILE_TEXT,
+    "edit_file": EDIT_FILE_TEXT,
+    "hashline_edit": HASHLINE_EDIT_TEXT,
+    "glob": GLOB_TEXT,
+    "grep": GREP_TEXT,
+    "execute": EXECUTE_TEXT,
+    "run_in_background": RUN_IN_BACKGROUND_TEXT,
+    "read_output": READ_OUTPUT_TEXT,
+    "kill_shell": KILL_SHELL_TEXT,
+    "list_shells": LIST_SHELLS_TEXT,
+}
+"""Every text the console toolset can register, keyed by its id.
 
-After editing, re-read before making subsequent edits to the same file — \
-auto-formatters or pre-commit hooks may have changed content on disk.
-When making substitutions, change ONLY the exact tokens specified. \
-Do NOT adjust surrounding text (articles, grammar, punctuation)."""
+The ids are tool names except `hashline_read_file`, which is `read_file` under
+the hashline edit format — one tool with two texts, so the registry needs two
+keys where a caller overriding it still names the tool, `read_file`.
+"""
 
-GLOB_DESCRIPTION = """\
-Find files matching a glob pattern. Use this to discover files in the \
-codebase before reading or editing them.
+OVERRIDE_KEYS: frozenset[str] = frozenset(key for key in TOOL_TEXT if key != "hashline_read_file")
+"""Tool names a caller may override, which is `TOOL_TEXT` keyed by tool.
 
-Common patterns:
-- `"*.py"` — Python files in current directory only
-- `"**/*.py"` — Python files recursively in all subdirectories
-- `"src/**/*.ts"` — TypeScript files under src/
-- `"**/test_*.py"` — All test files recursively
-- `"**/*.{js,ts,tsx}"` — Multiple extensions
+Kept as its own set so an unknown key can be refused rather than ignored: a
+misspelled or renamed key used to mean the override silently did nothing, and
+nothing said so — including to a host whose catalogue then showed one text while
+the model read another.
+"""
 
-You can call glob multiple times in a single response to search for \
-different patterns in parallel."""
 
-GREP_DESCRIPTION = """\
-Search for a regex pattern across files. ALWAYS use this instead of \
-shell `grep` or `rg` commands.
-
-Supports full regex syntax (e.g., `"log.*Error"`, `"function\\s+\\w+"`).
-
-Output modes:
-- `"files_with_matches"` (default) — returns only file paths that match
-- `"content"` — returns matching lines with file path and line numbers
-- `"count"` — returns the number of matches"""
-
-EXECUTE_DESCRIPTION = """\
-Execute a shell command in the working directory.
-
-IMPORTANT: This tool is for operations that REQUIRE a real shell — \
-running tests, builds, git commands, package installs, running scripts.
-
-## You MUST use specialized tools instead of shell equivalents:
-- `read_file` instead of `cat`, `head`, `tail`
-- `edit_file`/`hashline_edit` instead of `sed`, `awk`
-- `write_file` instead of `echo >` or `cat <<EOF`
-- `glob` instead of `find` or `ls`
-- `grep` instead of shell `grep` or `rg`
-
-## Usage
-- Always quote file paths containing spaces with double quotes.
-- Prefer absolute paths over relative paths.
-- When running multiple independent commands, make separate `execute` calls \
-in a single response (parallel execution).
-- When commands depend on each other, chain with `&&` in a single call \
-(e.g., `cd /project && make test`).
-- For long-running commands (builds, large test suites), increase the timeout.
-- For verbose output, redirect to a temp file and inspect with `read_file`.
-
-## Debugging
-- Read the FULL error output when a command fails — the root cause is often \
-in the middle of a traceback, not the last line.
-- Reproduce the error before attempting a fix.
-- Change one thing at a time — don't make multiple speculative fixes.
-- If something fails 3 times with the same approach, STOP and try a \
-completely different strategy.
-
-## Dependencies
-- If a command fails because a package or tool is missing, install it \
-immediately (`pip install X`, `npm install X`) and retry.
-- Check what's already installed before installing new packages \
-(`which <tool>`, `pip list`).
-- Use the project's package manager (check for pyproject.toml, package.json, \
-Cargo.toml).
-
-## Git Safety
-- NEVER run destructive git commands unless explicitly asked: \
-`push --force`, `reset --hard`, `clean -f`, `branch -D`, `checkout .`
-- NEVER skip hooks (`--no-verify`) unless explicitly asked.
-- NEVER force push to main/master — warn the user first.
-- ALWAYS create NEW commits rather than amending existing ones \
-(unless the user explicitly asks for amend).
-- When staging files, prefer `git add <specific files>` over `git add -A` \
-or `git add .` to avoid accidentally including .env, credentials, or binaries.
-- NEVER commit changes unless the user explicitly asks.
-
-## Safety
-- Be careful not to introduce command injection vulnerabilities.
-- Never commit secrets (.env, credentials.json, API keys).
-- Be careful with destructive commands (`rm -rf`, `drop table`, etc.) — \
-verify the target path/object before executing."""
-
-RUN_IN_BACKGROUND_DESCRIPTION = """\
-Start a long-lived command in the background and return immediately with a \
-`shell_id`. Use this for processes that don't exit on their own — dev servers, \
-watchers, `uvicorn`/`npm run dev`, tailing logs.
-
-Do NOT use plain `execute` for servers: it blocks until the command finishes \
-and kills the process tree on timeout, so a server gets reaped.
-
-After starting: poll its output with `read_output(shell_id)`, probe it from a \
-separate `execute` call (e.g. `curl`), and stop it with `kill_shell(shell_id)` \
-when done. Don't write your own launcher scripts — use this tool."""
-
-READ_OUTPUT_DESCRIPTION = """\
-Read output produced by a background shell since your last read (stdout+stderr), \
-along with whether it's still running and its exit code if finished. Call \
-repeatedly to follow a server's startup logs."""
-
-KILL_SHELL_DESCRIPTION = """\
-Stop a background shell started with `run_in_background`. Always kill background \
-shells you no longer need (e.g. a dev server after you've verified it)."""
-
-LIST_SHELLS_DESCRIPTION = """\
-List the background shells started this session with their status \
-(running / exited) and command."""
+LS_DESCRIPTION = LS_TEXT.render()
+READ_FILE_DESCRIPTION = READ_FILE_TEXT.render()
+HASHLINE_READ_FILE_DESCRIPTION = HASHLINE_READ_FILE_TEXT.render()
+WRITE_FILE_DESCRIPTION = WRITE_FILE_TEXT.render()
+EDIT_FILE_DESCRIPTION = EDIT_FILE_TEXT.render()
+HASHLINE_EDIT_DESCRIPTION = HASHLINE_EDIT_TEXT.render()
+GLOB_DESCRIPTION = GLOB_TEXT.render()
+GREP_DESCRIPTION = GREP_TEXT.render()
+EXECUTE_DESCRIPTION = EXECUTE_TEXT.render()
+RUN_IN_BACKGROUND_DESCRIPTION = RUN_IN_BACKGROUND_TEXT.render()
+READ_OUTPUT_DESCRIPTION = READ_OUTPUT_TEXT.render()
+KILL_SHELL_DESCRIPTION = KILL_SHELL_TEXT.render()
+LIST_SHELLS_DESCRIPTION = LIST_SHELLS_TEXT.render()

--- a/tests/test_console_failures.py
+++ b/tests/test_console_failures.py
@@ -1,0 +1,215 @@
+"""Which failures steer the model with `ModelRetry`, and which are its answer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai import ModelRetry, RunContext
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from pydantic_ai_backends import LocalBackend, StateBackend, create_console_toolset
+from pydantic_ai_backends.backends._guard import PERMISSION_DENIED_PREFIX, PermissionGuard
+from pydantic_ai_backends.permissions import create_ruleset
+from pydantic_ai_backends.toolsets._failures import is_refusal, steer
+
+
+@dataclass
+class _Deps:
+    backend: Any
+
+
+def _ctx(backend: Any, *, retry: int = 0, max_retries: int = 1) -> RunContext[Any]:
+    """A context with retry budget left, unless the test says otherwise."""
+    return RunContext(
+        deps=_Deps(backend=backend),
+        model=TestModel(),
+        usage=RunUsage(),
+        retry=retry,
+        max_retries=max_retries,
+    )
+
+
+async def _call(toolset: Any, tool: str, ctx: RunContext[Any], **args: Any) -> Any:
+    return await toolset.tools[tool].function_schema.function(ctx, **args)
+
+
+class TestAMistakeSteersTheModel:
+    """A call the model could have got right comes back as `ModelRetry`."""
+
+    async def test_an_old_string_matching_twice_is_a_retry(self):
+        backend = StateBackend()
+        backend.write("/f.py", "x = 1\nx = 1\n")
+        toolset = create_console_toolset()
+        ctx = _ctx(backend)
+        await _call(toolset, "read_file", ctx, path="/f.py")
+
+        with pytest.raises(ModelRetry) as exc:
+            await _call(
+                toolset, "edit_file", ctx, path="/f.py", old_string="x = 1", new_string="x = 2"
+            )
+
+        assert "found 2 times" in str(exc.value)
+
+    async def test_an_old_string_that_is_absent_is_a_retry(self):
+        backend = StateBackend()
+        backend.write("/f.py", "x = 1\n")
+        toolset = create_console_toolset()
+        ctx = _ctx(backend)
+        await _call(toolset, "read_file", ctx, path="/f.py")
+
+        with pytest.raises(ModelRetry):
+            await _call(
+                toolset, "edit_file", ctx, path="/f.py", old_string="y = 2", new_string="y = 3"
+            )
+
+    async def test_editing_a_file_that_changed_since_the_read_is_a_retry(self):
+        backend = StateBackend()
+        backend.write("/f.py", "x = 1\n")
+        toolset = create_console_toolset()
+        ctx = _ctx(backend)
+        await _call(toolset, "read_file", ctx, path="/f.py")
+        backend.write("/f.py", "x = 99\n")
+
+        with pytest.raises(ModelRetry) as exc:
+            await _call(
+                toolset, "edit_file", ctx, path="/f.py", old_string="x = 99", new_string="x = 2"
+            )
+
+        assert "changed since you last read it" in str(exc.value)
+
+    async def test_reading_a_file_that_is_not_there_is_a_retry(self):
+        toolset = create_console_toolset()
+
+        with pytest.raises(ModelRetry) as exc:
+            await _call(toolset, "read_file", _ctx(StateBackend()), path="/nope.txt")
+
+        assert "not found" in str(exc.value)
+
+    async def test_a_hashline_edit_against_a_stale_hash_is_a_retry(self):
+        backend = StateBackend()
+        backend.write("/f.py", "x = 1\n")
+        toolset = create_console_toolset(edit_format="hashline")
+
+        with pytest.raises(ModelRetry):
+            await _call(
+                toolset,
+                "hashline_edit",
+                _ctx(backend),
+                path="/f.py",
+                start_line=1,
+                start_hash="zz",
+                new_content="x = 2",
+            )
+
+    async def test_hashline_reading_a_missing_file_is_a_retry(self):
+        toolset = create_console_toolset(edit_format="hashline")
+
+        with pytest.raises(ModelRetry) as exc:
+            await _call(toolset, "read_file", _ctx(StateBackend()), path="/nope.txt")
+
+        assert "glob" in str(exc.value)
+
+
+class TestTheLastAttemptNeverKillsTheRun:
+    """`ModelRetry` past a tool's budget ends the whole run, so the floor is a string."""
+
+    async def test_the_message_is_returned_rather_than_raised(self):
+        backend = StateBackend()
+        backend.write("/f.py", "x = 1\nx = 1\n")
+        toolset = create_console_toolset()
+        ctx = _ctx(backend, retry=1, max_retries=1)
+        await _call(toolset, "read_file", ctx, path="/f.py")
+
+        out = await _call(
+            toolset, "edit_file", ctx, path="/f.py", old_string="x = 1", new_string="x = 2"
+        )
+
+        assert isinstance(out, str)
+        assert "found 2 times" in out
+
+    async def test_a_toolset_with_no_retries_behaves_as_it_did_before(self):
+        """`max_retries=0` is every failure as a returned string, as ever."""
+        toolset = create_console_toolset(max_retries=0)
+
+        out = await _call(
+            toolset, "read_file", _ctx(StateBackend(), max_retries=0), path="/nope.txt"
+        )
+
+        assert isinstance(out, str)
+        assert out.startswith("Error:")
+
+
+class TestARefusalIsNotAMistake:
+    """A retry prompt on a denial invites the model to find a way around it."""
+
+    async def test_a_denied_write_is_returned_not_retried(self, tmp_path: Path):
+        """`.env` is denied by the default secrets rules."""
+        backend = LocalBackend(root_dir=tmp_path)
+        toolset = create_console_toolset(permissions=create_ruleset(allow_write=True))
+
+        out = await _call(toolset, "write_file", _ctx(backend), path=".env", content="TOKEN=x")
+
+        assert isinstance(out, str)
+        assert PERMISSION_DENIED_PREFIX in out
+
+    def test_the_refusal_prefix_is_the_guard_s_own(self, tmp_path: Path):
+        """One string, two modules — a rename that split them would be silent."""
+        guard = PermissionGuard(create_ruleset(), root=tmp_path)
+
+        reason = guard.denial_reason("read", ".env")
+
+        assert reason is not None
+        assert is_refusal(reason)
+
+    def test_a_mistake_is_not_a_refusal(self):
+        assert not is_refusal("Error: File '/x.txt' not found")
+
+
+class TestAResultIsNotAMistake:
+    """What the model must reason about rather than call again differently."""
+
+    async def test_a_command_that_exits_non_zero_is_a_result(self, tmp_path: Path):
+        toolset = create_console_toolset()
+
+        out = await _call(
+            toolset, "execute", _ctx(LocalBackend(root_dir=tmp_path)), command="exit 3"
+        )
+
+        assert "exit code 3" in out
+
+    async def test_finding_nothing_is_an_answer(self, tmp_path: Path):
+        toolset = create_console_toolset()
+
+        out = await _call(
+            toolset, "grep", _ctx(LocalBackend(root_dir=tmp_path)), pattern="nothing-here"
+        )
+
+        assert "No matches" in out
+
+    async def test_a_transport_failure_is_reported_not_retried(self):
+        """A dropped socket is not something different arguments would fix."""
+
+        class Hostile(StateBackend):
+            def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
+                raise OSError("connection reset by peer")
+
+        toolset = create_console_toolset()
+
+        out = await _call(toolset, "read_file", _ctx(Hostile()), path="/f.txt")
+
+        assert "connection reset by peer" in out
+
+
+class TestSteer:
+    def test_it_raises_while_a_retry_remains(self):
+        with pytest.raises(ModelRetry):
+            steer(_ctx(StateBackend()), "Error: try something else")
+
+    def test_it_returns_on_the_last_attempt(self):
+        assert steer(_ctx(StateBackend(), retry=1), "Error: out of budget") == (
+            "Error: out of budget"
+        )

--- a/tests/test_console_retry_budget.py
+++ b/tests/test_console_retry_budget.py
@@ -1,0 +1,76 @@
+"""A model that gets the same call wrong twice must not end the run."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from pydantic_ai_backends import StateBackend, create_console_toolset
+
+
+@dataclass
+class _Deps:
+    backend: StateBackend
+
+
+def _wrong_twice_then_stop(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    """Two identical ambiguous edits, then an answer — the shape that used to be fatal."""
+    attempts = sum(
+        1
+        for message in messages
+        if isinstance(message, ModelResponse)
+        for part in message.parts
+        if isinstance(part, ToolCallPart)
+    )
+    if attempts < 2:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    "edit_file",
+                    {"path": "/f.py", "old_string": "x = 1", "new_string": "x = 2"},
+                )
+            ]
+        )
+    return ModelResponse(parts=[TextPart("I could not make that edit uniquely.")])
+
+
+async def test_a_second_ambiguous_edit_is_answered_not_fatal():
+    """`ModelRetry` past the budget raises `UnexpectedModelBehavior` and kills the run.
+
+    The floor in `_failures.steer` is what stops that, and only a real run
+    exercises it: `max_retries` reaches the tool from the toolset, and the
+    exception is raised by pydantic-ai rather than by anything here.
+    """
+    backend = StateBackend()
+    backend.write("/f.py", "x = 1\nx = 1\n")
+    agent = Agent(
+        FunctionModel(_wrong_twice_then_stop),
+        deps_type=_Deps,
+        toolsets=[create_console_toolset()],
+    )
+
+    result = await agent.run("Change x to 2.", deps=_Deps(backend=backend))
+
+    assert result.output == "I could not make that edit uniquely."
+
+    kinds = [
+        part.part_kind
+        for message in result.all_messages()
+        for part in message.parts
+        if getattr(part, "part_kind", None) in {"tool-return", "retry-prompt"}
+    ]
+    contents = [
+        str(part.content)
+        for message in result.all_messages()
+        for part in message.parts
+        if getattr(part, "part_kind", None) in {"tool-return", "retry-prompt"}
+    ]
+
+    # The first wrong edit steered the model; the second, out of budget, came
+    # back as an ordinary result. Either half missing is a different bug: no
+    # retry prompt means nothing steers, and no tool return means the run died.
+    assert kinds == ["retry-prompt", "tool-return"]
+    assert all("found 2 times" in content for content in contents)

--- a/tests/test_tool_text.py
+++ b/tests/test_tool_text.py
@@ -1,0 +1,150 @@
+"""Tests for the text the model reads about each console tool."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai.exceptions import UserError
+
+from pydantic_ai_backends import create_console_toolset
+from pydantic_ai_backends.toolsets import descriptions as text_module
+from pydantic_ai_backends.toolsets.descriptions import OVERRIDE_KEYS, TOOL_TEXT, ToolText
+
+
+def _text_id(tool_name: str, edit_format: str) -> str:
+    """Which `TOOL_TEXT` entry a registered tool takes its text from."""
+    if tool_name == "read_file" and edit_format == "hashline":
+        return "hashline_read_file"
+    return tool_name
+
+
+class TestEveryToolIsDescribed:
+    """What the model is handed, for every tool, in both edit formats."""
+
+    @pytest.mark.parametrize("edit_format", ["str_replace", "hashline"])
+    def test_every_argument_carries_its_own_description(self, edit_format: str) -> None:
+        """An argument with no description is one the model has to guess at."""
+        toolset = create_console_toolset(edit_format=edit_format)  # type: ignore[arg-type]
+
+        undescribed = {
+            f"{name}.{arg}": schema
+            for name, tool in toolset.tools.items()
+            for arg, schema in tool.tool_def.parameters_json_schema.get("properties", {}).items()
+            if not schema.get("description")
+        }
+
+        assert undescribed == {}
+
+    @pytest.mark.parametrize("edit_format", ["str_replace", "hashline"])
+    def test_the_argument_text_matches_the_signature(self, edit_format: str) -> None:
+        """`TOOL_TEXT` names every argument the tool takes, and no others.
+
+        Both directions, because both fail silently: an argument the registry
+        forgot reaches the model undescribed, and one it names that no longer
+        exists is text nobody will ever see and nobody will notice is stale.
+        """
+        toolset = create_console_toolset(edit_format=edit_format)  # type: ignore[arg-type]
+
+        for name, tool in toolset.tools.items():
+            declared = set(TOOL_TEXT[_text_id(name, edit_format)].args)
+            actual = set(tool.tool_def.parameters_json_schema.get("properties", {}))
+            assert declared == actual, name
+
+    @pytest.mark.parametrize("edit_format", ["str_replace", "hashline"])
+    def test_the_description_is_the_rendered_text(self, edit_format: str) -> None:
+        toolset = create_console_toolset(edit_format=edit_format)  # type: ignore[arg-type]
+
+        for name, tool in toolset.tools.items():
+            expected = TOOL_TEXT[_text_id(name, edit_format)].render()
+            assert tool.tool_def.description == expected
+
+    def test_every_tool_says_what_it_returns(self) -> None:
+        """The half a tool description usually leaves out."""
+        assert all(entry.returns for entry in TOOL_TEXT.values())
+
+    def test_the_exported_constants_render_the_same_objects(self) -> None:
+        """A caller importing `LS_DESCRIPTION` reads what the model reads."""
+        assert TOOL_TEXT["ls"].render() == text_module.LS_DESCRIPTION
+        assert TOOL_TEXT["execute"].render() == text_module.EXECUTE_DESCRIPTION
+        assert (
+            TOOL_TEXT["hashline_read_file"].render()
+        ) == text_module.HASHLINE_READ_FILE_DESCRIPTION
+
+
+class TestProfiles:
+    def test_the_agent_profile_drops_the_repository_guidance(self) -> None:
+        """An agent with a scratch workspace pays for none of it."""
+        execute = TOOL_TEXT["execute"]
+
+        agent = execute.render("agent")
+        coding = execute.render("coding")
+
+        assert execute.coding in coding
+        assert execute.coding not in agent
+        assert execute.summary in agent
+        assert len(agent) < len(coding)
+
+    def test_the_profile_reaches_the_registered_tool(self) -> None:
+        lean = create_console_toolset(profile="agent")
+        full = create_console_toolset(profile="coding")
+
+        assert lean.tools["execute"].tool_def.description == TOOL_TEXT["execute"].render("agent")
+        assert full.tools["execute"].tool_def.description == TOOL_TEXT["execute"].render("coding")
+
+    def test_a_text_with_only_a_summary_renders_it_alone(self) -> None:
+        assert ToolText(summary="Do one thing.").render() == "Do one thing."
+
+
+class TestOverrides:
+    def test_a_string_replaces_the_description_and_keeps_the_arguments(self) -> None:
+        """A host rewording a tool should not lose its argument text with it."""
+        toolset = create_console_toolset(descriptions={"execute": "Run a command."})
+
+        execute = toolset.tools["execute"].tool_def
+        assert execute.description == "Run a command."
+        assert execute.parameters_json_schema["properties"]["command"]["description"]
+
+    def test_a_tool_text_replaces_both_halves(self) -> None:
+        replacement = ToolText(
+            summary="Run a command in the customer's environment.",
+            args={
+                "command": "The command, exactly as the runbook writes it.",
+                "timeout": "Seconds.",
+            },
+        )
+
+        toolset = create_console_toolset(descriptions={"execute": replacement})
+
+        execute = toolset.tools["execute"].tool_def
+        assert execute.description == replacement.render()
+        assert execute.parameters_json_schema["properties"]["command"]["description"] == (
+            "The command, exactly as the runbook writes it."
+        )
+
+    def test_an_unknown_tool_name_is_refused(self) -> None:
+        """Silently ignoring it is how an override reaches nothing for months."""
+        with pytest.raises(UserError) as exc:
+            create_console_toolset(descriptions={"read_flie": "..."})
+
+        assert "read_flie" in str(exc.value)
+
+    def test_the_read_file_override_covers_both_edit_formats(self) -> None:
+        """One tool, two texts, and a caller who names the tool it sees."""
+        toolset = create_console_toolset(
+            edit_format="hashline", descriptions={"read_file": "Read a file."}
+        )
+
+        assert toolset.tools["read_file"].tool_def.description == "Read a file."
+
+    def test_the_override_keys_are_the_tool_names(self) -> None:
+        assert "hashline_read_file" not in OVERRIDE_KEYS
+        assert set(TOOL_TEXT) - {"hashline_read_file"} == OVERRIDE_KEYS
+
+
+class TestGeneratedDocstring:
+    def test_arguments_are_listed_under_a_google_args_section(self) -> None:
+        text = ToolText(summary="Do a thing.", args={"path": "Where."})
+
+        assert text.docstring() == "Do a thing.\n\nArgs:\n    path: Where."
+
+    def test_a_tool_with_no_arguments_gets_no_args_section(self) -> None:
+        assert ToolText(summary="Do a thing.").docstring() == "Do a thing."


### PR DESCRIPTION
Two commits, both about what a tool says to the model.

## 1. One text object per tool, with a `Returns:` — `feat(toolsets): give each console tool one text object`

Each tool's text is now one `ToolText` — `summary`, `usage`, `coding`, `args`, `returns` — instead of a description constant in one file and an argument docstring beside the function in another. The description is rendered from it; `args` becomes the per-argument text in the JSON schema.

The prose was rewritten against the house standard: what it does, when to use it and when to use another tool, every argument, and **what comes back**. That last part existed nowhere. Nothing said that `grep` answers in three shapes depending on `output_mode`, that `glob` lists 100 paths and `grep` 50 before summarising the rest as `... and N more`, that `read_file`'s `offset` counts from 0 while the printed line numbers count from 1, or that a failed `execute` still returns its output under `Command failed (exit code N)`.

Also: `profile="agent"` drops the repository-specific guidance `execute` carried on every request (about 240 tokens across the seven tools a typical host registers), and `descriptions` now takes a `ToolText` as well as a string, with an unknown key raising `UserError` instead of being ignored.

## 2. `ModelRetry` for a mistake the model can fix — `feat(toolsets): raise ModelRetry`

Every failure used to be a returned string, including the ones the model had plainly got wrong: an `old_string` matching three places, a file edited between the read and the edit, a path that does not exist. It was told in a sentence indistinguishable from a real answer and left to notice.

**Raises `ModelRetry`** — a missing file, an offset past the end, an absent or ambiguous `old_string`, a stale read, a hashline hash that no longer matches.

**Stays a returned string, deliberately** — a non-zero exit from `execute` is a *result* to reason about rather than a malformed call; `grep` finding nothing is an answer; a dropped connection is not something different arguments would fix; and a **permission refusal must never be a retry**, since a retry prompt invites the model to look for a way around the rule. `PERMISSION_DENIED_PREFIX` is one constant `PermissionGuard` writes and `toolsets/_failures.py` reads, with a test holding both ends.

**`max_retries` becomes a floor as well as a ceiling.** `ModelRetry` past the budget ends the whole run with `UnexpectedModelBehavior` — so without the floor, a model that mistyped an `old_string` twice would kill a run that used to carry on: a regression hiding inside an improvement. On a tool's last attempt the message is returned rather than raised, so the worst case is exactly the old behaviour, and `max_retries=0` reproduces it entirely.

`tests/test_console_retry_budget.py` proves that in a real run rather than by assertion: a `FunctionModel` sends the same ambiguous edit twice, and the message history is exactly one retry prompt followed by one tool return.

## Verified

1713 tests, coverage 100%, pyright and mypy strict clean, `mkdocs --strict` builds, and the suite passes against the declared pydantic-ai floor 1.74.0 as well as 1.80.0 — `RunContext.last_attempt` and the `__doc__` assignment are the two things that had to hold on both.

**Not verified:** no eval against a real model. Whether the new text changes behaviour gets measured in agenticos.

## Next, not in this PR

agenticos takes `profile="agent"`, uses `ToolText.summary` for the Builder's catalogue, bumps its pin, and gets the same failure taxonomy written down and applied to its own capabilities — most already raise `ModelRetry`; `channel_tools` returns strings for a documented and correct reason; `code_execution.run_python` returning `Execution failed: ...` for a `SyntaxError` in code the model itself wrote is the one clear mismatch.
